### PR TITLE
feat(plugin): add requirements: section to plugin.yaml

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -16,6 +16,32 @@ dependencies:
   claire:
     min: 0.2.0
 
+requirements:
+  tools:
+    - name: dotnet
+      version: ">=8"
+      install: "brew install --cask dotnet-sdk"
+    - name: docker
+      install: "Install Docker Desktop from https://docker.com"
+    - name: node
+      version: ">=18"
+      install: "brew install node"
+
+  tokens:
+    - env: AZURE_DEVOPS_PAT
+      file: "~/.config/claire/.env"
+      description: "Azure DevOps — generate PAT in ADO portal"
+    - env: GITHUB_TOKEN
+      file: "~/.config/claire/github_manager.env"
+      description: "GitHub identity for spawned sessions"
+
+  paths:
+    - name: TFIOneGit
+      env: TFIONE_REPO_PATH
+      default: "~/TFIOneGit"
+      marker: "com.tfione.sln"
+      description: "TFI One repository — clone from ADO"
+
 commands:
   - name: "fivepoints reply"
     script: "domain/commands/reply.sh"


### PR DESCRIPTION
## Summary

Adds the `requirements:` section to `plugin.yaml` as specified in claire-labs/claire#3185.

Declares the system dependencies needed to use this plugin:
- **tools**: dotnet (>=8), docker, node (>=18)
- **tokens**: AZURE_DEVOPS_PAT, GITHUB_TOKEN
- **paths**: TFIOneGit (TFI One repository)

This enables `claire boot` pre-flight checks (see claire-labs/claire#3189).

## Verification Log

```
Command: claire plugin validate fivepoints  (after update)
Context: local plugin.yaml updated with requirements: section
```

Closes claire-labs/claire#3185