### PR TITLE
feat(analyst): detect and document new FDS sections

### DIFF
--- a/domain/knowledge/ANALYST_PERSONA.md
+++ b/domain/knowledge/ANALYST_PERSONA.md
@@ -43,6 +43,24 @@ pr: "#2312"
       claire domain search "<section name from ADO work item>"
       → Identify relevant domain docs (FACE_SHEET_SECTION_PATTERNS, section-specific docs)
       → Read any existing section domain doc before analyzing code
+- [ ] Detect new FDS sections (before writing specs):
+      For each FDS section referenced in the issue:
+        claire domain search "<section name>"
+        claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+      If the section does NOT exist in domain knowledge → it is new. Flag it explicitly
+      in the issue comment:
+        > ⚠️ New FDS section detected: **<Section Name>**
+        > Not yet in domain knowledge — documenting now.
+      Then document the new section in the plugin repo:
+        - Create domain/knowledge/<SECTION_NAME>.md with:
+            • Section purpose and scope
+            • Key business rules and constraints
+            • Field-level notes (types, validations, dependencies)
+            • Any gotchas or non-obvious behavior from the FDS
+        - Update domain/technical/FACE_SHEET_SECTION_PATTERNS.md to include the new
+          section (so it is discoverable via claire context)
+      Commit BOTH files to the plugin repo via PR (follow plugin PR workflow).
+      ⚠️ Do NOT push directly to main. The new domain docs land in the plugin via PR.
 - [ ] Identify and post the FDS section for this PBI:
       From the domain search results (or FDS source documents), identify the FDS section
       number and title that covers this task (e.g., "16.9 — Client Agreements").

--- a/domain/operational/PIPELINE_WORKFLOW.md
+++ b/domain/operational/PIPELINE_WORKFLOW.md
@@ -85,6 +85,24 @@ and includes the role-specific checklist in CLAUDE.md.
 - [ ] Read FDS sections referenced in the issue
       Find FDS section: claire domain search "<section name from issue>"
       Section patterns: claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+- [ ] Detect new FDS sections (before writing specs):
+      For each FDS section referenced in the issue:
+        claire domain search "<section name>"
+        claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+      If the section does NOT exist in domain knowledge → it is new. Flag it explicitly
+      in the issue comment:
+        > ⚠️ New FDS section detected: **<Section Name>**
+        > Not yet in domain knowledge — documenting now.
+      Then document the new section in the plugin repo:
+        - Create domain/knowledge/<SECTION_NAME>.md with:
+            • Section purpose and scope
+            • Key business rules and constraints
+            • Field-level notes (types, validations, dependencies)
+            • Any gotchas or non-obvious behavior from the FDS
+        - Update domain/technical/FACE_SHEET_SECTION_PATTERNS.md to include the new
+          section (so it is discoverable via claire context)
+      Commit BOTH files to the plugin repo via PR (follow plugin PR workflow).
+      ⚠️ Do NOT push directly to main. The new domain docs land in the plugin via PR.
 - [ ] Write all specs to the GitHub issue comment:
       - FDS sections referenced
       - Known constraints or dependencies


### PR DESCRIPTION
## Summary
Adds a "Detect new FDS sections" step to the analyst checklist. When an FDS section referenced in a PBI is not yet in domain knowledge, the analyst now flags it, documents it, and updates the discovery index — instead of letting the knowledge die with the session.

## Files changed
- `domain/operational/PIPELINE_WORKFLOW.md` — new step inserted in `## Role: Analyst` checklist, before spec-writing.
- `domain/knowledge/ANALYST_PERSONA.md` — mirror step inserted in the Pipeline Workflow block.

## Acceptance criteria
- [x] Analyst checklist includes the new FDS detection step
- [x] Step explicitly requires flagging new sections in the issue comment
- [x] Step covers creating the domain doc AND updating `FACE_SHEET_SECTION_PATTERNS`
- [x] New domain docs are committed via PR (instructed in the step), not pushed directly to main

## Verification Log
Docs-only change — no CLI to dogfood, no `claire test` run (per plugin checklist: skip for `.md`-only PRs).

```
$ git diff --stat main..issue-9
 domain/knowledge/ANALYST_PERSONA.md     | 18 ++++++++++++++++++
 domain/operational/PIPELINE_WORKFLOW.md | 18 ++++++++++++++++++
 2 files changed, 36 insertions(+)
```

Closes #9