### PR TITLE
docs(gates): add FK pattern rule — search migrations before writing constraints

### DIFF
--- a/domain/operational/DEVELOPER_GATES.md
+++ b/domain/operational/DEVELOPER_GATES.md
@@ -3,7 +3,7 @@ domain: five_points
 category: operational
 name: DEVELOPER_GATES
 title: "Five Points — Developer Gates Before Pushing to Azure DevOps"
-keywords: [five-points, fivepoints, developer-gates, build, test, typescript, stylecop, eslint, flyway, e2e, pre-push, quality-gate]
+keywords: [five-points, fivepoints, developer-gates, build, test, typescript, stylecop, eslint, flyway, e2e, pre-push, quality-gate, migration, fk, foreign-key, references]
 updated: 2026-04-08
 ---
 
@@ -294,6 +294,20 @@ V{major}.{minor}.{date}.{workitem}.{sequence}__{description}.sql
 
 Example: `V1.0.20260307.1234.1__add_client_education_table.sql`
 
+### Before writing a FK constraint
+
+Before writing any new FK constraint, search existing migrations to see how the target table is
+already referenced. Guessing the schema leads to wrong column names, wrong types, or missing
+indexes — and FK constraints that don't match the established pattern break on apply and are a
+common review rejection cause.
+
+1. Search existing migrations for how the target table is already referenced:
+   ```bash
+   grep -r "REFERENCES <TargetTable>" com.tfione.db/migration/
+   ```
+2. Match the column name, type, and nullability **exactly** as established in prior migrations.
+3. Never guess the schema — the existing migrations are the source of truth.
+
 ---
 
 ## Gate 6 — End-to-End (if you changed UI flows or API contracts)
@@ -329,6 +343,7 @@ Or run the relevant E2E scenario for the area you changed.
 [ ] Gate 3  cd com.tfione.web && npm run build-gate   → 0 errors (tsc -b + vite build)
 [ ] Gate 4  cd com.tfione.web && npm run lint         → 0 errors in your files
 [ ] Gate 5  claire flyway verify     [if migrations]  → no checksum mismatches
+[ ] Gate 5  grep -r "REFERENCES <Table>" com.tfione.db/migration/  [if new FK]  → match existing column/type/nullability
 [ ] Gate 6  claire fivepoints e2e-* [if UI changed]  → flows pass
 ```
 


### PR DESCRIPTION
## Summary
Adds a new rule to **Gate 5 — Migration** in `domain/operational/DEVELOPER_GATES.md` requiring developers to grep existing migrations for `REFERENCES <TargetTable>` before writing any new FK constraint, and to match the established column name, type, and nullability exactly.

## What changed
- New subsection in Gate 5: **"Before writing a FK constraint"** — three numbered rules + rationale
- New Quick Reference checklist line for the FK grep check
- Frontmatter keywords extended with `migration`, `fk`, `foreign-key`, `references` so `claire context "migration FK"` surfaces the doc

## Acceptance criteria
- [x] Rule added to Gate 5 (Migration) in `DEVELOPER_GATES.md`
- [x] Rule discoverable via `claire context "migration FK"` (keywords added to frontmatter)

## Verification Log
Docs-only change. `claire context "migration FK"` indexes keywords from domain-doc frontmatter — the added `migration`, `fk`, `foreign-key`, `references` keywords make the doc discoverable once the plugin's domain index is refreshed.

```
$ git diff --stat HEAD~1
 domain/operational/DEVELOPER_GATES.md | 17 ++++++++++++++++-
 1 file changed, 16 insertions(+), 1 deletion(-)
```

Command: `grep -r "REFERENCES <TargetTable>" com.tfione.db/migration/` (illustrative example in the doc — not run here; the migration directory lives in the Five Points repo).
Context: docs-only PR in the fivepoints plugin worktree.

Closes #6