### PR TITLE
fix(domains): normalize domain name five_points → fivepoints

### DIFF
--- a/domain/knowledge/ANALYST_PERSONA.md
+++ b/domain/knowledge/ANALYST_PERSONA.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: ANALYST_PERSONA
 title: "Five Points — Section Analyst Persona"

--- a/domain/knowledge/CODE_REVIEW_PERSONA.md
+++ b/domain/knowledge/CODE_REVIEW_PERSONA.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: CODE_REVIEW_PERSONA
 title: "Five Points — Code Review Persona (AI Gatekeeper)"

--- a/domain/knowledge/DEV_RULES.md
+++ b/domain/knowledge/DEV_RULES.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: DEV_RULES
 title: "Five Points — Development Rules (Overrides Core)"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_OVERVIEW.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_OVERVIEW.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_OVERVIEW
 title: "Five Points — FDS Client Management: Overview & Glossary"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_ADOPTION.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_ADOPTION.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_SCREENS_ADOPTION
 title: "Five Points — FDS Client Management: Screens — Adoption through Independent Living"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_INTAKE.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_INTAKE.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_SCREENS_INTAKE
 title: "Five Points — FDS Client Management: Screens — Intake through Worker Assignment"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_LEGAL.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_LEGAL.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_SCREENS_LEGAL
 title: "Five Points — FDS Client Management: Screens — Legal through Incident Reports"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_WORKFLOWS.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_WORKFLOWS.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_WORKFLOWS
 title: "Five Points — FDS Client Management: Workflows (Intake & Placement)"

--- a/domain/knowledge/FINISH_EXISTING_PR_PERSONA.md
+++ b/domain/knowledge/FINISH_EXISTING_PR_PERSONA.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FINISH_EXISTING_PR_PERSONA
 title: "FivePoints — Finish Existing PR Persona"

--- a/domain/operational/ADO_PAT_GUIDE.md
+++ b/domain/operational/ADO_PAT_GUIDE.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: ADO_PAT_GUIDE
 title: "FivePoints — ADO PAT Guide (read vs write)"

--- a/domain/operational/ADO_WATCH.md
+++ b/domain/operational/ADO_WATCH.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: ADO_WATCH
 title: "Five Points — ADO PR Continuous Monitor (ado-watch)"

--- a/domain/operational/AZURE_DEVOPS_ACCESS.md
+++ b/domain/operational/AZURE_DEVOPS_ACCESS.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: AZURE_DEVOPS_ACCESS
 title: "Five Points — Azure DevOps Repo Access"

--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: AZURE_ISSUE_BRIDGE
 title: "Five Points — Azure DevOps Email Bridge (PBI Assignment → GitHub Issue Pipeline)"

--- a/domain/operational/BUILD_VERIFICATION.md
+++ b/domain/operational/BUILD_VERIFICATION.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: BUILD_VERIFICATION
 title: "Five Points — Gate Build Verification"

--- a/domain/operational/CODE_REVIEW_WORKFLOW.md
+++ b/domain/operational/CODE_REVIEW_WORKFLOW.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: CODE_REVIEW_WORKFLOW
 title: "Five Points — Code Review Workflow"

--- a/domain/operational/DEVELOPER_GATES.md
+++ b/domain/operational/DEVELOPER_GATES.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: DEVELOPER_GATES
 title: "Five Points — Developer Gates Before Pushing to Azure DevOps"

--- a/domain/operational/GIT_HOOKS.md
+++ b/domain/operational/GIT_HOOKS.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: GIT_HOOKS
 title: "Five Points — TFI One Git Hooks"

--- a/domain/operational/NO_FORCE_PUSH_STRATEGY.md
+++ b/domain/operational/NO_FORCE_PUSH_STRATEGY.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: NO_FORCE_PUSH_STRATEGY
 title: "FivePoints — No-Force-Push Strategy for Stale PRs"

--- a/domain/operational/PIPELINE_WORKFLOW.md
+++ b/domain/operational/PIPELINE_WORKFLOW.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: PIPELINE_WORKFLOW
 title: "Five Points — Client Pipeline Workflow (PBI → ADO Merge)"

--- a/domain/operational/SWAGGER_VERIFICATION.md
+++ b/domain/operational/SWAGGER_VERIFICATION.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: SWAGGER_VERIFICATION
 title: "FivePoints — Swagger Endpoint Verification (Code Gen tasks)"

--- a/domain/operational/TEST_ENV_START.md
+++ b/domain/operational/TEST_ENV_START.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: TEST_ENV_START
 title: "FivePoints — Test Environment Start (fivepoints test-env-start)"


### PR DESCRIPTION
## Summary

Closes #17.

Replaces `domain: five_points` with `domain: fivepoints` in frontmatter across 21 files under `domain/` (9 knowledge + 12 operational), so lookups via the canonical plugin name (`fivepoints`, no underscore) resolve correctly.

## What changed

- 21 files touched, single-line frontmatter change each
- Anchored `sed 's/^domain: five_points$/domain: fivepoints/'` — only the exact frontmatter field, no body content
- Verified: `grep -r 'domain: five_points' domain/` → no matches

## Verification Log

```
$ grep -rl 'domain: five_points' domain/ | wc -l
21

$ grep -rl 'domain: five_points' domain/ | xargs sed -i '' 's/^domain: five_points$/domain: fivepoints/'

$ grep -r 'domain: five_points' domain/ || echo "NO MATCHES"
NO MATCHES

$ head -2 domain/knowledge/ANALYST_PERSONA.md
---
domain: fivepoints
```

Command: `sed -i '' 's/^domain: five_points$/domain: fivepoints/'` on 21 files
Context: worktree `issue-17-fix-domains-normalize-domain-n`

Note: running `claire domain read fivepoints ...` from the worktree still resolves the installed plugin path (not the worktree checkout), so the CLI output reflects pre-fix state until the PR merges and the plugin install is re-synced. The files on this branch are correct.

## Acceptance Criteria
- [x] All 21 domain docs use `domain: fivepoints` in frontmatter
- [x] No residual `domain: five_points` in `domain/`