### PR TITLE
fix(domains): normalize frontmatter domain to fivepoints (#16)

### DIFF
--- a/domain/knowledge/ANALYST_PERSONA.md
+++ b/domain/knowledge/ANALYST_PERSONA.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: ANALYST_PERSONA
 title: "Five Points — Section Analyst Persona"

--- a/domain/knowledge/CODE_REVIEW_PERSONA.md
+++ b/domain/knowledge/CODE_REVIEW_PERSONA.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: CODE_REVIEW_PERSONA
 title: "Five Points — Code Review Persona (AI Gatekeeper)"

--- a/domain/knowledge/DEV_RULES.md
+++ b/domain/knowledge/DEV_RULES.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: DEV_RULES
 title: "Five Points — Development Rules (Overrides Core)"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_OVERVIEW.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_OVERVIEW.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_OVERVIEW
 title: "Five Points — FDS Client Management: Overview & Glossary"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_ADOPTION.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_ADOPTION.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_SCREENS_ADOPTION
 title: "Five Points — FDS Client Management: Screens — Adoption through Independent Living"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_INTAKE.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_INTAKE.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_SCREENS_INTAKE
 title: "Five Points — FDS Client Management: Screens — Intake through Worker Assignment"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_LEGAL.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_SCREENS_LEGAL.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_SCREENS_LEGAL
 title: "Five Points — FDS Client Management: Screens — Legal through Incident Reports"

--- a/domain/knowledge/FDS_CLIENT_MANAGEMENT_WORKFLOWS.md
+++ b/domain/knowledge/FDS_CLIENT_MANAGEMENT_WORKFLOWS.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FDS_CLIENT_MANAGEMENT_WORKFLOWS
 title: "Five Points — FDS Client Management: Workflows (Intake & Placement)"

--- a/domain/knowledge/FINISH_EXISTING_PR_PERSONA.md
+++ b/domain/knowledge/FINISH_EXISTING_PR_PERSONA.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: knowledge
 name: FINISH_EXISTING_PR_PERSONA
 title: "FivePoints — Finish Existing PR Persona"

--- a/domain/operational/ADO_PAT_GUIDE.md
+++ b/domain/operational/ADO_PAT_GUIDE.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: ADO_PAT_GUIDE
 title: "FivePoints — ADO PAT Guide (read vs write)"

--- a/domain/operational/ADO_WATCH.md
+++ b/domain/operational/ADO_WATCH.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: ADO_WATCH
 title: "Five Points — ADO PR Continuous Monitor (ado-watch)"

--- a/domain/operational/AZURE_DEVOPS_ACCESS.md
+++ b/domain/operational/AZURE_DEVOPS_ACCESS.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: AZURE_DEVOPS_ACCESS
 title: "Five Points — Azure DevOps Repo Access"

--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: AZURE_ISSUE_BRIDGE
 title: "Five Points — Azure DevOps Email Bridge (PBI Assignment → GitHub Issue Pipeline)"

--- a/domain/operational/BUILD_VERIFICATION.md
+++ b/domain/operational/BUILD_VERIFICATION.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: BUILD_VERIFICATION
 title: "Five Points — Gate Build Verification"

--- a/domain/operational/CODE_REVIEW_WORKFLOW.md
+++ b/domain/operational/CODE_REVIEW_WORKFLOW.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: CODE_REVIEW_WORKFLOW
 title: "Five Points — Code Review Workflow"

--- a/domain/operational/DEVELOPER_GATES.md
+++ b/domain/operational/DEVELOPER_GATES.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: DEVELOPER_GATES
 title: "Five Points — Developer Gates Before Pushing to Azure DevOps"

--- a/domain/operational/GIT_HOOKS.md
+++ b/domain/operational/GIT_HOOKS.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: GIT_HOOKS
 title: "Five Points — TFI One Git Hooks"

--- a/domain/operational/NO_FORCE_PUSH_STRATEGY.md
+++ b/domain/operational/NO_FORCE_PUSH_STRATEGY.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: NO_FORCE_PUSH_STRATEGY
 title: "FivePoints — No-Force-Push Strategy for Stale PRs"

--- a/domain/operational/PIPELINE_WORKFLOW.md
+++ b/domain/operational/PIPELINE_WORKFLOW.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: PIPELINE_WORKFLOW
 title: "Five Points — Client Pipeline Workflow (PBI → ADO Merge)"

--- a/domain/operational/SWAGGER_VERIFICATION.md
+++ b/domain/operational/SWAGGER_VERIFICATION.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: SWAGGER_VERIFICATION
 title: "FivePoints — Swagger Endpoint Verification (Code Gen tasks)"

--- a/domain/operational/TEST_ENV_START.md
+++ b/domain/operational/TEST_ENV_START.md
@@ -1,5 +1,5 @@
 ---
-domain: five_points
+domain: fivepoints
 category: operational
 name: TEST_ENV_START
 title: "FivePoints — Test Environment Start (fivepoints test-env-start)"


### PR DESCRIPTION
## Summary
Normalize frontmatter `domain:` field to `fivepoints` across 21 domain docs that had the inconsistent `five_points` value. The canonical domain name (from `plugin.yaml` `name: fivepoints`) is what the CLI uses for lookup; frontmatter metadata now matches.

Closes #16.

## Note on Acceptance Criteria
The issue's first AC (`claire domain read five_points ...` should return the document) conflicts with ACs 2 & 3 (canonical is `fivepoints`, list shows only `fivepoints`). Interpreting intent: canonical is `fivepoints`, so `five_points` as a lookup key continues to fail (correctly — it's not the domain name). If underscore-alias support is actually desired, that's a separate enhancement in `claire-labs/claire` (CLI-level, not plugin-level).

## Verification Log
```
$ claire domain read fivepoints knowledge ANALYST_PERSONA
Loaded 39 domains
---
domain: five_points      # reads from main plugin checkout (pre-merge); post-merge will show 'fivepoints'
category: knowledge
...

$ claire domain list | grep -i five
  fivepoints/
    knowledge/ (17 docs)
    operational/ (18 docs)

$ grep -l '^domain: five_points' domain/**/*.md
(no matches — all normalized)
```
Context: verification run from worktree. Live `claire domain read` resolves against the main plugin checkout at `~/claire/.claire/plugins/fivepoints/`, so the frontmatter change is visible post-merge. Local frontmatter correctness confirmed via `grep`.