### PR TITLE
fix(docs): replace five_points with fivepoints in all domain commands

### DIFF
--- a/domain/README.md
+++ b/domain/README.md
@@ -31,7 +31,7 @@ See `knowledge/CLIENT_GUIDE.md` for the full onboarding checklist.
 
 ## Documents
 
-Use `claire domain show five_points` to see all documents in this domain.
+Use `claire domain show fivepoints` to see all documents in this domain.
 
 ### knowledge/
 - `CLIENT_GUIDE.md` — Contacts, stack, PoC options, onboarding checklist

--- a/domain/knowledge/ANALYST_PERSONA.md
+++ b/domain/knowledge/ANALYST_PERSONA.md
@@ -27,7 +27,7 @@ pr: "#2312"
 ## Pipeline Workflow (MANDATORY — follow in order)
 
 ```
-- [ ] Load persona: claire domain read five_points knowledge ANALYST_PERSONA
+- [ ] Load persona: claire domain read fivepoints knowledge ANALYST_PERSONA
 - [ ] Read GitHub issue body (gh issue view N) — extract PBI ID, acceptance criteria
 - [ ] Read ADO work item via PAT (read-only) — title, description, acceptance criteria,
       comments, AND parent items (Feature/Epic) for full work context
@@ -46,7 +46,7 @@ pr: "#2312"
 - [ ] Detect new FDS sections (before writing specs):
       For each FDS section referenced in the issue:
         claire domain search "<section name>"
-        claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+        claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       If the section does NOT exist in domain knowledge → it is new. Flag it explicitly
       in the issue comment:
         > ⚠️ New FDS section detected: **<Section Name>**
@@ -167,7 +167,7 @@ feature/{ticket-id}-{short-description}
 ### Spec Guard — Testing (HARD STOP)
 
 > ⚠️ **Before writing any test-related recommendation in a spec, read DEV_RULES rule #4.**
-> `claire domain read five_points knowledge DEV_RULES` → section "Business Logic Tests Not Committed"
+> `claire domain read fivepoints knowledge DEV_RULES` → section "Business Logic Tests Not Committed"
 
 The following patterns are **forbidden in TFI One** and must **never** appear in analyst specs:
 
@@ -575,7 +575,7 @@ The Analyst posts its findings as a single GitHub comment on the relevant issue:
 
 ## Reference
 
-- **Patterns doc:** `claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS`
+- **Patterns doc:** `claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS`
 - **Tier scoring:** `claire tier-score --agent-help`
 - **Reference analysis (Section 16.9):** claire-labs/fivepoints#60
 - **Reference branch:** `feature/10847-client-adoptive-placement`

--- a/domain/knowledge/CLIENT_GUIDE.md
+++ b/domain/knowledge/CLIENT_GUIDE.md
@@ -107,7 +107,7 @@ looks indistinguishable from their hand-written code, the commercial case is cle
 1. **Receive materials** — request everything in the checklist above
 2. **Calibration session** — 30–45 min with Steve Franklin to walk through the codebase
    - More efficient than 2–3 rounds of misaligned output
-3. **Document patterns** — update `five_points/technical/PATTERNS.md` after the session
+3. **Document patterns** — update `fivepoints/technical/PATTERNS.md` after the session
 4. **First PBI** — generate, submit for review, calibrate based on feedback
 5. **Iterate** — the first 1–2 PBIs are calibration; speed increases after that
 

--- a/domain/knowledge/CODE_REVIEW_PERSONA.md
+++ b/domain/knowledge/CODE_REVIEW_PERSONA.md
@@ -39,13 +39,13 @@ The Five Points gatekeeper enforces the **hierarchical DEV_RULES system** — a 
 ```
 core/knowledge/DEV_RULES (universal baseline)
   ↓ inherits
-five_points/knowledge/DEV_RULES (Five Points-specific overrides — most specific wins)
+fivepoints/knowledge/DEV_RULES (Five Points-specific overrides — most specific wins)
 ```
 
 **Load rules before reviewing:**
 ```bash
 claire domain read core knowledge DEV_RULES
-claire domain read five_points knowledge DEV_RULES
+claire domain read fivepoints knowledge DEV_RULES
 ```
 
 The mandatory checks below enforce these shared rules. Each check maps to a specific DEV_RULE.

--- a/domain/knowledge/REVIEWER_PERSONA.md
+++ b/domain/knowledge/REVIEWER_PERSONA.md
@@ -6,7 +6,7 @@ title: "Steven Franklin — Senior Developer Reviewer Persona [DEPRECATED]"
 keywords: [five-points, reviewer, persona, steven-franklin, pr-review, checklist, deprecated]
 updated: 2026-03-31
 deprecated: true
-replaced_by: five_points/knowledge/CODE_REVIEW_PERSONA
+replaced_by: fivepoints/knowledge/CODE_REVIEW_PERSONA
 ---
 
 # ⚠️ DEPRECATED — Do Not Use
@@ -16,7 +16,7 @@ Five Points code review persona.
 
 **Use instead:**
 ```bash
-claire domain read five_points knowledge CODE_REVIEW_PERSONA
+claire domain read fivepoints knowledge CODE_REVIEW_PERSONA
 ```
 
 This file is retained for reference only and will be removed in a future cleanup.

--- a/domain/operational/AZURE_DEVOPS_ACCESS.md
+++ b/domain/operational/AZURE_DEVOPS_ACCESS.md
@@ -116,7 +116,7 @@ curl -s -H "Authorization: Basic ${AUTH}" \
 
 ## PAT Management
 
-See `30_universe/domains/five_points/operational/TESTING.md` → `## Azure DevOps PAT` for the 3 ways to configure the PAT (git remote URL, claire config, env var).
+See `30_universe/domains/fivepoints/operational/TESTING.md` → `## Azure DevOps PAT` for the 3 ways to configure the PAT (git remote URL, claire config, env var).
 
 PAT extraction logic: `30_universe/plugins/fivepoints/domain/scripts/ado_common.sh` — function `ado_init`.
 

--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -10,9 +10,9 @@ updated: 2026-04-14
 
 ```
 - [ ] Load domain context:
-      claire domain read five_points knowledge ANALYST_PERSONA
-      claire domain read five_points operational PIPELINE_WORKFLOW
-      claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+      claire domain read fivepoints knowledge ANALYST_PERSONA
+      claire domain read fivepoints operational PIPELINE_WORKFLOW
+      claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
 - [ ] Read issue body (PBI reference, requirements)
 - [ ] Read ADO work item (read-only) — title, description, acceptance criteria, parent items
 - [ ] Deep dive the assigned task — identify the FDS section to implement:

--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -30,10 +30,10 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 ```
 - [ ] [1/11] Load domain context, read issue, checkout branch:
-      claire domain read five_points operational PIPELINE_WORKFLOW
-      claire domain read five_points operational CODE_REVIEW_WORKFLOW
-      claire domain read five_points operational SWAGGER_VERIFICATION
-      claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+      claire domain read fivepoints operational PIPELINE_WORKFLOW
+      claire domain read fivepoints operational CODE_REVIEW_WORKFLOW
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
+      claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       claire domain read claire knowledge DEBUG_METHODOLOGY
       Read the GitHub issue — analyst has written all specs there (no ADO lookup needed)
       If specs are incomplete → follow the Gap Recovery section below before proceeding
@@ -49,7 +49,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       Gate 4: cd com.tfione.web && npm run lint → 0 errors
       Gate 5: flyway verify → clean (no checksum mismatch)
       Then start test environment to verify app runs:
-      → Script reference: claire domain read five_points operational TEST_ENV_START
+      → Script reference: claire domain read fivepoints operational TEST_ENV_START
       claire fivepoints test-env-start  (or ./scripts/test-env-start.sh)
       → Wait for "✅ Environment ready — API: https://localhost:58337 | UI: http://localhost:5173"
       → Verify the app loads in the browser (http://localhost:5173)
@@ -96,7 +96,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       → TaskUpdate(<task_6_id>, status="completed")
 
 - [ ] [7/11] Swagger verification (backend gate — run BEFORE Playwright):
-      claire domain read five_points operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
       → Verify all new endpoints appear in swagger.json
       → Verify all endpoints return HTTP 200 with valid Bearer token
       ❌ If any endpoint missing or 4xx:
@@ -107,7 +107,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 - [ ] [8/11] Verify shared login fixture exists, then run E2E tests:
       Check: e2e/global-setup.ts exists in com.tfione.web/
       If missing → create it before running feature tests
-      Reference credentials: claire domain read five_points operational TESTING
+      Reference credentials: claire domain read fivepoints operational TESTING
       Run E2E tests (Playwright) — only after Swagger passed
       ❌ If tests fail:
          Fix in dev worktree (feature branch) → push fix to GitHub

--- a/domain/operational/CHECKLIST_TESTER.md
+++ b/domain/operational/CHECKLIST_TESTER.md
@@ -28,11 +28,11 @@ TaskCreate(title="[8/8] Stop test environment + claire stop")
 ```
 - [ ] Load domain context (MANDATORY before any testing):
       # Pipeline & project rules
-      claire domain read five_points operational PIPELINE_WORKFLOW
-      claire domain read five_points operational TESTING
-      claire domain read five_points operational SWAGGER_VERIFICATION
-      claire domain read five_points operational DEVELOPER_GATES
-      claire domain read five_points knowledge DEV_RULES
+      claire domain read fivepoints operational PIPELINE_WORKFLOW
+      claire domain read fivepoints operational TESTING
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational DEVELOPER_GATES
+      claire domain read fivepoints knowledge DEV_RULES
       # Proof recording
       claire domain read video_proof operational RECORDING_WORKFLOW
       claire domain read video_proof technical PLAYWRIGHT_PATTERNS
@@ -47,7 +47,7 @@ TaskCreate(title="[8/8] Stop test environment + claire stop")
       → TaskUpdate(<task_1_id>, status="completed")
 
 - [ ] [2/8] Swagger verification (backend gate — FAST, run before Playwright):
-      claire domain read five_points operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
       → Verify all new endpoints appear in swagger.json
       → Verify all endpoints return HTTP 200 with valid Bearer token
       ❌ If any endpoint is missing or returns 4xx → FAIL immediately
@@ -57,7 +57,7 @@ TaskCreate(title="[8/8] Stop test environment + claire stop")
 - [ ] [3/8] Verify shared login fixture exists:
       Check: e2e/global-setup.ts exists in com.tfione.web/
       If missing → create it before writing any feature tests
-      Reference credentials: claire domain read five_points operational TESTING
+      Reference credentials: claire domain read fivepoints operational TESTING
       → TaskUpdate(<task_3_id>, status="completed")
 
 - [ ] [4/8] Read the FDS/requirements referenced in the issue

--- a/domain/operational/CODE_REVIEW_WORKFLOW.md
+++ b/domain/operational/CODE_REVIEW_WORKFLOW.md
@@ -47,7 +47,7 @@ When `claire review --pr N` is run, Claire:
 1. **Reads domain docs** before looking at code:
    - `claire domain read fivepoints knowledge CODE_REVIEW_PERSONA` — review checklist and standards
    - `claire domain read fivepoints knowledge REVIEWER_PERSONA` — Steven Franklin persona
-   - `claire domain read five_points operational CODING_STANDARDS`
+   - `claire domain read fivepoints operational CODING_STANDARDS`
 
 2. **Reads the PR diff** via `gh pr diff N`
 
@@ -109,5 +109,5 @@ Test: Before approving a migration, ask: "Would this script run cleanly on an em
 ## Reference
 
 - Reviewer checklist and standards: `claire domain read fivepoints knowledge CODE_REVIEW_PERSONA`
-- Coding rules: `claire domain read five_points operational CODING_STANDARDS`
-- Code patterns: `claire domain read five_points technical CODE_PATTERNS`
+- Coding rules: `claire domain read fivepoints operational CODING_STANDARDS`
+- Code patterns: `claire domain read fivepoints technical CODE_PATTERNS`

--- a/domain/operational/DEVELOPER_GATES.md
+++ b/domain/operational/DEVELOPER_GATES.md
@@ -412,7 +412,7 @@ Fix locally — do not push and wait for CI to tell you.
 
 This document is referenced in:
 
-- `five_points/operational/CODE_REVIEW_WORKFLOW` — Steven Franklin checks gate compliance
+- `fivepoints/operational/CODE_REVIEW_WORKFLOW` — Steven Franklin checks gate compliance
   during PR review
 - Work checklist (prepended to spawned fivepoints tasks)
 - Session CLAUDE.md for fivepoints worktrees
@@ -421,7 +421,7 @@ This document is referenced in:
 
 ## Related Documents
 
-- Code quality tool details: `claire domain read five_points technical CODE_QUALITY_TOOLS`
-- Coding standards: `claire domain read five_points operational CODING_STANDARDS`
-- Code review process: `claire domain read five_points operational CODE_REVIEW_WORKFLOW`
-- Local test setup: `claire domain read five_points operational TESTING`
+- Code quality tool details: `claire domain read fivepoints technical CODE_QUALITY_TOOLS`
+- Coding standards: `claire domain read fivepoints operational CODING_STANDARDS`
+- Code review process: `claire domain read fivepoints operational CODE_REVIEW_WORKFLOW`
+- Local test setup: `claire domain read fivepoints operational TESTING`

--- a/domain/operational/GIT_HOOKS.md
+++ b/domain/operational/GIT_HOOKS.md
@@ -183,6 +183,6 @@ migration with corrective SQL instead of modifying the existing file. See CODING
 
 ## Related Documents
 
-- Full gate specifications: `claire domain read five_points operational DEVELOPER_GATES`
-- Coding standards the hooks enforce: `claire domain read five_points operational CODING_STANDARDS`
-- Flyway migration rules: `claire domain read five_points operational CODING_STANDARDS` (§9)
+- Full gate specifications: `claire domain read fivepoints operational DEVELOPER_GATES`
+- Coding standards the hooks enforce: `claire domain read fivepoints operational CODING_STANDARDS`
+- Flyway migration rules: `claire domain read fivepoints operational CODING_STANDARDS` (§9)

--- a/domain/operational/PIPELINE_WORKFLOW.md
+++ b/domain/operational/PIPELINE_WORKFLOW.md
@@ -65,7 +65,7 @@ are loaded when `claire start` / `claire boot` generates CLAUDE.md.
 > ⚠️ **Note:** There are no `soul-fivepoints-*.md` template files. The analyst (and all pipeline role)
 > checklists are **generated dynamically** by `generator.py` at `claire boot` time.
 > To update the analyst checklist, edit BOTH:
-> 1. `30_universe/domains/five_points/knowledge/ANALYST_PERSONA.md` — the Pipeline Workflow section
+> 1. `30_universe/domains/fivepoints/knowledge/ANALYST_PERSONA.md` — the Pipeline Workflow section
 > 2. `10_systems/claire_py/template/generator.py` → `_build_fivepoints_analyst_persona_section()`
 
 **Label detection**: `claire boot` reads issue labels via `gh issue view N --json labels`
@@ -84,11 +84,11 @@ and includes the role-specific checklist in CLAUDE.md.
 - [ ] Read issue body (PBI reference, requirements)
 - [ ] Read FDS sections referenced in the issue
       Find FDS section: claire domain search "<section name from issue>"
-      Section patterns: claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+      Section patterns: claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
 - [ ] Detect new FDS sections (before writing specs):
       For each FDS section referenced in the issue:
         claire domain search "<section name>"
-        claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+        claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       If the section does NOT exist in domain knowledge → it is new. Flag it explicitly
       in the issue comment:
         > ⚠️ New FDS section detected: **<Section Name>**
@@ -163,7 +163,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       Gate 4: cd com.tfione.web && npm run lint → 0 errors
       Gate 5: flyway verify → clean
       Then start test environment to verify app runs:
-      → Script reference: claire domain read five_points operational TEST_ENV_START
+      → Script reference: claire domain read fivepoints operational TEST_ENV_START
       claire fivepoints test-env-start  (or ./scripts/test-env-start.sh)
       → Wait for "✅ Environment ready — API: https://localhost:58337 | UI: http://localhost:5173"
       Verify: browser loads at http://localhost:5173
@@ -199,7 +199,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       → TaskUpdate(<task_6_id>, status="completed")
 
 - [ ] [7/11] Swagger verification (backend gate — before Playwright):
-      claire domain read five_points operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
       Verify endpoints + HTTP 200 with Bearer token
       ❌ Fail → fix in dev worktree (feature branch) → push → copy to isolated worktree → retest
       → TaskUpdate(<task_7_id>, status="completed")
@@ -220,7 +220,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
          → Open Swagger UI at https://localhost:58337/swagger
          → For each new endpoint: expand it, execute it with a valid Bearer token, show HTTP 200
          → Do NOT skip this: reviewer must see each new route exists and responds correctly
-         → Reference: claire domain read five_points operational SWAGGER_VERIFICATION
+         → Reference: claire domain read fivepoints operational SWAGGER_VERIFICATION
 
       2. Application UI proof (one video per FDS section):
          → Show the complete user workflow for that FDS section
@@ -245,7 +245,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 - [ ] [10/11] PAT gate + push feature branch to ADO:
       🚨 MANDATORY pre-transition verification — run Gate 5b (flyway migrate) against the local SQL Server:
-      → Canonical command lives in `claire domain read five_points operational DEVELOPER_GATES` (§ Gate 5b)
+      → Canonical command lives in `claire domain read fivepoints operational DEVELOPER_GATES` (§ Gate 5b)
       ✅ Passing criteria: Flyway reports 0 errors, all pending migrations applied successfully
       ❌ FAIL → fix migration before proceeding — do NOT run `fivepoints ado-transition`
       Then:
@@ -310,11 +310,11 @@ TaskCreate(title="[8/8] Stop test environment + claire stop")
 ```
 - [ ] Load domain context (MANDATORY before any testing):
       # Pipeline & project rules
-      claire domain read five_points operational PIPELINE_WORKFLOW
-      claire domain read five_points operational TESTING
-      claire domain read five_points operational SWAGGER_VERIFICATION
-      claire domain read five_points operational DEVELOPER_GATES
-      claire domain read five_points knowledge DEV_RULES
+      claire domain read fivepoints operational PIPELINE_WORKFLOW
+      claire domain read fivepoints operational TESTING
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational DEVELOPER_GATES
+      claire domain read fivepoints knowledge DEV_RULES
       # Proof recording
       claire domain read video_proof operational RECORDING_WORKFLOW
       claire domain read video_proof technical PLAYWRIGHT_PATTERNS
@@ -329,7 +329,7 @@ TaskCreate(title="[8/8] Stop test environment + claire stop")
       → TaskUpdate(<task_1_id>, status="completed")
 
 - [ ] [2/8] Swagger verification (backend gate — run BEFORE Playwright):
-      claire domain read five_points operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
       → Verify all new endpoints appear in swagger.json
       → Verify all endpoints return HTTP 200 with valid Bearer token
       ❌ If any endpoint is missing or returns 4xx → FAIL immediately
@@ -339,7 +339,7 @@ TaskCreate(title="[8/8] Stop test environment + claire stop")
 - [ ] [3/8] Verify shared login fixture exists:
       Check: e2e/global-setup.ts exists in com.tfione.web/
       If missing → create it before writing any feature tests
-      Reference credentials: claire domain read five_points operational TESTING
+      Reference credentials: claire domain read fivepoints operational TESTING
       → TaskUpdate(<task_3_id>, status="completed")
 
 - [ ] [4/8] Run E2E tests (Playwright) — only after Swagger passed
@@ -358,7 +358,7 @@ TaskCreate(title="[8/8] Stop test environment + claire stop")
                → Open Swagger UI at https://localhost:58337/swagger
                → For each new endpoint: expand it, execute with valid Bearer token, show HTTP 200
                → Do NOT skip: reviewer must see each new route exists and responds correctly
-               → Reference: claire domain read five_points operational SWAGGER_VERIFICATION
+               → Reference: claire domain read fivepoints operational SWAGGER_VERIFICATION
 
             2. Application UI proof (one video per FDS section):
                → Show the complete user workflow for that FDS section

--- a/domain/operational/TEST_ENV_START.md
+++ b/domain/operational/TEST_ENV_START.md
@@ -152,6 +152,6 @@ Then run your gate (`npm run build-gate`, `npm run lint`, etc.).
 
 ## Related
 
-- `claire domain read five_points operational SWAGGER_VERIFICATION` — next step after env is ready
-- `claire domain read five_points operational TESTING` — login credentials and test patterns
-- `claire domain read five_points operational PIPELINE_WORKFLOW` — full dev/tester checklist
+- `claire domain read fivepoints operational SWAGGER_VERIFICATION` — next step after env is ready
+- `claire domain read fivepoints operational TESTING` — login credentials and test patterns
+- `claire domain read fivepoints operational PIPELINE_WORKFLOW` — full dev/tester checklist

--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -16,7 +16,7 @@ updated: 2026-04-13
 ### Load Full Persona First
 
 ```bash
-claire domain read five_points knowledge ANALYST_PERSONA
+claire domain read fivepoints knowledge ANALYST_PERSONA
 ```
 
 Read this before starting — it has scope guard rules and detailed patterns.
@@ -33,4 +33,4 @@ Read this before starting — it has scope guard rules and detailed patterns.
 ### Key Commands
 - `claire analyze --branch <branch> --section <N> --fds-note "<spec>"` — Run section analysis
 - `claire fivepoints transition --role analyst --issue N` — Hand off to developer
-- `claire domain read five_points knowledge ANALYST_PERSONA` — Full persona details
+- `claire domain read fivepoints knowledge ANALYST_PERSONA` — Full persona details

--- a/domain/persona/fivepoints-dev-pipeline.md
+++ b/domain/persona/fivepoints-dev-pipeline.md
@@ -19,7 +19,7 @@ If you encounter something missing or unclear in the analyst's specs:
 
 1. **FDS first** — The FDS (Functional Design Specification) is the primary source of truth for fivepoints.
    Read the relevant FDS section before looking anywhere else.
-   → `claire domain read five_points technical <SECTION>`
+   → `claire domain read fivepoints technical <SECTION>`
 
 2. **Other domain docs second** — If the FDS doesn't cover it, check other fivepoints domain docs:
    → `claire domain search <keyword>`

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -32,10 +32,10 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 ```
 - [ ] [1/11] Load domain context, read issue, checkout branch:
-      claire domain read five_points operational PIPELINE_WORKFLOW
-      claire domain read five_points operational CODE_REVIEW_WORKFLOW
-      claire domain read five_points operational SWAGGER_VERIFICATION
-      claire domain read five_points technical FACE_SHEET_SECTION_PATTERNS
+      claire domain read fivepoints operational PIPELINE_WORKFLOW
+      claire domain read fivepoints operational CODE_REVIEW_WORKFLOW
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
+      claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       claire domain read claire knowledge DEBUG_METHODOLOGY
       Read the GitHub issue — analyst has written all specs there (no ADO lookup needed)
       If specs are incomplete → follow the Gap Recovery section below before proceeding
@@ -51,7 +51,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       Gate 4: cd com.tfione.web && npm run lint → 0 errors
       Gate 5: flyway verify → clean (no checksum mismatch)
       Then start test environment to verify app runs:
-      → Script reference: claire domain read five_points operational TEST_ENV_START
+      → Script reference: claire domain read fivepoints operational TEST_ENV_START
       claire fivepoints test-env-start  (or ./scripts/test-env-start.sh)
       → Wait for "✅ Environment ready — API: https://localhost:58337 | UI: http://localhost:5173"
       → Verify the app loads in the browser (http://localhost:5173)
@@ -98,7 +98,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       → TaskUpdate(<task_6_id>, status="completed")
 
 - [ ] [7/11] Swagger verification (backend gate — run BEFORE Playwright):
-      claire domain read five_points operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational SWAGGER_VERIFICATION
       → Verify all new endpoints appear in swagger.json
       → Verify all endpoints return HTTP 200 with valid Bearer token
       ❌ If any endpoint missing or 4xx:
@@ -109,7 +109,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 - [ ] [8/11] Verify shared login fixture exists, then run E2E tests:
       Check: e2e/global-setup.ts exists in com.tfione.web/
       If missing → create it before running feature tests
-      Reference credentials: claire domain read five_points operational TESTING
+      Reference credentials: claire domain read fivepoints operational TESTING
       Run E2E tests (Playwright) — only after Swagger passed
       ❌ If tests fail:
          Fix in dev worktree (feature branch) → push fix to GitHub
@@ -170,7 +170,7 @@ If you encounter something missing or unclear in the analyst's specs:
 
 1. **FDS first** — The FDS (Functional Design Specification) is the primary source of truth for fivepoints.
    Read the relevant FDS section before looking anywhere else.
-   → `claire domain read five_points technical <SECTION>`
+   → `claire domain read fivepoints technical <SECTION>`
 
 2. **Other domain docs second** — If the FDS doesn't cover it, check other fivepoints domain docs:
    → `claire domain search <keyword>`

--- a/domain/persona/fivepoints-tester.md
+++ b/domain/persona/fivepoints-tester.md
@@ -51,7 +51,7 @@ updated: 2026-04-13
 
 ### Key Commands
 - `./scripts/test-env-start.sh` — Start full TFI One stack (SQL Server + API + frontend)
-- `claire domain read five_points operational SWAGGER_VERIFICATION` — Swagger endpoint verification guide
+- `claire domain read fivepoints operational SWAGGER_VERIFICATION` — Swagger endpoint verification guide
 - `claire fivepoints transition --role tester --next dev --issue N` — Send back to dev (ONLY on TEST failure, never on ado-push failure)
 - `claire fivepoints ado-push --issue N` — Push to ADO + create PR (on pass, requires proof)
 - `claire domain read video_proof technical PLAYWRIGHT_PATTERNS` — Frontend proof recording (MANDATORY)

--- a/domain/technical/PATTERNS.md
+++ b/domain/technical/PATTERNS.md
@@ -4,8 +4,8 @@ keywords: [patterns, repository, controller, dto, validation, auth, soft-delete,
 
 # TFI One — Design Patterns & Conventions
 
-> **See also**: `five_points/operational/CODING_STANDARDS.md` — numbered code review rules (branch discipline, dual validation, StyleCop, CI gate build standards)
-> `five_points/technical/PATTERNS.md` — architecture overview, feature checklist, naming conventions
+> **See also**: `fivepoints/operational/CODING_STANDARDS.md` — numbered code review rules (branch discipline, dual validation, StyleCop, CI gate build standards)
+> `fivepoints/technical/PATTERNS.md` — architecture overview, feature checklist, naming conventions
 
 ---
 


### PR DESCRIPTION
## Summary

- `claire domain read five_points` was silently failing throughout all checklists — the domain is named `fivepoints` (no underscore)
- Analyst agents couldn't load `ANALYST_PERSONA` on step 1, fell back to wrong assumptions about the repo being empty, FDS inaccessible, etc.
- 19 files updated: all checklists, personas, and domain docs

## Root Cause

`claire domain read five_points knowledge ANALYST_PERSONA` → domain not found → silent failure → agent proceeds without critical context

## Fix

Bulk replace `five_points` → `fivepoints` in every `claire domain read/show` command and domain path reference across all plugin docs.

## Files Changed

- `CHECKLIST_ANALYST.md` — step 1 load context now works
- `CHECKLIST_DEV_PIPELINE.md` — all domain reads fixed
- `CHECKLIST_TESTER.md` — all domain reads fixed  
- `PIPELINE_WORKFLOW.md`, `ANALYST_PERSONA.md`, all personas and operational docs

## Verification

```
grep -rn "claire domain read five_points" domain/
# → no results
```