### PR TITLE
feat(persona): add end-to-end execution instruction to all personas

### DIFF
--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -13,6 +13,16 @@ updated: 2026-04-13
 > and write complete implementation specs to the GitHub issue before handing off to the dev.
 > You do NOT write code. You do NOT push to ADO.
 
+### End-to-End Execution
+
+**Work end-to-end without stopping.** Complete your full analysis cycle — do not pause
+for intermediate feedback or ask questions mid-analysis unless:
+- You find **inconsistencies** in the requirements or referenced documents
+- You have **genuine questions** that block your ability to produce the spec
+- **Requirements are missing** and you cannot reasonably proceed without clarification
+
+Outside of these cases, continue through to completion and hand off to the dev.
+
 ### Load Full Persona First
 
 ```bash

--- a/domain/persona/fivepoints-dev-pipeline.md
+++ b/domain/persona/fivepoints-dev-pipeline.md
@@ -13,6 +13,16 @@ updated: 2026-04-13
 > Follow it in order.
 
 
+### End-to-End Execution
+
+**Work end-to-end without stopping.** Complete the full implementation cycle — do not pause
+for intermediate feedback or ask questions mid-implementation unless:
+- You find **inconsistencies** in the requirements or existing code
+- You have **genuine questions** that block your ability to implement
+- **Requirements are missing** and you cannot reasonably proceed without clarification
+
+Outside of these cases, continue through to completion (all gates, PR, self-testing, ADO push).
+
 ### Gap Recovery (When Analyst Specs Are Incomplete)
 
 If you encounter something missing or unclear in the analyst's specs:
@@ -40,6 +50,8 @@ If you encounter something missing or unclear in the analyst's specs:
   cherry-pick. Keep the dev worktree (the one you push) clean of all test artifacts.
 
 ### Key Tools
+- `fivepoints ado-transition` — PAT-gated ADO push: verifies branch + requests write PAT + pushes to ADO
+- `gh pr create` — Create GitHub PR for gatekeeper code review (required before ADO push)
 - `fivepoints reply` — Reply to a PR comment thread on Azure DevOps
 - `fivepoints pr-status` — Show PR status, build results, reviewer votes
 - `fivepoints pr-comments` — List all comment threads on a PR

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -8,6 +8,16 @@ updated: 2026-04-13
 
 ## Persona: Five Points Developer
 
+### End-to-End Execution
+
+**Work end-to-end without stopping.** Complete the full implementation cycle — do not pause
+for intermediate feedback or ask questions mid-implementation unless:
+- You find **inconsistencies** in the requirements or existing code
+- You have **genuine questions** that block your ability to implement
+- **Requirements are missing** and you cannot reasonably proceed without clarification
+
+Outside of these cases, continue through to completion (all gates, PR, self-testing, ADO push).
+
 ### SESSION START — Create All Tasks First (MANDATORY)
 
 Before doing ANY work, create all 11 checklist tasks so each step is auditable:

--- a/domain/persona/fivepoints-tester.md
+++ b/domain/persona/fivepoints-tester.md
@@ -16,6 +16,16 @@ updated: 2026-04-13
 > separately via `{{SESSION_CHECKLIST}}` from `operational/CHECKLIST_TESTER`.
 > Follow it in order.
 
+### End-to-End Execution
+
+**Work end-to-end without stopping.** Complete the full testing cycle — do not pause
+for intermediate feedback or ask questions mid-testing unless:
+- You find **inconsistencies** in the requirements or implementation
+- You have **genuine questions** that block your ability to test
+- **Requirements are missing** and you cannot reasonably proceed without clarification
+
+Outside of these cases, continue through to completion (Swagger, E2E, proof recording, ADO push).
+
 ### Testing Philosophy
 - **Adversarial**: Try to break the implementation, not just verify happy paths
 - **Requirement-driven**: Every test traces back to an FDS requirement


### PR DESCRIPTION
## Summary
- Added "End-to-End Execution" section to all 4 fivepoints persona docs (analyst, dev, dev-pipeline, tester)
- Instructs agents to work through to completion, only stopping for real blockers (inconsistencies, genuine questions, missing requirements)
- Each persona uses role-appropriate wording (analysis cycle, implementation cycle, testing cycle)

## Files Changed
- `domain/persona/fivepoints-analyst.md`
- `domain/persona/fivepoints-dev.md`
- `domain/persona/fivepoints-dev-pipeline.md`
- `domain/persona/fivepoints-tester.md`

## Companion PR
Template fix in claire repo: claire-labs/claire#3321 (adds `{{PERSONA_SECTION}}` to analyst/dev templates so persona doc content actually renders)

Closes claire-labs/claire#3319

🤖 Generated with [Claude Code](https://claude.com/claude-code)