### PR TITLE
feat(reset-pbi): per-PBI factory reset for pipeline validation

### DIFF
--- a/domain/commands/reset-pbi.sh
+++ b/domain/commands/reset-pbi.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fivepoints reset-pbi — Factory reset a single PBI so the pipeline can replay
+# from zero. Complements `fivepoints reset-pipeline` (bulk) with per-PBI scope.
+#
+# Usage:
+#   claire fivepoints reset-pbi --pbi <ado-id> --issue <github-num> [options]
+#
+# See `claire fivepoints reset-pbi --help` for the full option list and the
+# corresponding domain doc: `claire domain read fivepoints operational RESET_PBI`.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPTS_DIR="$PLUGIN_ROOT/domain/scripts"
+PY_MODULE="$SCRIPTS_DIR/reset_pbi.py"
+
+# Default repo for fivepoints PBIs. Override with --repo.
+DEFAULT_REPO="CLAIRE-Fivepoints/fivepoints"
+
+# Default TFIOne clone (the mirror that hosts feature/<pbi-id>-* branches).
+DEFAULT_TFIONE_PATH="${TFIONE_REPO_PATH:-$HOME/TFIOneGit}"
+
+PBI_ID=""
+ISSUE_NUM=""
+REPO="$DEFAULT_REPO"
+TFIONE_PATH="$DEFAULT_TFIONE_PATH"
+MODE=""     # dry-run | confirm
+KEEP_DB=false
+
+show_help() {
+    cat <<'EOF'
+Usage: claire fivepoints reset-pbi --pbi <id> --issue <n> [options]
+
+Factory reset a PBI so a fresh agent session can replay the full pipeline.
+
+Required:
+  --pbi <id>          ADO PBI (work item) id, e.g. 18839
+  --issue <n>         GitHub issue number linked to the PBI
+
+Mode (exactly one required):
+  --dry-run           Print the plan and exit — no changes applied
+  --confirm           Execute the plan (destructive)
+
+Options:
+  --repo owner/name   GitHub repo (default: CLAIRE-Fivepoints/fivepoints)
+  --tfione-path PATH  TFIOneGit clone path (default: $TFIONE_REPO_PATH or ~/TFIOneGit)
+  --keep-db           Reserved; currently a no-op
+
+What gets reset (when --confirm):
+  1. Local + github-remote feature/<pbi>-* branches on TFIOneGit
+     (never the ADO 'origin' remote)
+  2. Worktrees matching issue-<n>-* in TFIOneGit and its .claire/worktrees/
+  3. Open PR on the fivepoints repo whose head is the feature branch: closed
+  4. Agent-authored comments on the GitHub issue: deleted
+  5. Labels on the issue: reset to [role:analyst]
+  6. Issue is reopened if closed
+  7. github-manager state: issue purged from processed_issues / issue_assignees
+  8. Release assets referencing the issue number: deleted
+
+Guardrails:
+  * Refuses to run if the linked PR is already merged
+  * Refuses if the GitHub issue title does not reference the given --pbi
+  * Never touches the ADO 'origin' remote on TFIOneGit
+  * Every destructive action is logged to
+    $HOME/.claire/logs/reset-pbi-<pbi>-<timestamp>.log
+
+Examples:
+  claire fivepoints reset-pbi --pbi 18839 --issue 71 --dry-run
+  claire fivepoints reset-pbi --pbi 18839 --issue 71 --confirm
+EOF
+}
+
+show_agent_help() {
+    cat <<'EOF'
+# fivepoints reset-pbi — Agent Help
+
+## Purpose
+Reset a single PBI + its linked GitHub issue, branches, worktrees, PR, comments,
+labels, and release assets so a fresh agent session can replay the pipeline
+from the analyst role without memory of the previous run.
+
+## When to use
+* Validating a pipeline fix (e.g. after merging an analyst/dev/tester change)
+* Recovering from a botched run where manual cleanup would be error-prone
+
+## Required inputs
+--pbi <id>    ADO work item id (must match the GitHub issue title)
+--issue <n>   GitHub issue number on --repo
+
+## Modes
+--dry-run     Show the plan, make no changes
+--confirm     Execute the plan (destructive)
+
+## Guardrails (abort conditions)
+* GitHub issue title does not reference PBI <id>    -> exit 2
+* Linked PR is already merged                       -> exit 3
+* --confirm without GITHUB_TOKEN in environment     -> exit 4
+
+## Required env
+GITHUB_TOKEN    read from ~/.config/claire/github_manager.env or env var
+                (needed for both --dry-run comment fetch and --confirm execution)
+
+## Produces
+Log file at: $HOME/.claire/logs/reset-pbi-<pbi>-<timestamp>.log
+
+## Never does
+* Touch the ADO 'origin' remote (only the 'github' mirror)
+* Delete commits (PR is closed, not force-deleted)
+* Reset if the PR is already merged (explicit refusal)
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --pbi)      PBI_ID="$2"; shift 2 ;;
+        --issue)    ISSUE_NUM="$2"; shift 2 ;;
+        --repo)     REPO="$2"; shift 2 ;;
+        --tfione-path) TFIONE_PATH="$2"; shift 2 ;;
+        --dry-run)  MODE="dry-run"; shift ;;
+        --confirm)  MODE="confirm"; shift ;;
+        --keep-db)  KEEP_DB=true; shift ;;
+        --help|-h)  show_help; exit 0 ;;
+        --agent-help) show_agent_help; exit 0 ;;
+        *) die "Unknown argument: $1 (see --help)" ;;
+    esac
+done
+
+[[ -n "$PBI_ID"    ]] || die "--pbi is required"
+[[ -n "$ISSUE_NUM" ]] || die "--issue is required"
+[[ -n "$MODE"      ]] || die "one of --dry-run / --confirm is required"
+[[ "$PBI_ID"    =~ ^[0-9]+$ ]] || die "--pbi must be numeric"
+[[ "$ISSUE_NUM" =~ ^[0-9]+$ ]] || die "--issue must be numeric"
+[[ "$REPO" == */* ]] || die "--repo must be in owner/name form"
+
+# ── Token: GITHUB_TOKEN from env or github_manager.env ──────────────────────
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    for env_file in ~/.config/claire/github_manager.env ~/.config/claire/.env; do
+        [[ -f "$env_file" ]] || continue
+        tok=$(grep -E '^(GITHUB_TOKEN|GH_TOKEN)=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2- || true)
+        if [[ -n "$tok" ]]; then
+            export GITHUB_TOKEN="$tok"
+            break
+        fi
+    done
+fi
+
+if [[ "$MODE" == "confirm" && -z "${GITHUB_TOKEN:-}" ]]; then
+    die "--confirm requires GITHUB_TOKEN (set in env or ~/.config/claire/github_manager.env)"
+fi
+
+# ── Paths ───────────────────────────────────────────────────────────────────
+TS=$(date +%Y%m%d-%H%M%S)
+LOG_DIR="$HOME/.claire/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/reset-pbi-${PBI_ID}-${TS}.log"
+
+OWNER="${REPO%/*}"
+NAME="${REPO#*/}"
+STATE_FILE_DEFAULT="${CLAIRE_HOME:-$HOME/claire}/99_runtime/github-manager/github_manager_state_${OWNER}_${NAME}.json"
+STATE_FILE="${CLAIRE_GITHUB_MANAGER_STATE:-$STATE_FILE_DEFAULT}"
+
+echo "=== fivepoints reset-pbi ==="
+echo "PBI:        $PBI_ID"
+echo "Issue:      #$ISSUE_NUM on $REPO"
+echo "Mode:       $MODE"
+echo "State file: $STATE_FILE"
+echo "TFIOneGit:  $TFIONE_PATH"
+echo "Log file:   $LOG_FILE"
+echo ""
+
+# ── Collect context via gh (orchestration layer) ────────────────────────────
+
+echo "── Collecting issue + PR + release context via gh..."
+
+ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --repo "$REPO" \
+    --json title,state,labels 2>/dev/null) || ISSUE_JSON=""
+[[ -n "$ISSUE_JSON" ]] || die "could not fetch issue #$ISSUE_NUM on $REPO"
+
+# Find the linked PR: branch names for fivepoints are feature/<pbi>-*.
+# Look up all open PRs on the repo whose head startswith 'feature/<pbi>-'.
+PR_JSON_ARRAY=$(gh pr list --repo "$REPO" --state all --limit 20 \
+    --search "head:feature/${PBI_ID}" \
+    --json number,state,headRefName,mergedAt 2>/dev/null || echo "[]")
+
+# Pick the first PR whose headRefName starts with feature/<pbi>-.
+PR_JSON=$(jq -c --arg p "feature/${PBI_ID}-" \
+    'map(select(.headRefName | startswith($p))) | .[0] // null' \
+    <<<"$PR_JSON_ARRAY")
+
+if [[ "$PR_JSON" == "null" ]]; then
+    PR_JSON=""
+fi
+
+# Pre-fetch comments (keeps Python offline-friendly for dry-run + tests).
+COMMENTS_JSON=$(gh api --paginate \
+    "/repos/${REPO}/issues/${ISSUE_NUM}/comments" \
+    --jq '[.[] | {id, user: {login: .user.login}, body, created_at}]' \
+    2>/dev/null || echo "[]")
+
+# Release assets whose name references the issue (proof-issue-71-*, etc.).
+# We inspect up to 10 most recent releases (untagged builds included).
+RELEASES_JSON=$(gh release list --repo "$REPO" --limit 10 \
+    --json tagName 2>/dev/null || echo "[]")
+
+ASSETS_FILTERED="[]"
+if [[ -n "$RELEASES_JSON" && "$RELEASES_JSON" != "[]" ]]; then
+    for tag in $(jq -r '.[].tagName' <<<"$RELEASES_JSON"); do
+        # `gh release view` handles both tagged and untagged releases correctly,
+        # unlike the REST endpoint /releases/tags/{tag} which 404s on untagged ones.
+        tag_assets=$(gh release view "$tag" --repo "$REPO" \
+            --json assets --jq '[.assets[]? | {id, name}]' 2>/dev/null || echo "[]")
+        if ! echo "$tag_assets" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            tag_assets="[]"
+        fi
+        filtered=$(jq --arg tag "$tag" --arg n "$ISSUE_NUM" \
+            '[.[] | select((.name // "") | test("issue[-_]" + $n + "([^0-9]|$)")) | . + {release_tag: $tag}]' \
+            <<<"$tag_assets")
+        ASSETS_FILTERED=$(jq -s '.[0] + .[1]' <(echo "$ASSETS_FILTERED") <(echo "$filtered"))
+    done
+fi
+
+# ── Hand off to Python (logic layer) ────────────────────────────────────────
+
+PY_ARGS=(
+    --pbi "$PBI_ID"
+    --issue "$ISSUE_NUM"
+    --repo "$REPO"
+    --state-file "$STATE_FILE"
+    --log-file "$LOG_FILE"
+    --issue-json "$ISSUE_JSON"
+    --comments-json "$COMMENTS_JSON"
+    --releases-json "$ASSETS_FILTERED"
+)
+if [[ -n "$PR_JSON" ]]; then
+    PY_ARGS+=(--pr-json "$PR_JSON")
+fi
+if [[ "$MODE" == "dry-run" ]]; then
+    PY_ARGS+=(--dry-run)
+else
+    PY_ARGS+=(--confirm)
+fi
+if [[ "$KEEP_DB" == true ]]; then
+    PY_ARGS+=(--keep-db)
+fi
+
+set +e
+PYTHONPATH="$SCRIPTS_DIR" python3 "$PY_MODULE" "${PY_ARGS[@]}"
+PY_RC=$?
+set -e
+
+if [[ $PY_RC -ne 0 ]]; then
+    echo ""
+    echo "ERROR: Python reset_pbi exited with code $PY_RC (see $LOG_FILE)"
+    exit "$PY_RC"
+fi
+
+# ── Close open PR (orchestration) ───────────────────────────────────────────
+
+if [[ -n "$PR_JSON" ]]; then
+    PR_NUM=$(jq -r '.number' <<<"$PR_JSON")
+    PR_STATE=$(jq -r '.state' <<<"$PR_JSON")
+    if [[ "$PR_STATE" == "OPEN" ]]; then
+        echo ""
+        echo "── PR #${PR_NUM}: $(if [[ "$MODE" == "dry-run" ]]; then echo '[would close]'; else echo 'closing'; fi)"
+        echo "[pr] close PR #${PR_NUM}" >>"$LOG_FILE"
+        if [[ "$MODE" == "confirm" ]]; then
+            gh pr close "$PR_NUM" --repo "$REPO" \
+                --comment "Closed by fivepoints reset-pbi (factory reset for PBI #${PBI_ID})" \
+                >/dev/null 2>&1 || echo "  WARN: could not close PR #${PR_NUM}"
+        fi
+    fi
+fi
+
+# ── Git + worktree operations on TFIOneGit ──────────────────────────────────
+
+echo ""
+echo "── Git + worktree cleanup on $TFIONE_PATH"
+
+if [[ ! -d "$TFIONE_PATH/.git" && ! -f "$TFIONE_PATH/.git" ]]; then
+    echo "  SKIP: TFIOneGit clone not found at $TFIONE_PATH"
+    echo "[git] SKIP: TFIOneGit clone missing at $TFIONE_PATH" >>"$LOG_FILE"
+else
+    # Find matching worktrees. We match by branch name (feature/<pbi>-*) and
+    # we SKIP the primary working tree — even if it's on a matching branch,
+    # `git worktree remove` rightly refuses it and rm -rf would be catastrophic.
+    PRIMARY_WT=$(git -C "$TFIONE_PATH" rev-parse --show-toplevel 2>/dev/null || echo "")
+    WT_LIST=$(git -C "$TFIONE_PATH" worktree list --porcelain 2>/dev/null || true)
+    CUR_PATH=""
+    CUR_BRANCH=""
+    WT_MATCHES=()
+
+    _collect_wt_match() {
+        if [[ -z "$CUR_PATH" || "$CUR_BRANCH" != feature/${PBI_ID}-* ]]; then
+            return
+        fi
+        if [[ "$CUR_PATH" == "$PRIMARY_WT" ]]; then
+            echo "  SKIP primary worktree at $CUR_PATH (branch $CUR_BRANCH — checkout a different branch to reset this branch)"
+            echo "[git] SKIP primary worktree $CUR_PATH on $CUR_BRANCH" >>"$LOG_FILE"
+            return
+        fi
+        WT_MATCHES+=("$CUR_PATH")
+    }
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+            CUR_PATH="${BASH_REMATCH[1]}"
+        elif [[ "$line" == "branch refs/heads/"* ]]; then
+            CUR_BRANCH="${line#branch refs/heads/}"
+        elif [[ -z "$line" ]]; then
+            _collect_wt_match
+            CUR_PATH=""
+            CUR_BRANCH=""
+        fi
+    done <<<"$WT_LIST"
+    _collect_wt_match  # flush trailing block
+
+    for wt in ${WT_MATCHES[@]+"${WT_MATCHES[@]}"}; do
+        echo "  worktree: $wt"
+        echo "[git] worktree remove $wt" >>"$LOG_FILE"
+        if [[ "$MODE" == "confirm" ]]; then
+            git -C "$TFIONE_PATH" worktree remove "$wt" --force 2>/dev/null || {
+                echo "  WARN: worktree remove failed, falling back to rm -rf $wt"
+                rm -rf "$wt"
+            }
+        fi
+    done
+
+    # Find feature/<pbi>-* branches (local).
+    LOCAL_BRANCHES=$(git -C "$TFIONE_PATH" for-each-ref \
+        --format='%(refname:short)' "refs/heads/feature/${PBI_ID}-*" 2>/dev/null || true)
+    for br in $LOCAL_BRANCHES; do
+        echo "  local branch: $br"
+        echo "[git] branch -D $br" >>"$LOG_FILE"
+        if [[ "$MODE" == "confirm" ]]; then
+            git -C "$TFIONE_PATH" branch -D "$br" 2>/dev/null || \
+                echo "  WARN: could not delete local branch $br"
+        fi
+    done
+
+    # Remote branches on the 'github' mirror only.
+    if git -C "$TFIONE_PATH" remote get-url github >/dev/null 2>&1; then
+        REMOTE_BRANCHES=$(git -C "$TFIONE_PATH" ls-remote --heads github \
+            "refs/heads/feature/${PBI_ID}-*" 2>/dev/null \
+            | awk '{sub("refs/heads/", "", $2); print $2}' || true)
+        for br in $REMOTE_BRANCHES; do
+            # Safety: check if an ADO PR exists on 'origin' for this branch.
+            ORIG_HAS=$(git -C "$TFIONE_PATH" ls-remote --heads origin \
+                "refs/heads/$br" 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+            if [[ "$ORIG_HAS" != "0" ]]; then
+                echo "  NOTE: branch $br also exists on 'origin' (ADO) — leaving ADO side untouched"
+            fi
+            echo "  github remote branch: $br"
+            echo "[git] push github --delete $br" >>"$LOG_FILE"
+            if [[ "$MODE" == "confirm" ]]; then
+                git -C "$TFIONE_PATH" push github --delete "$br" 2>/dev/null || \
+                    echo "  WARN: could not delete remote branch $br on 'github'"
+            fi
+        done
+    else
+        echo "  SKIP: TFIOneGit has no 'github' remote — nothing to push-delete"
+    fi
+fi
+
+echo ""
+if [[ "$MODE" == "dry-run" ]]; then
+    echo "=== DRY RUN complete — no changes applied ==="
+    echo "Log: $LOG_FILE"
+else
+    echo "=== Reset complete ==="
+    echo "Log: $LOG_FILE"
+    echo ""
+    echo "Next: wait for the GitHub Manager to re-process issue #$ISSUE_NUM"
+    echo "      (label role:analyst was applied — a fresh analyst session will spawn)"
+fi

--- a/domain/operational/RESET_PBI.md
+++ b/domain/operational/RESET_PBI.md
@@ -1,0 +1,166 @@
+---
+domain: fivepoints
+category: operational
+name: RESET_PBI
+title: "Five Points — Factory Reset a PBI (reset-pbi)"
+keywords: [fivepoints, reset-pbi, pbi, factory-reset, pipeline, validation, tfi-one, ado, analyst, dev, tester, worktree, release-assets, guardrails]
+updated: 2026-04-16
+---
+
+# Five Points — Factory Reset a PBI (`reset-pbi`)
+
+Resets a **single PBI** plus its linked GitHub issue, worktrees, branches, PR,
+agent comments, labels, github-manager state, and release assets — so a fresh
+agent session can replay the analyst → dev → tester pipeline from zero.
+
+Complements `fivepoints reset-pipeline` (bulk). Use `reset-pbi` when validating
+pipeline fixes on a specific regression target (e.g. PBI #18839 / issue #71).
+
+---
+
+## Command
+
+```bash
+claire fivepoints reset-pbi --pbi <id> --issue <n> (--dry-run | --confirm)
+                            [--repo owner/name] [--tfione-path PATH] [--keep-db]
+```
+
+Required arguments:
+
+| Arg | Meaning |
+|---|---|
+| `--pbi <id>` | ADO PBI (work item) id — must match the issue title |
+| `--issue <n>` | GitHub issue number linked to the PBI |
+| `--dry-run` / `--confirm` | Exactly one — see below |
+
+Optional:
+
+| Arg | Default | Purpose |
+|---|---|---|
+| `--repo owner/name` | `CLAIRE-Fivepoints/fivepoints` | Target repo for the PBI's GitHub issue |
+| `--tfione-path PATH` | `$TFIONE_REPO_PATH` or `~/TFIOneGit` | Local TFIOneGit mirror clone |
+| `--keep-db` | off | Reserved for future — currently a no-op |
+
+---
+
+## What gets reset
+
+| # | Bucket | Effect |
+|---|---|---|
+| 1 | Local branches | `feature/<pbi>-*` deleted from TFIOneGit |
+| 2 | `github` remote branches | `feature/<pbi>-*` deleted on the mirror remote (**`origin` / ADO is NEVER touched**) |
+| 3 | Worktrees | `git worktree remove --force` for any worktree on a matching `feature/<pbi>-*` branch |
+| 4 | GitHub PR | Open PR whose head is the feature branch → **closed** (GitHub doesn't truly delete PRs) |
+| 5 | Agent comments | Comments authored by `claire-test-ai`, `claire-plugin-gatekeeper-ai`, `myclaire-ai`, `claire-gatekeeper-ai` are deleted via REST |
+| 6 | Issue labels | Reset to exactly `[role:analyst]` (triggers a fresh analyst spawn) |
+| 7 | Issue state | Reopened if closed |
+| 8 | github-manager state | Issue removed from `processed_issues` + `issue_assignees` in `github_manager_state_<owner>_<repo>.json` |
+| 9 | Release assets | Assets whose name matches `issue-<n>` (e.g. `proof-issue-71-*.mp4`, `BEFORE_issue-71.png`) are deleted |
+
+---
+
+## What does NOT get reset
+
+- **ADO-side branch (`origin` remote on TFIOneGit)** — the command checks and
+  logs a warning if a branch exists on both remotes, but only removes the one
+  on `github`.
+- **ADO work item state** — managed by ADO, not by this tool.
+- **Domain knowledge docs** — FDS extracts, personas, checklists are left
+  untouched.
+- **Other PBIs' state** — strictly scoped to `--pbi` and `--issue`.
+
+---
+
+## Guardrails
+
+The command refuses to proceed if:
+
+| Condition | Exit code | Message |
+|---|---|---|
+| `--pbi` does not match the issue title | `2` | `issue #N is linked to PBI #X, not PBI #<pbi>` |
+| Issue title has no PBI reference | `2` | `issue #N title does not reference any PBI` |
+| Linked PR is already **merged** | `3` | `PR #X ... is already MERGED — refusing reset` |
+| `--confirm` without `GITHUB_TOKEN` in env | `4` | `--confirm requires GITHUB_TOKEN` |
+
+`--dry-run` **always** prints the full plan (including API/state/release/git
+steps) without mutating anything.
+
+Every run writes a full log to:
+
+```
+$HOME/.claire/logs/reset-pbi-<pbi>-<YYYYMMDD-HHMMSS>.log
+```
+
+---
+
+## Tokens
+
+`GITHUB_TOKEN` is required for `--confirm`. Lookup order (first hit wins):
+
+1. `GITHUB_TOKEN` in the environment
+2. `GITHUB_TOKEN` or `GH_TOKEN` in `~/.config/claire/github_manager.env`
+3. `GITHUB_TOKEN` or `GH_TOKEN` in `~/.config/claire/.env`
+
+The token must have `repo` scope (issue/comment/PR mutation) and
+`admin:repo_hook` or equivalent for release asset deletion — the same scopes
+used by the github-manager.
+
+---
+
+## Validation flow (the reason this tool exists)
+
+After the fixes in claire-plugin#27 / #29 / #30 land, a validator session runs:
+
+```bash
+claire fivepoints reset-pbi --pbi 18839 --issue 71 --dry-run    # sanity check
+claire fivepoints reset-pbi --pbi 18839 --issue 71 --confirm    # factory reset
+
+# Wait for the GitHub Manager to re-spawn under role:analyst:
+#   - analyst pulls the fresh FDS (validates #30)
+#   - analyst posts an FDS read-receipt (validates #27)
+#   - dev cross-checks against the FDS before implementing
+#   - final PR scope matches FDS §10 (validates pipeline integrity)
+```
+
+Without `reset-pbi`, each validation attempt requires ~30 minutes of manual
+cleanup that is error-prone.
+
+---
+
+## Example — dry-run
+
+```bash
+$ claire fivepoints reset-pbi --pbi 18839 --issue 71 --dry-run
+=== fivepoints reset-pbi ===
+PBI:        18839
+Issue:      #71 on CLAIRE-Fivepoints/fivepoints
+Mode:       dry-run
+State file: /Users/.../99_runtime/github-manager/github_manager_state_CLAIRE-Fivepoints_fivepoints.json
+TFIOneGit:  /Users/.../TFIOneGit
+Log file:   /Users/.../.claire/logs/reset-pbi-18839-20260416-180000.log
+
+── Collecting issue + PR + release context via gh...
+=== reset_pbi plan (pbi=18839 issue=#71) ===
+  [gh:comment] delete comment #4263612757 by claire-test-ai: '👍 Picking up this task.'
+  [gh:labels]  set labels ['role:dev'] -> ['role:analyst']
+  [gh:asset]   delete release asset 'proof-issue-71-swagger.mp4' from untagged-4eff
+  [state:purge] remove issue #71 from ...github_manager_state_CLAIRE-Fivepoints_fivepoints.json
+
+[dry-run] no changes applied
+
+── Git + worktree cleanup on /Users/.../TFIOneGit
+  worktree: /Users/.../TFIOneGit/.claire/worktrees/issue-71-feat-code-gen
+  local branch: feature/18839-client-face-sheet
+  github remote branch: feature/18839-client-face-sheet
+
+=== DRY RUN complete — no changes applied ===
+```
+
+---
+
+## See also
+
+- `claire fivepoints reset-pipeline` — bulk reset of the whole pipeline backlog
+- `claire issue reset <n>` — generic Claire issue reset (single issue, claire core)
+- `claire domain read github_manager technical STATE_MANAGEMENT`
+- `claire domain read claire operational SPAWN_TROUBLESHOOT`

--- a/domain/scripts/reset_pbi.py
+++ b/domain/scripts/reset_pbi.py
@@ -1,0 +1,591 @@
+"""
+reset_pbi — Per-PBI factory reset for the fivepoints pipeline.
+
+Purpose:
+    Reset a single PBI + its linked GitHub issue to a clean state so a fresh
+    agent session can replay the full analyst -> dev -> tester flow from zero.
+    Used to validate pipeline fixes (e.g. issues #27, #29, #30).
+
+Scope (Python portion — HTTP + JSON only, no subprocess):
+    * Verify the GitHub issue title references the given --pbi id
+    * Refuse to proceed if the linked PR is already merged
+    * Delete agent-authored comments on the issue
+    * Reset labels to [role:analyst] (removing any other role:* labels)
+    * Reopen the issue if closed
+    * Remove the issue from the github-manager state JSON
+    * Delete release assets whose name references the issue/PBI
+
+Git operations (branch / worktree delete) are executed by the bash
+orchestrator (domain/commands/reset-pbi.sh) — see DEV_RULES #2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Authors whose comments are considered agent-authored and will be deleted.
+AGENT_LOGINS = frozenset(
+    {
+        "claire-test-ai",
+        "claire-plugin-gatekeeper-ai",
+        "myclaire-ai",
+        "claire-gatekeeper-ai",
+    }
+)
+
+PBI_TITLE_RE = re.compile(r"PBI\s*#\s*(\d+)", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Plan representation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Action:
+    """One entry in the reset plan. ``kind`` names the bucket; ``describe`` is
+    the one-line preview used by dry-run and the log file."""
+
+    kind: str
+    describe: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Plan:
+    actions: list[Action] = field(default_factory=list)
+
+    def add(self, kind: str, describe: str, **payload: Any) -> None:
+        self.actions.append(Action(kind=kind, describe=describe, payload=payload))
+
+    def render(self) -> str:
+        if not self.actions:
+            return "  (no actions)"
+        return "\n".join(f"  [{a.kind}] {a.describe}" for a in self.actions)
+
+
+# ---------------------------------------------------------------------------
+# Guardrail / validation helpers (pure logic, unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def parse_pbi_from_title(title: str) -> str | None:
+    """Return the PBI id referenced in an issue title, or None."""
+    m = PBI_TITLE_RE.search(title or "")
+    return m.group(1) if m else None
+
+
+def verify_pbi_matches_issue(
+    pbi_id: str, issue_title: str
+) -> tuple[bool, str | None]:
+    """Confirm the issue title references ``pbi_id``.
+
+    Returns (True, None) on match. On mismatch returns (False, detected_pbi)
+    where detected_pbi is what the title actually references (or None if the
+    title has no PBI reference at all).
+    """
+    detected = parse_pbi_from_title(issue_title)
+    if detected is None:
+        return False, None
+    return detected == str(pbi_id), detected
+
+
+def check_pr_merged(pr_state: str | None, merged: bool) -> bool:
+    """Return True if the PR blocks the reset (merged already)."""
+    if merged:
+        return True
+    # gh reports state "MERGED" alongside merged=true, but guard both.
+    return (pr_state or "").upper() == "MERGED"
+
+
+def is_agent_comment(author_login: str) -> bool:
+    return author_login in AGENT_LOGINS
+
+
+# ---------------------------------------------------------------------------
+# GitHub REST client (urllib-based — no requests, no subprocess)
+# ---------------------------------------------------------------------------
+
+
+class GitHubClient:
+    """Minimal authenticated GitHub REST client."""
+
+    def __init__(self, token: str, repo: str, *, base_url: str = "https://api.github.com"):
+        if not token:
+            raise ValueError("GitHub token is required")
+        if "/" not in repo:
+            raise ValueError(f"repo must be 'owner/name', got {repo!r}")
+        self._token = token
+        self._repo = repo
+        self._base_url = base_url.rstrip("/")
+
+    def _request(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> Any:
+        url = f"{self._base_url}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("Authorization", f"Bearer {self._token}")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if body is not None:
+            req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            raw = resp.read()
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw.decode(errors="replace")
+
+    # ---- issue comments ----
+    def list_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        comments: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            path = (
+                f"/repos/{self._repo}/issues/{issue_number}/comments"
+                f"?per_page=100&page={page}"
+            )
+            batch = self._request("GET", path) or []
+            if not batch:
+                break
+            comments.extend(batch)
+            if len(batch) < 100:
+                break
+            page += 1
+        return comments
+
+    def delete_issue_comment(self, comment_id: int) -> None:
+        self._request("DELETE", f"/repos/{self._repo}/issues/comments/{comment_id}")
+
+    # ---- issues ----
+    def set_issue_labels(self, issue_number: int, labels: list[str]) -> None:
+        self._request(
+            "PUT",
+            f"/repos/{self._repo}/issues/{issue_number}/labels",
+            {"labels": labels},
+        )
+
+    def reopen_issue(self, issue_number: int) -> None:
+        self._request(
+            "PATCH",
+            f"/repos/{self._repo}/issues/{issue_number}",
+            {"state": "open"},
+        )
+
+    # ---- releases ----
+    def delete_release_asset(self, asset_id: int) -> None:
+        self._request(
+            "DELETE", f"/repos/{self._repo}/releases/assets/{asset_id}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plan building
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Context:
+    pbi_id: str
+    issue_number: int
+    repo: str
+    issue_title: str
+    issue_state: str
+    issue_labels: list[str]
+    pr_number: int | None
+    pr_state: str | None
+    pr_merged: bool
+    comments: list[dict[str, Any]]
+    release_assets: list[dict[str, Any]]  # each: {id, name, release_tag}
+    state_file: Path
+    state_has_issue: bool
+
+
+def build_plan(ctx: Context) -> Plan:
+    """Compute the ordered list of reset actions for ``ctx``."""
+    plan = Plan()
+
+    # 1. Comments (agent-authored only)
+    agent_comments = [c for c in ctx.comments if is_agent_comment(c["user"]["login"])]
+    for c in agent_comments:
+        preview = (c.get("body") or "").splitlines()[0][:60]
+        plan.add(
+            "gh:comment",
+            f"delete comment #{c['id']} by {c['user']['login']}: {preview!r}",
+            comment_id=c["id"],
+        )
+
+    # 2. Labels — reset to exactly [role:analyst]
+    current = sorted(ctx.issue_labels)
+    desired = ["role:analyst"]
+    if current != desired:
+        plan.add(
+            "gh:labels",
+            f"set labels {current} -> {desired}",
+            labels=desired,
+        )
+
+    # 3. Reopen if closed
+    if (ctx.issue_state or "").upper() == "CLOSED":
+        plan.add("gh:reopen", f"reopen issue #{ctx.issue_number}")
+
+    # 4. Release assets
+    for a in ctx.release_assets:
+        plan.add(
+            "gh:asset",
+            f"delete release asset '{a['name']}' from {a.get('release_tag', '?')}",
+            asset_id=a["id"],
+        )
+
+    # 5. Claire github-manager state
+    if ctx.state_has_issue:
+        plan.add(
+            "state:purge",
+            f"remove issue #{ctx.issue_number} from {ctx.state_file}",
+        )
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# State-file mutation
+# ---------------------------------------------------------------------------
+
+
+def purge_state(state_file: Path, issue_number: int) -> bool:
+    """Remove ``issue_number`` from the github-manager state JSON.
+
+    Returns True if a change was written, False if the issue was not present.
+    """
+    if not state_file.exists():
+        logger.warning("state file does not exist: %s", state_file)
+        return False
+    with open(state_file) as f:
+        data = json.load(f)
+    changed = False
+    key = str(issue_number)
+    processed = data.get("processed_issues", {})
+    if key in processed:
+        processed.pop(key)
+        changed = True
+    assignees = data.get("issue_assignees", {})
+    if key in assignees:
+        assignees.pop(key)
+        changed = True
+    if changed:
+        data["last_updated"] = datetime.now(timezone.utc).isoformat()
+        with open(state_file, "w") as f:
+            json.dump(data, f, indent=2)
+    return changed
+
+
+def state_contains_issue(state_file: Path, issue_number: int) -> bool:
+    if not state_file.exists():
+        return False
+    try:
+        with open(state_file) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("could not read state file %s: %s", state_file, exc)
+        return False
+    key = str(issue_number)
+    return key in data.get("processed_issues", {}) or key in data.get(
+        "issue_assignees", {}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan execution
+# ---------------------------------------------------------------------------
+
+
+def execute_plan(plan: Plan, client: GitHubClient, ctx: Context) -> list[str]:
+    """Execute every action in ``plan``. Returns per-action result strings."""
+    results: list[str] = []
+    for action in plan.actions:
+        try:
+            if action.kind == "gh:comment":
+                client.delete_issue_comment(action.payload["comment_id"])
+            elif action.kind == "gh:labels":
+                client.set_issue_labels(
+                    ctx.issue_number, action.payload["labels"]
+                )
+            elif action.kind == "gh:reopen":
+                client.reopen_issue(ctx.issue_number)
+            elif action.kind == "gh:asset":
+                client.delete_release_asset(action.payload["asset_id"])
+            elif action.kind == "state:purge":
+                purge_state(ctx.state_file, ctx.issue_number)
+            else:
+                logger.warning("unknown action kind: %s", action.kind)
+                results.append(f"SKIP {action.kind}: unknown kind")
+                continue
+            results.append(f"OK   [{action.kind}] {action.describe}")
+        except urllib.error.HTTPError as e:
+            results.append(
+                f"FAIL [{action.kind}] {action.describe}: HTTP {e.code} {e.reason}"
+            )
+            logger.warning("action failed: %s — HTTP %s", action.describe, e.code)
+        except (urllib.error.URLError, OSError, ValueError, KeyError) as e:
+            results.append(
+                f"FAIL [{action.kind}] {action.describe}: {type(e).__name__}: {e}"
+            )
+            logger.warning("action failed: %s — %s", action.describe, e)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_json_arg(value: str | None, label: str) -> Any:
+    """Load JSON from ``value`` (either a literal or a path prefixed with @)."""
+    if value is None:
+        return None
+    if value.startswith("@"):
+        path = Path(value[1:])
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise SystemExit(f"could not read {label} JSON from {path}: {e}")
+    if value.strip() == "":
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"invalid {label} JSON: {e}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="reset_pbi",
+        description=(
+            "Factory reset a PBI's GitHub issue + state so the pipeline can "
+            "replay from zero. Called by domain/commands/reset-pbi.sh."
+        ),
+    )
+    p.add_argument("--pbi", required=True, help="ADO PBI id (numeric)")
+    p.add_argument(
+        "--issue", required=True, type=int, help="GitHub issue number"
+    )
+    p.add_argument(
+        "--repo", required=True, help="GitHub repo in owner/name form"
+    )
+    p.add_argument(
+        "--state-file",
+        required=True,
+        type=Path,
+        help="Path to github_manager_state_<owner>_<repo>.json",
+    )
+    p.add_argument(
+        "--log-file",
+        type=Path,
+        default=None,
+        help="Path to the reset log file (written to)",
+    )
+    p.add_argument(
+        "--issue-json",
+        required=True,
+        help='JSON blob or @path with {title,state,labels[]} for the issue',
+    )
+    p.add_argument(
+        "--pr-json",
+        default=None,
+        help='JSON blob or @path with {number,state,merged} for the linked PR',
+    )
+    p.add_argument(
+        "--comments-json",
+        default=None,
+        help="JSON blob or @path — if provided, skip the API fetch of comments",
+    )
+    p.add_argument(
+        "--releases-json",
+        default=None,
+        help=(
+            "JSON blob or @path — list of {id,name,release_tag} release assets "
+            "pre-filtered by issue number"
+        ),
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Print plan and exit")
+    mode.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Execute plan (destructive). Required for any real mutation.",
+    )
+    p.add_argument(
+        "--keep-db",
+        action="store_true",
+        help="Reserved for future use — no-op today (state file is untouched by --keep-db)",
+    )
+    return p
+
+
+def _write_log(log_file: Path, lines: list[str]) -> None:
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_file, "a") as f:
+        for line in lines:
+            f.write(line + "\n")
+
+
+def _collect_context(args: argparse.Namespace, client: GitHubClient) -> Context:
+    issue = _load_json_arg(args.issue_json, "issue-json") or {}
+    pr = _load_json_arg(args.pr_json, "pr-json")
+    comments_payload = _load_json_arg(args.comments_json, "comments-json")
+    releases_payload = _load_json_arg(args.releases_json, "releases-json") or []
+
+    # If comments weren't pre-supplied, fetch via API.
+    if comments_payload is None:
+        comments = client.list_issue_comments(args.issue)
+    else:
+        comments = comments_payload
+
+    pr_number: int | None = None
+    pr_state: str | None = None
+    pr_merged = False
+    if pr:
+        pr_number = pr.get("number")
+        pr_state = pr.get("state")
+        pr_merged = bool(pr.get("merged", False))
+
+    state_file: Path = args.state_file
+    state_has_issue = state_contains_issue(state_file, args.issue)
+
+    return Context(
+        pbi_id=str(args.pbi),
+        issue_number=int(args.issue),
+        repo=args.repo,
+        issue_title=issue.get("title", ""),
+        issue_state=issue.get("state", ""),
+        issue_labels=[
+            label["name"] if isinstance(label, dict) else str(label)
+            for label in issue.get("labels", [])
+        ],
+        pr_number=pr_number,
+        pr_state=pr_state,
+        pr_merged=pr_merged,
+        comments=comments,
+        release_assets=releases_payload,
+        state_file=state_file,
+        state_has_issue=state_has_issue,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    args = _build_parser().parse_args(argv)
+
+    log_lines: list[str] = [
+        f"=== reset_pbi pbi={args.pbi} issue={args.issue} repo={args.repo} ==="
+    ]
+
+    # Guardrail 1: PBI must match issue title.
+    issue_data = _load_json_arg(args.issue_json, "issue-json") or {}
+    match, detected = verify_pbi_matches_issue(args.pbi, issue_data.get("title", ""))
+    if not match:
+        if detected is None:
+            msg = (
+                f"ERROR: issue #{args.issue} title does not reference any PBI — "
+                f"got {issue_data.get('title', '')!r}"
+            )
+        else:
+            msg = (
+                f"ERROR: issue #{args.issue} is linked to PBI #{detected}, "
+                f"not PBI #{args.pbi}"
+            )
+        print(msg, file=sys.stderr)
+        if args.log_file:
+            _write_log(args.log_file, log_lines + [msg])
+        return 2
+
+    # Guardrail 2: PR must not be merged.
+    pr_data = _load_json_arg(args.pr_json, "pr-json") or {}
+    if check_pr_merged(pr_data.get("state"), bool(pr_data.get("merged", False))):
+        msg = (
+            f"ERROR: PR #{pr_data.get('number')} on branch "
+            f"{pr_data.get('headRefName', '<?>')} is already MERGED — refusing reset"
+        )
+        print(msg, file=sys.stderr)
+        if args.log_file:
+            _write_log(args.log_file, log_lines + [msg])
+        return 3
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    # In dry-run without comments provided we'd still need a token to fetch.
+    # Fall back to an empty-comment list if no token is available and nothing supplied.
+    if not token and args.comments_json is None:
+        print(
+            "WARNING: GITHUB_TOKEN not set and no --comments-json supplied; "
+            "dry-run will assume zero agent comments",
+            file=sys.stderr,
+        )
+        # Inject an empty comments payload so _collect_context skips the API call.
+        args.comments_json = "[]"
+
+    client = GitHubClient(token or "unset", args.repo) if token else None
+
+    # When no token, we need a dummy client for execute only if confirm.
+    if args.confirm and not token:
+        print(
+            "ERROR: --confirm requires GITHUB_TOKEN in the environment",
+            file=sys.stderr,
+        )
+        return 4
+
+    ctx = _collect_context(
+        args,
+        client
+        if client is not None
+        else GitHubClient("dummy-token-for-dry-run", args.repo),
+    )
+    plan = build_plan(ctx)
+
+    print(f"=== reset_pbi plan (pbi={ctx.pbi_id} issue=#{ctx.issue_number}) ===")
+    print(plan.render())
+    log_lines.append(f"[plan] {len(plan.actions)} action(s)")
+    log_lines.extend(f"  {a.kind}: {a.describe}" for a in plan.actions)
+
+    if args.dry_run:
+        print("\n[dry-run] no changes applied")
+        log_lines.append("mode: dry-run")
+        if args.log_file:
+            _write_log(args.log_file, log_lines)
+        return 0
+
+    print("\n[confirm] executing plan...")
+    results = execute_plan(plan, client, ctx)  # type: ignore[arg-type]
+    for r in results:
+        print(r)
+    log_lines.append("mode: confirm")
+    log_lines.extend(results)
+    if args.log_file:
+        _write_log(args.log_file, log_lines)
+
+    failures = [r for r in results if r.startswith("FAIL")]
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/domain/scripts/tests/test_reset_pbi.py
+++ b/domain/scripts/tests/test_reset_pbi.py
@@ -1,0 +1,251 @@
+"""Unit tests for reset_pbi — guardrails, plan building, state mutation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow tests to import the single-file module from its sibling directory.
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+from reset_pbi import (  # noqa: E402  (import after sys.path mutation)
+    AGENT_LOGINS,
+    Context,
+    build_plan,
+    check_pr_merged,
+    is_agent_comment,
+    parse_pbi_from_title,
+    purge_state,
+    state_contains_issue,
+    verify_pbi_matches_issue,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_pbi_from_title
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        ("1 - Code Gen (PBI #18839)", "18839"),
+        ("feat: something PBI#12345", "12345"),
+        ("(PBI #1)", "1"),
+        ("pbi # 987 lowercase and spaces", "987"),
+        ("nothing interesting", None),
+        ("", None),
+    ],
+)
+def test_parse_pbi_from_title(title: str, expected: str | None) -> None:
+    assert parse_pbi_from_title(title) == expected
+
+
+# ---------------------------------------------------------------------------
+# verify_pbi_matches_issue
+# ---------------------------------------------------------------------------
+
+
+def test_verify_pbi_matches_issue_match() -> None:
+    ok, detected = verify_pbi_matches_issue("18839", "1 - Code Gen (PBI #18839)")
+    assert ok is True
+    assert detected == "18839"
+
+
+def test_verify_pbi_matches_issue_mismatch() -> None:
+    ok, detected = verify_pbi_matches_issue("18839", "Something (PBI #99)")
+    assert ok is False
+    assert detected == "99"
+
+
+def test_verify_pbi_matches_issue_no_reference() -> None:
+    ok, detected = verify_pbi_matches_issue("18839", "plain title no reference")
+    assert ok is False
+    assert detected is None
+
+
+# ---------------------------------------------------------------------------
+# check_pr_merged
+# ---------------------------------------------------------------------------
+
+
+def test_check_pr_merged_true_when_merged_flag() -> None:
+    assert check_pr_merged(pr_state="OPEN", merged=True) is True
+
+
+def test_check_pr_merged_true_when_state_merged() -> None:
+    assert check_pr_merged(pr_state="MERGED", merged=False) is True
+
+
+def test_check_pr_merged_false_when_open() -> None:
+    assert check_pr_merged(pr_state="OPEN", merged=False) is False
+
+
+def test_check_pr_merged_false_when_closed_not_merged() -> None:
+    assert check_pr_merged(pr_state="CLOSED", merged=False) is False
+
+
+# ---------------------------------------------------------------------------
+# is_agent_comment
+# ---------------------------------------------------------------------------
+
+
+def test_is_agent_comment_known_agents() -> None:
+    for login in AGENT_LOGINS:
+        assert is_agent_comment(login) is True
+
+
+def test_is_agent_comment_human_login() -> None:
+    assert is_agent_comment("andreoperez") is False
+
+
+# ---------------------------------------------------------------------------
+# build_plan
+# ---------------------------------------------------------------------------
+
+
+def _mk_ctx(**overrides: object) -> Context:
+    defaults = {
+        "pbi_id": "18839",
+        "issue_number": 71,
+        "repo": "CLAIRE-Fivepoints/fivepoints",
+        "issue_title": "1 - Code Gen (PBI #18839)",
+        "issue_state": "OPEN",
+        "issue_labels": ["role:analyst"],
+        "pr_number": None,
+        "pr_state": None,
+        "pr_merged": False,
+        "comments": [],
+        "release_assets": [],
+        "state_file": Path("/tmp/nonexistent_state.json"),
+        "state_has_issue": False,
+    }
+    defaults.update(overrides)
+    return Context(**defaults)  # type: ignore[arg-type]
+
+
+def test_build_plan_empty_when_clean() -> None:
+    ctx = _mk_ctx()
+    plan = build_plan(ctx)
+    assert plan.actions == []
+
+
+def test_build_plan_deletes_agent_comments_only() -> None:
+    ctx = _mk_ctx(
+        comments=[
+            {"id": 1, "user": {"login": "claire-test-ai"}, "body": "hi"},
+            {"id": 2, "user": {"login": "human-reviewer"}, "body": "lgtm"},
+            {"id": 3, "user": {"login": "claire-plugin-gatekeeper-ai"}, "body": "ok"},
+        ]
+    )
+    plan = build_plan(ctx)
+    comment_actions = [a for a in plan.actions if a.kind == "gh:comment"]
+    comment_ids = {a.payload["comment_id"] for a in comment_actions}
+    assert comment_ids == {1, 3}, "only agent-authored comments should be scheduled"
+
+
+def test_build_plan_resets_labels_when_not_analyst() -> None:
+    ctx = _mk_ctx(issue_labels=["role:dev", "role:dev:in-progress", "priority:high"])
+    plan = build_plan(ctx)
+    label_actions = [a for a in plan.actions if a.kind == "gh:labels"]
+    assert len(label_actions) == 1
+    assert label_actions[0].payload["labels"] == ["role:analyst"]
+
+
+def test_build_plan_skips_label_action_when_already_analyst_only() -> None:
+    ctx = _mk_ctx(issue_labels=["role:analyst"])
+    plan = build_plan(ctx)
+    assert [a.kind for a in plan.actions] == []
+
+
+def test_build_plan_reopens_closed_issue() -> None:
+    ctx = _mk_ctx(issue_state="CLOSED")
+    plan = build_plan(ctx)
+    assert any(a.kind == "gh:reopen" for a in plan.actions)
+
+
+def test_build_plan_deletes_release_assets() -> None:
+    ctx = _mk_ctx(
+        release_assets=[
+            {"id": 100, "name": "proof-issue-71-swagger.mp4", "release_tag": "v1"},
+            {"id": 101, "name": "BEFORE_issue-71.png", "release_tag": "v1"},
+        ]
+    )
+    plan = build_plan(ctx)
+    asset_actions = [a for a in plan.actions if a.kind == "gh:asset"]
+    assert {a.payload["asset_id"] for a in asset_actions} == {100, 101}
+
+
+def test_build_plan_purges_state_when_present() -> None:
+    ctx = _mk_ctx(state_has_issue=True)
+    plan = build_plan(ctx)
+    assert any(a.kind == "state:purge" for a in plan.actions)
+
+
+def test_build_plan_skips_state_purge_when_absent() -> None:
+    ctx = _mk_ctx(state_has_issue=False)
+    plan = build_plan(ctx)
+    assert not any(a.kind == "state:purge" for a in plan.actions)
+
+
+# ---------------------------------------------------------------------------
+# purge_state / state_contains_issue
+# ---------------------------------------------------------------------------
+
+
+def _write_state(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def test_state_contains_issue_true_in_processed(tmp_path: Path) -> None:
+    f = tmp_path / "state.json"
+    _write_state(f, {"processed_issues": {"71": "2026-04-16T00:00:00"}})
+    assert state_contains_issue(f, 71) is True
+
+
+def test_state_contains_issue_true_in_assignees_only(tmp_path: Path) -> None:
+    f = tmp_path / "state.json"
+    _write_state(f, {"issue_assignees": {"71": ["claire-test-ai"]}})
+    assert state_contains_issue(f, 71) is True
+
+
+def test_state_contains_issue_false_when_missing_file(tmp_path: Path) -> None:
+    assert state_contains_issue(tmp_path / "absent.json", 71) is False
+
+
+def test_state_contains_issue_false_when_unrelated(tmp_path: Path) -> None:
+    f = tmp_path / "state.json"
+    _write_state(f, {"processed_issues": {"99": "x"}})
+    assert state_contains_issue(f, 71) is False
+
+
+def test_purge_state_removes_entries(tmp_path: Path) -> None:
+    f = tmp_path / "state.json"
+    _write_state(
+        f,
+        {
+            "processed_issues": {"71": "t1", "72": "t2"},
+            "issue_assignees": {"71": ["claire-test-ai"], "72": ["bot"]},
+            "last_updated": "old",
+        },
+    )
+    changed = purge_state(f, 71)
+    assert changed is True
+    data = json.loads(f.read_text())
+    assert "71" not in data["processed_issues"]
+    assert "71" not in data["issue_assignees"]
+    # Untouched entries survive.
+    assert data["processed_issues"]["72"] == "t2"
+    assert data["issue_assignees"]["72"] == ["bot"]
+    # last_updated is refreshed.
+    assert data["last_updated"] != "old"
+
+
+def test_purge_state_returns_false_when_absent(tmp_path: Path) -> None:
+    f = tmp_path / "state.json"
+    _write_state(f, {"processed_issues": {"99": "t"}})
+    assert purge_state(f, 71) is False

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -87,6 +87,10 @@ commands:
     script: "domain/commands/reset-pipeline.sh"
     description: "Reset all pipeline issues to clean backlog state (remove assignees, labels, worktrees, branches)"
 
+  - name: "fivepoints reset-pbi"
+    script: "domain/commands/reset-pbi.sh"
+    description: "Factory reset a single PBI (branches, worktrees, PR, agent comments, labels, state, release assets) so the pipeline can replay from zero"
+
   - name: "fivepoints install-hooks"
     script: "domain/commands/install-hooks.sh"
     description: "Install TFI One pre-commit hook into TFIOneGit (branch naming, no GRANT/DENY, no d.ts, no biz logic tests)"


### PR DESCRIPTION
## Summary

Adds `claire fivepoints reset-pbi` — a per-PBI factory reset so the full analyst → dev → tester pipeline can be replayed end-to-end to validate pipeline fixes (issues #27 / #29 / #30). Complements the existing bulk `fivepoints reset-pipeline`.

Closes #31

## What gets reset

| Bucket | Effect |
|---|---|
| Local + `github`-remote `feature/<pbi>-*` branches | deleted (ADO `origin` **never** touched) |
| Worktrees on matching branches | removed (primary worktree **skipped**) |
| Open PR on the head branch | closed |
| Agent-authored comments (`claire-test-ai`, `claire-plugin-gatekeeper-ai`, `myclaire-ai`, `claire-gatekeeper-ai`) | deleted via REST |
| Issue labels | reset to `[role:analyst]` |
| Issue state | reopened if closed |
| github-manager state JSON | issue removed from `processed_issues` + `issue_assignees` |
| Release assets matching `issue-<n>` | deleted |

## Guardrails

| Condition | Exit code |
|---|---|
| `--pbi` does not match issue title | `2` |
| Issue title references no PBI | `2` |
| Linked PR already MERGED | `3` |
| `--confirm` without `GITHUB_TOKEN` | `4` |

Every action is logged to `~/.claire/logs/reset-pbi-<pbi>-<timestamp>.log`.

## Architecture compliance

* **Bash = orchestration** — `domain/commands/reset-pbi.sh` handles arg parsing, `gh` context fetching, git worktree/branch/remote ops, PR close
* **Python = logic** — `domain/scripts/reset_pbi.py` handles guardrail checks, plan building, urllib-based GitHub REST mutations, JSON state-file mutation. **No `subprocess`** (DEV_RULES #2)

## Tests

29 unit tests — all pass:

```
$ pytest domain/scripts/tests/test_reset_pbi.py -q
29 passed in 0.05s
```

Coverage: PBI-title parsing, verify_pbi_matches_issue, check_pr_merged, agent-comment filter, plan building (empty / comments / labels / reopen / assets / state), state_contains_issue, purge_state.

## Verification Log

Command: `claire fivepoints reset-pbi --pbi 18839 --issue 71 --dry-run`
Context: fresh worktree on `issue-31`, PBI #18839 / issue #71 is the canonical regression target.

```
=== fivepoints reset-pbi ===
PBI:        18839
Issue:      #71 on CLAIRE-Fivepoints/fivepoints
Mode:       dry-run
State file: /Users/andreperez/claire/99_runtime/github-manager/github_manager_state_CLAIRE-Fivepoints_fivepoints.json
TFIOneGit:  /Users/andreperez/TFIOneGit
Log file:   /Users/andreperez/.claire/logs/reset-pbi-18839-20260416-175640.log

── Collecting issue + PR + release context via gh...
=== reset_pbi plan (pbi=18839 issue=#71) ===
  [gh:comment] delete comment #4256747264 by claire-test-ai: '👍 **Picking up this task.**'
  ... (13 agent comments total)
  [gh:labels] set labels ['role:dev'] -> ['role:analyst']
  [gh:asset] delete release asset 'proof-issue-71-real.mp4' from proof-issue-71-1776338658
  [gh:asset] delete release asset 'proof-issue-71.mp4' from proof-issue-71-1776338658
  [state:purge] remove issue #71 from .../github_manager_state_CLAIRE-Fivepoints_fivepoints.json

[dry-run] no changes applied

── PR #74: [would close]

── Git + worktree cleanup on /Users/andreperez/TFIOneGit
  SKIP primary worktree at /Users/andreperez/TFIOneGit (branch feature/18839-client-face-sheet — checkout a different branch to reset this branch)
  local branch: feature/18839-client-face-sheet
  github remote branch: feature/18839-client-face-sheet

=== DRY RUN complete — no changes applied ===
```

Guardrail dogfood (PBI mismatch):

```
$ claire fivepoints reset-pbi --pbi 9999 --issue 71 --dry-run
...
ERROR: issue #71 is linked to PBI #18839, not PBI #9999
ERROR: Python reset_pbi exited with code 2
```

## Test plan

- [x] `pytest domain/scripts/tests/test_reset_pbi.py` passes (29/29)
- [x] `--help` + `--agent-help` produce complete output
- [x] Missing args → clear error, exit 1
- [x] `--pbi/--issue` mismatch → exit 2
- [x] `--dry-run` produces complete plan, writes log, makes no changes
- [x] Primary worktree safely skipped (no `rm -rf` of main TFIOneGit)
- [x] Pre-commit sweep: no silent-exception swallowing, no inline `python3 -c`, no `subprocess` in Python
- [ ] (Manual, post-merge) `--confirm` against a disposable PBI verifies end-to-end destructive flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)