### PR TITLE
docs(fds-first): add FDS cross-check discipline — close analyst→dev blind spot (closes #27)

### DIFF
--- a/domain/commands/ado-transition.sh
+++ b/domain/commands/ado-transition.sh
@@ -65,7 +65,7 @@ claire fivepoints ado-transition --issue 2345 --branch feature/13644-adoption-hi
 ```
 
 ## When to call
-- After step [9/11] in dev checklist: all FDS sections proved working on video
+- After step [9/12] in dev checklist: all FDS sections proved working on video
 - Do NOT call before recording proof — ado_agent.py checks for .mp4 in issue
 
 ## PAT behavior

--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -60,21 +60,29 @@ updated: 2026-04-16
       After reading the target FDS section, post a receipt comment on the issue.
       This is the single piece of evidence the dev role will cross-check against.
       Skipping this step = silent failure chain → wrong specs ship to prod.
+      Use a heredoc with a flush-left `EOF` terminator — a multi-line
+      double-quoted string preserves the checklist indentation and GitHub
+      markdown then renders the body as a code block instead of a list.
 
-      gh issue comment <N> --body "**FDS Read Receipt**
-      - Document: <exact docx filename as attached to the PBI>
-      - Section: <exact section number + title> (pages X-Y)
-      - Screens identified: <count>
-      - Menu items: <count>
-      - Sub-pages per screen: <exhaustive list, one line per screen>
-        Example:
-          - Client Face Sheet: Demographics, Emergency Contacts, Household Members
-          - Medical File: Allergies, Medications, Diagnoses, Immunizations
-      - Labels verbatim from FDS: <list — no renaming, no guessing>"
+gh issue comment <N> --body "$(cat <<'EOF'
+**FDS Read Receipt**
+- Document: <exact docx filename as attached to the PBI>
+- Section: <exact section number + title> (pages X-Y)
+- Screens identified: <count>
+- Menu items: <count>
+- Sub-pages per screen: <exhaustive list, one line per screen>
+  Example:
+    - Client Face Sheet: Demographics, Emergency Contacts, Household Members
+    - Medical File: Allergies, Medications, Diagnoses, Immunizations
+- Labels verbatim from FDS: <list — no renaming, no guessing>
+EOF
+)"
 
-      ⚠️ The dev role's [1.5/12] FDS Cross-Check reads this comment to verify your spec
-         matches the FDS. If the receipt is missing or incomplete, the dev will block
-         and ask for it — adding hours of delay.
+      ⚠️ The dev role's [1.5/12] FDS Cross-Check reads this comment via
+         `gh issue view <N> --json comments --jq '.comments[] | select(.body | startswith("**FDS Read Receipt**")) | .body'`
+         — the receipt body MUST start with `**FDS Read Receipt**` (no leading
+         whitespace, no prefix) for that selector to find it. If the receipt
+         is missing or incomplete, the dev will block and ask for it.
       ⚠️ HARD STOP: Do NOT write specs or create the branch until this receipt is posted.
 
 - [ ] Deep dive the assigned task — identify the FDS section to implement:

--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -3,7 +3,7 @@ name: CHECKLIST_ANALYST
 description: "Five Points — Pipeline role:analyst session checklist"
 type: operational
 keywords: [fivepoints, analyst, pipeline, checklist, role]
-updated: 2026-04-14
+updated: 2026-04-16
 ---
 
 ## Your Checklist (MANDATORY — follow in order)
@@ -55,6 +55,27 @@ updated: 2026-04-14
         claire wait --issue <N>
       ⚠️ HARD STOP: Do NOT create a branch or write specs until the request is clear.
          One good question beats three pages of speculation.
+
+- [ ] 🚨 Post FDS Read Receipt on the GitHub issue (MANDATORY — audit trail):
+      After reading the target FDS section, post a receipt comment on the issue.
+      This is the single piece of evidence the dev role will cross-check against.
+      Skipping this step = silent failure chain → wrong specs ship to prod.
+
+      gh issue comment <N> --body "**FDS Read Receipt**
+      - Document: <exact docx filename as attached to the PBI>
+      - Section: <exact section number + title> (pages X-Y)
+      - Screens identified: <count>
+      - Menu items: <count>
+      - Sub-pages per screen: <exhaustive list, one line per screen>
+        Example:
+          - Client Face Sheet: Demographics, Emergency Contacts, Household Members
+          - Medical File: Allergies, Medications, Diagnoses, Immunizations
+      - Labels verbatim from FDS: <list — no renaming, no guessing>"
+
+      ⚠️ The dev role's [1.5/12] FDS Cross-Check reads this comment to verify your spec
+         matches the FDS. If the receipt is missing or incomplete, the dev will block
+         and ask for it — adding hours of delay.
+      ⚠️ HARD STOP: Do NOT write specs or create the branch until this receipt is posted.
 
 - [ ] Deep dive the assigned task — identify the FDS section to implement:
       - Task ID from the GitHub issue title (use this for branch naming, NOT the parent PBI ID)

--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -37,14 +37,8 @@ TaskCreate(title="[11/12] Stop test environment + claire stop (after ADO task cl
       claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       claire domain read claire knowledge DEBUG_METHODOLOGY
       Read the GitHub issue — analyst has written specs there.
-      ⚠️  MANDATORY CROSS-CHECK before implementing (do NOT skip — see [1.5/12] below):
-        1. Fetch the FDS attached to the parent PBI via the ADO REST API
-           (see claire domain read fivepoints operational AZURE_DEVOPS_ACCESS)
-        2. Open the FDS to the section the analyst referenced
-        3. Verify the analyst's list of screens / routes / cards / sub-pages matches the FDS exactly
-        4. If mismatch → post on the issue, claire wait, do NOT proceed on guesswork
-      The single point of failure at the analyst role was the root cause of PR #74 scope errors.
-      The dev role is the last line of defense against silent spec drift.
+      ⚠️  Do NOT skip the FDS cross-check — full protocol in [1.5/12] below.
+      The dev role is the last line of defense against silent spec drift (root cause of PR #74).
       If specs are still incomplete after cross-check → follow the Gap Recovery section below.
       git fetch github
       git checkout feature/{ticket-id}-{description}
@@ -64,8 +58,13 @@ TaskCreate(title="[11/12] Stop test environment + claire stop (after ADO task cl
         → For each .docx attachment → download, convert to text (python-docx or textract)
 
       Step 2 — Locate the analyst's FDS Read Receipt comment on the issue:
-        gh issue view <N> --comments | grep -A 10 "FDS Read Receipt"
+        # Anchor on body prefix — substring grep picks up reply threads that quote the phrase
+        gh issue view <N> --json comments \
+          --jq '.comments[] | select(.body | startswith("**FDS Read Receipt**")) | .body'
+        # Optional: also filter by author if your pipeline tags the analyst bot login:
+        #   --jq '.comments[] | select(.author.login == "<analyst-bot-login>" and (.body | startswith("**FDS Read Receipt**"))) | .body'
         → Note: document name, section number + title, screens count, menu items count, sub-pages
+        → If no receipt found → block; ask the analyst to post it (CHECKLIST_ANALYST requires it).
 
       Step 3 — Cross-check the analyst's spec against the FDS:
         - Screens / routes: does every screen the analyst listed appear in the FDS? Any extras? Any missing?
@@ -74,17 +73,24 @@ TaskCreate(title="[11/12] Stop test environment + claire stop (after ADO task cl
         - Source code cross-contamination: did the analyst copy from base_menu_options.tsx (stale code)
           instead of reading the FDS? Red flag if the spec mentions routes that exist in code but not the FDS.
 
-      Step 4 — Produce and post the delta:
-        delta_comment="**FDS Cross-Check delta (dev role)**\n"
-        delta_comment+="- FDS document: <docx filename>\n"
-        delta_comment+="- FDS section: <exact section number + title>\n"
-        delta_comment+="- Analyst said: N screens, M menu items\n"
-        delta_comment+="- FDS says: N' screens, M' menu items\n"
-        delta_comment+="- Extra (analyst added, not in FDS): <list>\n"
-        delta_comment+="- Missing (in FDS, analyst omitted): <list>\n"
-        delta_comment+="- Renamed (label mismatches): <list>\n"
-        delta_comment+="- Verdict: [MATCH | DELTA DETECTED]"
-        gh issue comment <N> --body "$delta_comment"
+      Step 4 — Produce and post the delta. Use a heredoc: `\n` in a bash
+      double-quoted string is literal backslash-n, not a newline, and GitHub
+      markdown does not interpret it either. The `EOF` terminator of a
+      `<<'EOF'` heredoc must be at column 0 — the block below is shown
+      flush-left intentionally; do NOT re-indent it when executing.
+
+gh issue comment <N> --body "$(cat <<'EOF'
+**FDS Cross-Check delta (dev role)**
+- FDS document: <docx filename>
+- FDS section: <exact section number + title>
+- Analyst said: N screens, M menu items
+- FDS says: N' screens, M' menu items
+- Extra (analyst added, not in FDS): <list>
+- Missing (in FDS, analyst omitted): <list>
+- Renamed (label mismatches): <list>
+- Verdict: [MATCH | DELTA DETECTED]
+EOF
+)"
 
       Step 5 — Decide:
         ✅ MATCH → proceed to [2/12] (baseline gates)

--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -3,45 +3,99 @@ name: CHECKLIST_DEV_PIPELINE
 description: "Five Points — Pipeline role:dev session checklist"
 type: operational
 keywords: [fivepoints, dev, developer, pipeline, checklist, role]
-updated: 2026-04-14
+updated: 2026-04-16
 ---
 
 ### SESSION START — Create All Tasks First (MANDATORY)
 
-Before doing ANY work, create all 11 checklist tasks so each step is auditable:
+Before doing ANY work, create all 12 checklist tasks so each step is auditable:
 
 ```
-TaskCreate(title="[1/11] Load context + read issue + checkout branch")
-TaskCreate(title="[2/11] [GATE-0] Baseline gates — all 5 gates pass on UNMODIFIED branch BEFORE any code")
-TaskCreate(title="[3/11] Implement requirements")
-TaskCreate(title="[4/11] Run all 5 gates + commit + push to GitHub")
-TaskCreate(title="[5/11] GitHub PR + gatekeeper code review")
-TaskCreate(title="[6/11] Copy to isolated worktree + start test environment")
-TaskCreate(title="[7/11] Swagger verification (backend gate)")
-TaskCreate(title="[8/11] Verify login fixture + run E2E tests (Playwright)")
-TaskCreate(title="[9/11] Record MP4 proof — ALL FDS sections")
-TaskCreate(title="[10/11] PAT gate + fivepoints ado-transition → push branch to ADO")
-TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task closed)")
+TaskCreate(title="[1/12] Load context + read issue + checkout branch")
+TaskCreate(title="[1.5/12] FDS Cross-Check — verify analyst specs against the FDS attached to the parent PBI")
+TaskCreate(title="[2/12] [GATE-0] Baseline gates — all 5 gates pass on UNMODIFIED branch BEFORE any code")
+TaskCreate(title="[3/12] Implement requirements")
+TaskCreate(title="[4/12] Run all 5 gates + commit + push to GitHub")
+TaskCreate(title="[5/12] GitHub PR + gatekeeper code review")
+TaskCreate(title="[6/12] Copy to isolated worktree + start test environment")
+TaskCreate(title="[7/12] Swagger verification (backend gate)")
+TaskCreate(title="[8/12] Verify login fixture + run E2E tests (Playwright)")
+TaskCreate(title="[9/12] Record MP4 proof — ALL FDS sections")
+TaskCreate(title="[10/12] PAT gate + fivepoints ado-transition → push branch to ADO")
+TaskCreate(title="[11/12] Stop test environment + claire stop (after ADO task closed)")
 ```
 
-❌ Do NOT start any work before all 11 tasks are created.
+❌ Do NOT start any work before all 12 tasks are created.
 
 ### Your Checklist (MANDATORY — follow in order)
 
 ```
-- [ ] [1/11] Load domain context, read issue, checkout branch:
+- [ ] [1/12] Load domain context, read issue, checkout branch:
       claire domain read fivepoints operational PIPELINE_WORKFLOW
       claire domain read fivepoints operational CODE_REVIEW_WORKFLOW
       claire domain read fivepoints operational SWAGGER_VERIFICATION
       claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       claire domain read claire knowledge DEBUG_METHODOLOGY
-      Read the GitHub issue — analyst has written all specs there (no ADO lookup needed)
-      If specs are incomplete → follow the Gap Recovery section below before proceeding
+      Read the GitHub issue — analyst has written specs there.
+      ⚠️  MANDATORY CROSS-CHECK before implementing (do NOT skip — see [1.5/12] below):
+        1. Fetch the FDS attached to the parent PBI via the ADO REST API
+           (see claire domain read fivepoints operational AZURE_DEVOPS_ACCESS)
+        2. Open the FDS to the section the analyst referenced
+        3. Verify the analyst's list of screens / routes / cards / sub-pages matches the FDS exactly
+        4. If mismatch → post on the issue, claire wait, do NOT proceed on guesswork
+      The single point of failure at the analyst role was the root cause of PR #74 scope errors.
+      The dev role is the last line of defense against silent spec drift.
+      If specs are still incomplete after cross-check → follow the Gap Recovery section below.
       git fetch github
       git checkout feature/{ticket-id}-{description}
       → TaskUpdate(<task_1_id>, status="completed")
 
-- [ ] [2/11] [GATE-0] Baseline gates — run ALL 5 gates on the UNMODIFIED branch (BEFORE writing any code):
+- [ ] [1.5/12] 🚨 FDS Cross-Check (MANDATORY — 10 minutes max, before any code):
+      ⚠️  HARD STOP: Do NOT write code until this step is complete.
+      This step verifies the analyst read the FDS. The dev is the last line of defense.
+
+      Step 1 — Fetch the FDS from the parent PBI:
+        # Preferred (when claire-plugin#29 lands): claire fivepoints ado-fetch-attachments --pbi <parent-pbi-id>
+        # Manual fallback (works today):
+        claire domain read fivepoints operational AZURE_DEVOPS_ACCESS   ← PAT setup
+        curl -s -u ":$AZURE_DEVOPS_PAT" \
+          "https://dev.azure.com/Fivepoints/TFIOne/_apis/wit/workItems/{PARENT_PBI_ID}?\$expand=relations&api-version=7.1" \
+          | jq '.relations[] | select(.rel == "AttachedFile") | {name: .attributes.name, url: .url}'
+        → For each .docx attachment → download, convert to text (python-docx or textract)
+
+      Step 2 — Locate the analyst's FDS Read Receipt comment on the issue:
+        gh issue view <N> --comments | grep -A 10 "FDS Read Receipt"
+        → Note: document name, section number + title, screens count, menu items count, sub-pages
+
+      Step 3 — Cross-check the analyst's spec against the FDS:
+        - Screens / routes: does every screen the analyst listed appear in the FDS? Any extras? Any missing?
+        - Labels: does every label match exactly (e.g. "Medical File" vs "Health/Medical")?
+        - Sub-pages: did the analyst enumerate every sub-page under each screen?
+        - Source code cross-contamination: did the analyst copy from base_menu_options.tsx (stale code)
+          instead of reading the FDS? Red flag if the spec mentions routes that exist in code but not the FDS.
+
+      Step 4 — Produce and post the delta:
+        delta_comment="**FDS Cross-Check delta (dev role)**\n"
+        delta_comment+="- FDS document: <docx filename>\n"
+        delta_comment+="- FDS section: <exact section number + title>\n"
+        delta_comment+="- Analyst said: N screens, M menu items\n"
+        delta_comment+="- FDS says: N' screens, M' menu items\n"
+        delta_comment+="- Extra (analyst added, not in FDS): <list>\n"
+        delta_comment+="- Missing (in FDS, analyst omitted): <list>\n"
+        delta_comment+="- Renamed (label mismatches): <list>\n"
+        delta_comment+="- Verdict: [MATCH | DELTA DETECTED]"
+        gh issue comment <N> --body "$delta_comment"
+
+      Step 5 — Decide:
+        ✅ MATCH → proceed to [2/12] (baseline gates)
+        ❌ DELTA DETECTED → post the delta (already done in Step 4), then:
+           claire wait --issue <N>
+           Do NOT implement. Wait for the analyst / owner to confirm the correct scope.
+      ❌ If FDS cannot be fetched (no attachment on PBI or parent chain) → post on issue,
+         claire wait. Never assume specs without the source document.
+      → TaskUpdate(<task_1.5_id>, status="completed")
+
+- [ ] [2/12] [GATE-0] Baseline gates — run ALL 5 gates on the UNMODIFIED branch (BEFORE writing any code):
       ⚠️  HARD STOP: Do NOT write a single line of code until ALL baseline gates pass.
       Gate 1: dotnet build com.tfione.api/com.tfione.api.csproj -c Gate -WarnAsError -nowarn:nu1901,nu1902 → 0 errors
       Gate 2: dotnet test com.tfione.service.test/com.tfione.service.test.csproj --configuration Gate → all passing
@@ -61,10 +115,10 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       ❌ If ANY gate fails → environment issue, NOT a feature issue — fix before implementing
       → TaskUpdate(<task_2_id>, status="completed")
 
-- [ ] [3/11] Implement the requirements
+- [ ] [3/12] Implement the requirements
       → TaskUpdate(<task_3_id>, status="completed")
 
-- [ ] [4/11] Run ALL 5 gates locally, commit, and push to GitHub:
+- [ ] [4/12] Run ALL 5 gates locally, commit, and push to GitHub:
       Gate 1: dotnet build com.tfione.api/com.tfione.api.csproj -c Gate -WarnAsError -nowarn:nu1901,nu1902
       Gate 2: dotnet test com.tfione.service.test/com.tfione.service.test.csproj --configuration Gate
       Gate 3: cd com.tfione.web && npm run build-gate — 0 errors (tsc -b + vite build)
@@ -75,7 +129,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       ⚠️ NEVER use git push origin — origin is the ADO remote
       → TaskUpdate(<task_4_id>, status="completed")
 
-- [ ] [5/11] Create GitHub PR + wait for gatekeeper review + post PR link on issue (MANDATORY — do not wait to be asked):
+- [ ] [5/12] Create GitHub PR + wait for gatekeeper review + post PR link on issue (MANDATORY — do not wait to be asked):
       gh pr create --base staging --title "feat(five-points): <description>" --body "Closes #<N>"
       # Gatekeeper review fires automatically via GitHub Actions runner (< 1s)
       Wait for gatekeeper APPROVE before continuing (arrives via claire wait).
@@ -86,7 +140,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 --- SELF-TESTING (in isolated worktree — MANDATORY) ---
 
-- [ ] [6/11] Copy feature branch to isolated worktree, start test environment:
+- [ ] [6/12] Copy feature branch to isolated worktree, start test environment:
       DO NOT test in the dev worktree — use a separate copy
       Copy feature branch to a new isolated worktree
       cd <isolated-worktree-path>
@@ -95,7 +149,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       → If script missing: start SQL Server, dotnet run, and npm run dev manually
       → TaskUpdate(<task_6_id>, status="completed")
 
-- [ ] [7/11] Swagger verification (backend gate — run BEFORE Playwright):
+- [ ] [7/12] Swagger verification (backend gate — run BEFORE Playwright):
       claire domain read fivepoints operational SWAGGER_VERIFICATION
       → Verify all new endpoints appear in swagger.json
       → Verify all endpoints return HTTP 200 with valid Bearer token
@@ -104,7 +158,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
          Copy updated changes to isolated worktree → retest from this step
       → TaskUpdate(<task_7_id>, status="completed")
 
-- [ ] [8/11] Verify shared login fixture exists, then run E2E tests:
+- [ ] [8/12] Verify shared login fixture exists, then run E2E tests:
       Check: e2e/global-setup.ts exists in com.tfione.web/
       If missing → create it before running feature tests
       Reference credentials: claire domain read fivepoints operational TESTING
@@ -114,7 +168,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
          Copy updated changes to isolated worktree → retest from step 7
       → TaskUpdate(<task_8_id>, status="completed")
 
-- [ ] [9/11] 🚨 HARD STOP — Record MP4 proof for ALL FDS sections (MANDATORY):
+- [ ] [9/12] 🚨 HARD STOP — Record MP4 proof for ALL FDS sections (MANDATORY):
       Every FDS requirement must be demonstrated on video — not just the happy path.
       ❌ Do NOT use ffmpeg or screencapture — use Playwright proof recording
       Frontend UI proof: claire domain read video_proof technical PLAYWRIGHT_PATTERNS
@@ -125,7 +179,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 --- ADO TRANSITION (after ALL FDS sections proved working) ---
 
-- [ ] [10/11] PAT gate + push feature branch to ADO:
+- [ ] [10/12] PAT gate + push feature branch to ADO:
       claire fivepoints ado-transition --issue <N>
       → [1/3] Verifies branch naming convention
       → [2/3] PAT gate: if AZURE_DEVOPS_WRITE_PAT is not set, posts wait comment
@@ -133,12 +187,12 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       → [3/3] Pushes branch to ADO + creates ADO PR + monitors build
       ❌ FAIL → fix in dev worktree → copy to isolated worktree → retest → rerun ado-transition
       ✅ PASS → ADO PR created, build passed, GitHub issue closed by ADO
-      ⚠️  Do NOT proceed to [11/11] until ado-transition has FULLY COMPLETED
+      ⚠️  Do NOT proceed to [11/12] until ado-transition has FULLY COMPLETED
           and confirmed the GitHub issue is closed.
       → TaskUpdate(<task_10_id>, status="completed")
 
-- [ ] [11/11] Stop test environment + execute claire stop:
-      ⚠️  Only after step [10/11] is completed and ADO has closed the GitHub issue.
+- [ ] [11/12] Stop test environment + execute claire stop:
+      ⚠️  Only after step [10/12] is completed and ADO has closed the GitHub issue.
       kill $API_PID $VITE_PID        # PIDs printed by test-env-start.sh
       docker stop tfione-sqlserver
       Execute: claire stop

--- a/domain/operational/PIPELINE_WORKFLOW.md
+++ b/domain/operational/PIPELINE_WORKFLOW.md
@@ -4,7 +4,7 @@ category: operational
 name: PIPELINE_WORKFLOW
 title: "Five Points — Client Pipeline Workflow (PBI → ADO Merge)"
 keywords: [five-points, pipeline, workflow, analyst, dev, tester, ado-push, ado-transition, transition, labels, checklist, pbi, role-dev, fivepoints-dev, role-tester, role-analyst]
-updated: 2026-04-06
+updated: 2026-04-16
 pr: "#2188"
 ---
 
@@ -134,28 +134,41 @@ and includes the role-specific checklist in CLAUDE.md.
 
 ### Session Start — Create All Tasks First (MANDATORY)
 
-Before doing ANY work, create all 11 checklist tasks so each step is auditable:
+Before doing ANY work, create all 12 checklist tasks so each step is auditable:
 
 ```
-TaskCreate(title="[1/11] Load context + read issue + checkout branch")
-TaskCreate(title="[2/11] [GATE-0] Baseline gates — all 5 gates pass on UNMODIFIED branch BEFORE any code")
-TaskCreate(title="[3/11] Implement requirements")
-TaskCreate(title="[4/11] Run all 5 gates + commit + push to GitHub")
-TaskCreate(title="[5/11] GitHub PR + gatekeeper code review")
-TaskCreate(title="[6/11] Copy to isolated worktree + start test environment")
-TaskCreate(title="[7/11] Swagger verification (backend gate)")
-TaskCreate(title="[8/11] Verify login fixture + run E2E tests (Playwright)")
-TaskCreate(title="[9/11] Record MP4 proof — ALL FDS sections")
-TaskCreate(title="[10/11] PAT gate + fivepoints ado-transition → push branch to ADO")
-TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task closed)")
+TaskCreate(title="[1/12] Load context + read issue + checkout branch")
+TaskCreate(title="[1.5/12] FDS Cross-Check — verify analyst specs against the FDS attached to the parent PBI")
+TaskCreate(title="[2/12] [GATE-0] Baseline gates — all 5 gates pass on UNMODIFIED branch BEFORE any code")
+TaskCreate(title="[3/12] Implement requirements")
+TaskCreate(title="[4/12] Run all 5 gates + commit + push to GitHub")
+TaskCreate(title="[5/12] GitHub PR + gatekeeper code review")
+TaskCreate(title="[6/12] Copy to isolated worktree + start test environment")
+TaskCreate(title="[7/12] Swagger verification (backend gate)")
+TaskCreate(title="[8/12] Verify login fixture + run E2E tests (Playwright)")
+TaskCreate(title="[9/12] Record MP4 proof — ALL FDS sections")
+TaskCreate(title="[10/12] PAT gate + fivepoints ado-transition → push branch to ADO")
+TaskCreate(title="[11/12] Stop test environment + claire stop (after ADO task closed)")
 ```
 
 ### Checklist
 ```
-- [ ] [1/11] Load domain context, read issue, checkout branch
+- [ ] [1/12] Load domain context, read issue, checkout branch
+      Read the GitHub issue + the analyst's FDS Read Receipt comment (required by CHECKLIST_ANALYST).
       → TaskUpdate(<task_1_id>, status="completed")
 
-- [ ] [2/11] [GATE-0] Baseline gates — run ALL 5 gates on UNMODIFIED branch (BEFORE writing any code):
+- [ ] [1.5/12] 🚨 FDS Cross-Check (MANDATORY — 10 minutes, before any code):
+      Full protocol: claire domain read fivepoints operational CHECKLIST_DEV_PIPELINE (step [1.5/12])
+      Summary:
+        1. Fetch FDS from parent PBI (curl via AZURE_DEVOPS_PAT, or claire-plugin#29 when it ships)
+        2. Read the analyst's FDS Read Receipt comment on the issue
+        3. Cross-check screens / routes / labels / sub-pages — produce delta
+        4. Post the delta as a comment on the issue
+        5. MATCH → proceed to [2/12]. DELTA DETECTED → claire wait, do NOT implement.
+      ⚠️ HARD STOP: the dev is the last line of defense against silent spec drift.
+      → TaskUpdate(<task_1.5_id>, status="completed")
+
+- [ ] [2/12] [GATE-0] Baseline gates — run ALL 5 gates on UNMODIFIED branch (BEFORE writing any code):
       ⚠️  HARD STOP: Do NOT write a single line of code until ALL baseline gates pass.
       Gate 1: dotnet build com.tfione.api/com.tfione.api.csproj -c Gate -WarnAsError -nowarn:nu1901,nu1902 → 0 errors
       Gate 2: dotnet test com.tfione.service.test/com.tfione.service.test.csproj --configuration Gate → all passing
@@ -175,15 +188,15 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       ❌ If ANY gate fails → environment issue, NOT a feature issue — fix before implementing
       → TaskUpdate(<task_2_id>, status="completed")
 
-- [ ] [3/11] Implement the requirements
+- [ ] [3/12] Implement the requirements
       → TaskUpdate(<task_3_id>, status="completed")
 
-- [ ] [4/11] Run all 5 gates, commit, push to GitHub ONLY:
+- [ ] [4/12] Run all 5 gates, commit, push to GitHub ONLY:
       git push github feature/{ticket-id}-{description}
       ⚠️ NEVER use git push origin — origin is the ADO remote
       → TaskUpdate(<task_4_id>, status="completed")
 
-- [ ] [5/11] Create GitHub PR, wait for gatekeeper review, post PR link on issue (MANDATORY — do not wait to be asked):
+- [ ] [5/12] Create GitHub PR, wait for gatekeeper review, post PR link on issue (MANDATORY — do not wait to be asked):
       gh pr create --base staging --title "feat(five-points): <description>" --body "Closes #<N>"
       # Gatekeeper review fires automatically via GitHub Actions runner (< 1s)
       Wait for gatekeeper APPROVE before continuing (arrives via claire wait)
@@ -193,24 +206,24 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 --- SELF-TESTING (in isolated worktree — MANDATORY) ---
 
-- [ ] [6/11] Copy feature branch to isolated worktree, start test environment:
+- [ ] [6/12] Copy feature branch to isolated worktree, start test environment:
       Copy feature branch to a new isolated worktree (not the dev worktree)
       ./scripts/test-env-start.sh → Wait for "✅ Environment ready"
       → TaskUpdate(<task_6_id>, status="completed")
 
-- [ ] [7/11] Swagger verification (backend gate — before Playwright):
+- [ ] [7/12] Swagger verification (backend gate — before Playwright):
       claire domain read fivepoints operational SWAGGER_VERIFICATION
       Verify endpoints + HTTP 200 with Bearer token
       ❌ Fail → fix in dev worktree (feature branch) → push → copy to isolated worktree → retest
       → TaskUpdate(<task_7_id>, status="completed")
 
-- [ ] [8/11] Verify login fixture + run E2E tests (Playwright):
+- [ ] [8/12] Verify login fixture + run E2E tests (Playwright):
       Check e2e/global-setup.ts exists — create if missing
       Run Playwright tests only after Swagger passed
       ❌ Fail → fix in dev worktree → push → copy to isolated worktree → retest from step 7
       → TaskUpdate(<task_8_id>, status="completed")
 
-- [ ] [9/11] 🚨 HARD STOP — Record MP4 proof for ALL FDS sections (MANDATORY):
+- [ ] [9/12] 🚨 HARD STOP — Record MP4 proof for ALL FDS sections (MANDATORY):
       Every FDS requirement must be demonstrated on video.
       ❌ fivepoints ado-transition will reject if no .mp4 found in issue.
 
@@ -243,7 +256,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 --- ADO TRANSITION (after ALL FDS sections proved working) ---
 
-- [ ] [10/11] PAT gate + push feature branch to ADO:
+- [ ] [10/12] PAT gate + push feature branch to ADO:
       🚨 MANDATORY pre-transition verification — run Gate 5b (flyway migrate) against the local SQL Server:
       → Canonical command lives in `claire domain read fivepoints operational DEVELOPER_GATES` (§ Gate 5b)
       ✅ Passing criteria: Flyway reports 0 errors, all pending migrations applied successfully
@@ -256,12 +269,12 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       → [3/3] Pushes branch to ADO + creates ADO PR + monitors build
       ❌ FAIL → fix in dev worktree → copy to isolated worktree → retest → rerun ado-transition
       ✅ PASS → ADO PR created, build passed, GitHub issue closed by ADO
-      ⚠️  Do NOT proceed to [11/11] until ado-transition has FULLY COMPLETED
+      ⚠️  Do NOT proceed to [11/12] until ado-transition has FULLY COMPLETED
           and confirmed the GitHub issue is closed.
       → TaskUpdate(<task_10_id>, status="completed")
 
-- [ ] [11/11] Stop test environment + claire stop:
-      ⚠️  Only after step [10/11] is completed and ADO has closed the GitHub issue.
+- [ ] [11/12] Stop test environment + claire stop:
+      ⚠️  Only after step [10/12] is completed and ADO has closed the GitHub issue.
       kill $API_PID $VITE_PID && docker stop tfione-sqlserver
       Execute: claire stop
       → TaskUpdate(<task_11_id>, status="completed")
@@ -271,7 +284,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 - Does not push to `origin` (ADO remote) manually — use `fivepoints ado-transition`
 - Does not test in the dev worktree — always uses an isolated copy
 - Does not merge PRs — never
-- Does not commit test code or test artifacts to the feature branch — the isolated worktree ([6/11]) is
+- Does not commit test code or test artifacts to the feature branch — the isolated worktree ([6/12]) is
   the enforcement boundary: changes in the isolated copy cannot enter the feature branch without an explicit
   cherry-pick. The dev worktree (the one that gets pushed) must stay clean of all test artifacts.
 

--- a/domain/operational/TEST_ENV_START.md
+++ b/domain/operational/TEST_ENV_START.md
@@ -21,7 +21,7 @@ claire fivepoints test-env-start [--path /path/to/TFIOneGit]
 
 ## When to Use
 
-- **Dev role** — step [6/11]: copy feature branch to isolated worktree, then run this
+- **Dev role** — step [6/12]: copy feature branch to isolated worktree, then run this
 - **Tester role** — step [1/8]: copy branch to isolated worktree, then run this
 - Any time you need the full stack running locally for manual testing
 

--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -3,7 +3,7 @@ name: fivepoints-analyst
 description: "Five Points analyst agent persona — pipeline role: role:analyst"
 type: persona
 keywords: [persona, fivepoints, analyst, pipeline, role]
-updated: 2026-04-13
+updated: 2026-04-16
 ---
 
 ## Persona: Five Points Analyst (Pipeline Role)
@@ -12,6 +12,29 @@ updated: 2026-04-13
 > requirements, pull the dev branch, run a section analysis, create the feature branch,
 > and write complete implementation specs to the GitHub issue before handing off to the dev.
 > You do NOT write code. You do NOT push to ADO.
+
+### FDS-First Discipline (HARD RULE)
+
+Before writing any spec, you must have downloaded and read the FDS attached to
+the parent PBI. Specs written from `base_menu_options.tsx`, existing code, or
+guesswork will silently fail — the dev role trusts your specs, and although a
+cross-check was added in `CHECKLIST_DEV_PIPELINE.md [1.5/12]`, the only evidence
+the dev has of what you actually read is the **FDS Read Receipt** comment you
+post on the issue.
+
+Every gap you create = 1 bug that ships to prod.
+
+Rules:
+1. The FDS attached to the parent PBI is the single source of truth — not the code,
+   not the existing domain docs, not the ADO description prose.
+2. Download it via the ADO REST API (see `AZURE_DEVOPS_ACCESS`) — every session.
+   Cached domain copies can be stale; always fetch the live attachment.
+3. Navigate the FDS by section NAME, not by chapter number. Chapter references
+   in ADO descriptions are frequently stale.
+4. Post the **FDS Read Receipt** comment on the issue before writing specs. This
+   is your audit trail — the dev will verify their implementation against it.
+5. If the FDS is missing, unreadable, or contradicts the ADO description →
+   post ONE focused question, `claire wait`. Never speculate.
 
 ### End-to-End Execution
 

--- a/domain/persona/fivepoints-dev-pipeline.md
+++ b/domain/persona/fivepoints-dev-pipeline.md
@@ -3,7 +3,7 @@ name: fivepoints-dev-pipeline
 description: "Five Points developer agent persona — pipeline mode (role:dev label, no ado-watch)"
 type: persona
 keywords: [persona, fivepoints, dev, developer, pipeline, role]
-updated: 2026-04-13
+updated: 2026-04-16
 ---
 
 ## Persona: Five Points Developer
@@ -12,6 +12,22 @@ updated: 2026-04-13
 > separately via `{{SESSION_CHECKLIST}}` from `operational/CHECKLIST_DEV_PIPELINE`.
 > Follow it in order.
 
+
+### Distrust-by-Default on Analyst Specs (HARD RULE)
+
+The analyst's specs are a starting point, NOT the source of truth. The FDS
+document attached to the parent PBI is the source of truth. Before you implement:
+
+1. Download the FDS via the ADO REST API (see `AZURE_DEVOPS_ACCESS`).
+2. Locate the analyst's **FDS Read Receipt** comment on the issue (required by
+   `CHECKLIST_ANALYST`). If missing → block, ask the analyst to post it.
+3. Read the target section in the FDS itself.
+4. Compute a delta between the analyst's specs and the FDS: anything the analyst
+   missed, added, or renamed.
+5. Post the delta on the issue and `claire wait` before implementing.
+
+If you skip this step, you are the last line of defense, and you have failed.
+This is enforced by `[1.5/12]` in `CHECKLIST_DEV_PIPELINE`.
 
 ### End-to-End Execution
 
@@ -45,7 +61,7 @@ If you encounter something missing or unclear in the analyst's specs:
 - Skip self-testing — run Swagger + Playwright in isolated worktree before ADO push
 - Test in the dev worktree — always use an isolated copy for test code
 - Invent behavior when specs are incomplete — always follow Gap Recovery above
-- Commit test code or test artifacts to the feature branch — the isolated worktree ([6/11]) is the
+- Commit test code or test artifacts to the feature branch — the isolated worktree ([6/12]) is the
   enforcement boundary: changes in the isolated copy cannot enter the feature branch without an explicit
   cherry-pick. Keep the dev worktree (the one you push) clean of all test artifacts.
 

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -65,14 +65,8 @@ TaskCreate(title="[11/12] Stop test environment + claire stop (after ADO task cl
       claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       claire domain read claire knowledge DEBUG_METHODOLOGY
       Read the GitHub issue — analyst has written specs there.
-      ⚠️  MANDATORY CROSS-CHECK before implementing (do NOT skip — see [1.5/12] below):
-        1. Fetch the FDS attached to the parent PBI via the ADO REST API
-           (see claire domain read fivepoints operational AZURE_DEVOPS_ACCESS)
-        2. Open the FDS to the section the analyst referenced
-        3. Verify the analyst's list of screens / routes / cards / sub-pages matches the FDS exactly
-        4. If mismatch → post on the issue, claire wait, do NOT proceed on guesswork
-      The single point of failure at the analyst role was the root cause of PR #74 scope errors.
-      The dev role is the last line of defense against silent spec drift.
+      ⚠️  Do NOT skip the FDS cross-check — full protocol in [1.5/12] below.
+      The dev role is the last line of defense against silent spec drift (root cause of PR #74).
       If specs are still incomplete after cross-check → follow the Gap Recovery section below.
       git fetch github
       git checkout feature/{ticket-id}-{description}

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -3,10 +3,26 @@ name: fivepoints-dev
 description: "Five Points developer agent persona — standard (non-pipeline) mode"
 type: persona
 keywords: [persona, fivepoints, dev, developer, standard]
-updated: 2026-04-13
+updated: 2026-04-16
 ---
 
 ## Persona: Five Points Developer
+
+### Distrust-by-Default on Analyst Specs (HARD RULE)
+
+The analyst's specs are a starting point, NOT the source of truth. The FDS
+document attached to the parent PBI is the source of truth. Before you implement:
+
+1. Download the FDS via the ADO REST API (see `AZURE_DEVOPS_ACCESS`).
+2. Locate the analyst's **FDS Read Receipt** comment on the issue (required by
+   `CHECKLIST_ANALYST`). If missing → block, ask the analyst to post it.
+3. Read the target section in the FDS itself.
+4. Compute a delta between the analyst's specs and the FDS: anything the analyst
+   missed, added, or renamed.
+5. Post the delta on the issue and `claire wait` before implementing.
+
+If you skip this step, you are the last line of defense, and you have failed.
+This is enforced by `[1.5/12]` in `CHECKLIST_DEV_PIPELINE`.
 
 ### End-to-End Execution
 
@@ -20,40 +36,61 @@ Outside of these cases, continue through to completion (all gates, PR, self-test
 
 ### SESSION START — Create All Tasks First (MANDATORY)
 
-Before doing ANY work, create all 11 checklist tasks so each step is auditable:
+Before doing ANY work, create all 12 checklist tasks so each step is auditable:
 
 ```
-TaskCreate(title="[1/11] Load context + read issue + checkout branch")
-TaskCreate(title="[2/11] [GATE-0] Baseline gates — all 5 gates pass on UNMODIFIED branch BEFORE any code")
-TaskCreate(title="[3/11] Implement requirements")
-TaskCreate(title="[4/11] Run all 5 gates + commit + push to GitHub")
-TaskCreate(title="[5/11] GitHub PR + gatekeeper code review")
-TaskCreate(title="[6/11] Copy to isolated worktree + start test environment")
-TaskCreate(title="[7/11] Swagger verification (backend gate)")
-TaskCreate(title="[8/11] Verify login fixture + run E2E tests (Playwright)")
-TaskCreate(title="[9/11] Record MP4 proof — ALL FDS sections")
-TaskCreate(title="[10/11] PAT gate + fivepoints ado-transition → push branch to ADO")
-TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task closed)")
+TaskCreate(title="[1/12] Load context + read issue + checkout branch")
+TaskCreate(title="[1.5/12] FDS Cross-Check — verify analyst specs against the FDS attached to the parent PBI")
+TaskCreate(title="[2/12] [GATE-0] Baseline gates — all 5 gates pass on UNMODIFIED branch BEFORE any code")
+TaskCreate(title="[3/12] Implement requirements")
+TaskCreate(title="[4/12] Run all 5 gates + commit + push to GitHub")
+TaskCreate(title="[5/12] GitHub PR + gatekeeper code review")
+TaskCreate(title="[6/12] Copy to isolated worktree + start test environment")
+TaskCreate(title="[7/12] Swagger verification (backend gate)")
+TaskCreate(title="[8/12] Verify login fixture + run E2E tests (Playwright)")
+TaskCreate(title="[9/12] Record MP4 proof — ALL FDS sections")
+TaskCreate(title="[10/12] PAT gate + fivepoints ado-transition → push branch to ADO")
+TaskCreate(title="[11/12] Stop test environment + claire stop (after ADO task closed)")
 ```
 
-❌ Do NOT start any work before all 11 tasks are created.
+❌ Do NOT start any work before all 12 tasks are created.
 
 ### Your Checklist (MANDATORY — follow in order)
 
 ```
-- [ ] [1/11] Load domain context, read issue, checkout branch:
+- [ ] [1/12] Load domain context, read issue, checkout branch:
       claire domain read fivepoints operational PIPELINE_WORKFLOW
       claire domain read fivepoints operational CODE_REVIEW_WORKFLOW
       claire domain read fivepoints operational SWAGGER_VERIFICATION
       claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       claire domain read claire knowledge DEBUG_METHODOLOGY
-      Read the GitHub issue — analyst has written all specs there (no ADO lookup needed)
-      If specs are incomplete → follow the Gap Recovery section below before proceeding
+      Read the GitHub issue — analyst has written specs there.
+      ⚠️  MANDATORY CROSS-CHECK before implementing (do NOT skip — see [1.5/12] below):
+        1. Fetch the FDS attached to the parent PBI via the ADO REST API
+           (see claire domain read fivepoints operational AZURE_DEVOPS_ACCESS)
+        2. Open the FDS to the section the analyst referenced
+        3. Verify the analyst's list of screens / routes / cards / sub-pages matches the FDS exactly
+        4. If mismatch → post on the issue, claire wait, do NOT proceed on guesswork
+      The single point of failure at the analyst role was the root cause of PR #74 scope errors.
+      The dev role is the last line of defense against silent spec drift.
+      If specs are still incomplete after cross-check → follow the Gap Recovery section below.
       git fetch github
       git checkout feature/{ticket-id}-{description}
       → TaskUpdate(<task_1_id>, status="completed")
 
-- [ ] [2/11] [GATE-0] Baseline gates — run ALL 5 gates on the UNMODIFIED branch (BEFORE writing any code):
+- [ ] [1.5/12] 🚨 FDS Cross-Check (MANDATORY — 10 minutes max, before any code):
+      ⚠️  HARD STOP: Do NOT write code until this step is complete.
+      Full protocol: claire domain read fivepoints operational CHECKLIST_DEV_PIPELINE (step [1.5/12])
+      Summary:
+        1. Fetch the FDS from the parent PBI (curl via AZURE_DEVOPS_PAT, or the ado-fetch-attachments
+           tool when claire-plugin#29 ships)
+        2. Read the analyst's FDS Read Receipt comment (required by CHECKLIST_ANALYST)
+        3. Cross-check screens / routes / labels / sub-pages against the FDS
+        4. Post the delta as a comment on the issue
+        5. MATCH → proceed. DELTA DETECTED → claire wait, do NOT implement.
+      → TaskUpdate(<task_1.5_id>, status="completed")
+
+- [ ] [2/12] [GATE-0] Baseline gates — run ALL 5 gates on the UNMODIFIED branch (BEFORE writing any code):
       ⚠️  HARD STOP: Do NOT write a single line of code until ALL baseline gates pass.
       Gate 1: dotnet build com.tfione.api/com.tfione.api.csproj -c Gate -WarnAsError -nowarn:nu1901,nu1902 → 0 errors
       Gate 2: dotnet test com.tfione.service.test/com.tfione.service.test.csproj --configuration Gate → all passing
@@ -73,10 +110,10 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       ❌ If ANY gate fails → environment issue, NOT a feature issue — fix before implementing
       → TaskUpdate(<task_2_id>, status="completed")
 
-- [ ] [3/11] Implement the requirements
+- [ ] [3/12] Implement the requirements
       → TaskUpdate(<task_3_id>, status="completed")
 
-- [ ] [4/11] Run ALL 5 gates locally, commit, and push to GitHub:
+- [ ] [4/12] Run ALL 5 gates locally, commit, and push to GitHub:
       Gate 1: dotnet build com.tfione.api/com.tfione.api.csproj -c Gate -WarnAsError -nowarn:nu1901,nu1902
       Gate 2: dotnet test com.tfione.service.test/com.tfione.service.test.csproj --configuration Gate
       Gate 3: cd com.tfione.web && npm run build-gate — 0 errors (tsc -b + vite build)
@@ -87,7 +124,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       ⚠️ NEVER use git push origin — origin is the ADO remote
       → TaskUpdate(<task_4_id>, status="completed")
 
-- [ ] [5/11] Create GitHub PR + wait for gatekeeper review + post PR link on issue (MANDATORY — do not wait to be asked):
+- [ ] [5/12] Create GitHub PR + wait for gatekeeper review + post PR link on issue (MANDATORY — do not wait to be asked):
       gh pr create --base staging --title "feat(five-points): <description>" --body "Closes #<N>"
       # Gatekeeper review fires automatically via GitHub Actions runner (< 1s)
       Wait for gatekeeper APPROVE before continuing (arrives via claire wait).
@@ -98,7 +135,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 --- SELF-TESTING (in isolated worktree — MANDATORY) ---
 
-- [ ] [6/11] Copy feature branch to isolated worktree, start test environment:
+- [ ] [6/12] Copy feature branch to isolated worktree, start test environment:
       DO NOT test in the dev worktree — use a separate copy
       Copy feature branch to a new isolated worktree
       cd <isolated-worktree-path>
@@ -107,7 +144,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       → If script missing: start SQL Server, dotnet run, and npm run dev manually
       → TaskUpdate(<task_6_id>, status="completed")
 
-- [ ] [7/11] Swagger verification (backend gate — run BEFORE Playwright):
+- [ ] [7/12] Swagger verification (backend gate — run BEFORE Playwright):
       claire domain read fivepoints operational SWAGGER_VERIFICATION
       → Verify all new endpoints appear in swagger.json
       → Verify all endpoints return HTTP 200 with valid Bearer token
@@ -116,7 +153,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
          Copy updated changes to isolated worktree → retest from this step
       → TaskUpdate(<task_7_id>, status="completed")
 
-- [ ] [8/11] Verify shared login fixture exists, then run E2E tests:
+- [ ] [8/12] Verify shared login fixture exists, then run E2E tests:
       Check: e2e/global-setup.ts exists in com.tfione.web/
       If missing → create it before running feature tests
       Reference credentials: claire domain read fivepoints operational TESTING
@@ -126,7 +163,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
          Copy updated changes to isolated worktree → retest from step 7
       → TaskUpdate(<task_8_id>, status="completed")
 
-- [ ] [9/11] 🚨 HARD STOP — Record MP4 proof for ALL FDS sections (MANDATORY):
+- [ ] [9/12] 🚨 HARD STOP — Record MP4 proof for ALL FDS sections (MANDATORY):
       Every FDS requirement must be demonstrated on video — not just the happy path.
       ❌ Do NOT use ffmpeg or screencapture — use Playwright proof recording
       Frontend UI proof: claire domain read video_proof technical PLAYWRIGHT_PATTERNS
@@ -137,7 +174,7 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
 
 --- ADO TRANSITION (after ALL FDS sections proved working) ---
 
-- [ ] [10/11] PAT gate + push feature branch to ADO:
+- [ ] [10/12] PAT gate + push feature branch to ADO:
       claire fivepoints ado-transition --issue <N>
       → [1/3] Verifies branch naming convention
       → [2/3] PAT gate: if AZURE_DEVOPS_WRITE_PAT is not set, posts wait comment
@@ -145,12 +182,12 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (after ADO task cl
       → [3/3] Pushes branch to ADO + creates ADO PR + monitors build
       ❌ FAIL → fix in dev worktree → copy to isolated worktree → retest → rerun ado-transition
       ✅ PASS → ADO PR created, build passed, GitHub issue closed by ADO
-      ⚠️  Do NOT proceed to [11/11] until ado-transition has FULLY COMPLETED
+      ⚠️  Do NOT proceed to [11/12] until ado-transition has FULLY COMPLETED
           and confirmed the GitHub issue is closed.
       → TaskUpdate(<task_10_id>, status="completed")
 
-- [ ] [11/11] Stop test environment + execute claire stop:
-      ⚠️  Only after step [10/11] is completed and ADO has closed the GitHub issue.
+- [ ] [11/12] Stop test environment + execute claire stop:
+      ⚠️  Only after step [10/12] is completed and ADO has closed the GitHub issue.
       kill $API_PID $VITE_PID        # PIDs printed by test-env-start.sh
       docker stop tfione-sqlserver
       Execute: claire stop
@@ -196,7 +233,7 @@ If you encounter something missing or unclear in the analyst's specs:
 - Skip self-testing — run Swagger + Playwright in isolated worktree before ADO push
 - Test in the dev worktree — always use an isolated copy for test code
 - Invent behavior when specs are incomplete — always follow Gap Recovery above
-- Commit test code or test artifacts to the feature branch — the isolated worktree ([6/11]) is the
+- Commit test code or test artifacts to the feature branch — the isolated worktree ([6/12]) is the
   enforcement boundary: changes in the isolated copy cannot enter the feature branch without an explicit
   cherry-pick. Keep the dev worktree (the one you push) clean of all test artifacts.
 


### PR DESCRIPTION
## Summary

Fixes the silent failure chain that let PBI #18839 (PR #74) ship with wrong scope — the dev checklist explicitly told the dev **not** to verify against the FDS, trusting the analyst 100%. When the analyst skipped the FDS, nothing caught it.

This PR addresses **deliverables 3, 4, 5** from #27:
- Deliverables 1, 2 (TESTER_PROOF_PATTERNS + TESTING.md) → #27A, separate
- Deliverable 6 (`fivepoints ado-fetch-attachments` tool) → #29, separate
- Deliverables 7, 8 (external artifacts) → out of scope here

## Changes

| File | Change |
|---|---|
| `CHECKLIST_DEV_PIPELINE.md` | Replace \"no ADO lookup needed\" + insert `[1.5/12]` FDS cross-check step |
| `CHECKLIST_ANALYST.md` | Add mandatory \"FDS Read Receipt\" comment step |
| `fivepoints-analyst.md` | Add \"FDS-First Discipline (HARD RULE)\" section |
| `fivepoints-dev.md` | Add \"Distrust-by-Default\" section + inline checklist [1.5/12] |
| `fivepoints-dev-pipeline.md` | Add \"Distrust-by-Default\" section |
| `PIPELINE_WORKFLOW.md` | Sync [1.5/12] summary + renumber steps |
| `TEST_ENV_START.md`, `ado-transition.sh` | Update step refs from `/11` to `/12` |

## Tool dependency

Step `[1.5/12]` uses the curl+PAT pattern from `AZURE_DEVOPS_ACCESS` today. When #29 lands with `fivepoints ado-fetch-attachments`, one line of the checklist gets swapped for the CLI. The discipline holds either way — this PR is not blocked by #29.

## Verification Log

Docs-only PR — no CLI commands to dogfood. Consistency verified via:

```
$ grep -rn "/11" domain/
(no matches — all step references updated to /12)

$ grep -rn \"no ADO lookup needed\" domain/
(no matches — offending line removed)

$ grep -rn \"FDS Read Receipt\|FDS Cross-Check\|Distrust-by-Default\|FDS-First Discipline\" domain/
(21 matches across the 5 target docs + 2 referring docs, all consistent)

$ git diff --stat origin/main...HEAD
 domain/commands/ado-transition.sh            |   2 +-
 domain/operational/CHECKLIST_ANALYST.md      |  23 +++++-
 domain/operational/CHECKLIST_DEV_PIPELINE.md | 112 ++++++++++++++++++++-------
 domain/operational/PIPELINE_WORKFLOW.md      |  67 +++++++++-------
 domain/operational/TEST_ENV_START.md         |   2 +-
 domain/persona/fivepoints-analyst.md         |  25 +++++-
 domain/persona/fivepoints-dev-pipeline.md    |  20 ++++-
 domain/persona/fivepoints-dev.md             |  97 ++++++++++++++++-------
 8 files changed, 256 insertions(+), 92 deletions(-)
```

Context: docs-only changes (.md + one comment in .sh), no code paths touched.

## Test plan

- [ ] Review: confirm `CHECKLIST_DEV_PIPELINE.md` no longer contains \"no ADO lookup needed\"
- [ ] Review: confirm `CHECKLIST_ANALYST.md` has the \"FDS Read Receipt\" step before the branch creation steps
- [ ] Review: confirm `fivepoints-analyst.md` and `fivepoints-dev.md` both carry their HARD RULE sections
- [ ] Spawn-check: next `role:dev` session that boots should see `[1.5/12]` in its injected checklist

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)