### PR TITLE
docs(persona): add Quick Reference table to fivepoints personas (closes #33)

### DIFF
--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -67,3 +67,19 @@ Read this before starting — it has scope guard rules and detailed patterns.
 - `claire analyze --branch <branch> --section <N> --fds-note "<spec>"` — Run section analysis
 - `claire fivepoints transition --role analyst --issue N` — Hand off to developer
 - `claire domain read fivepoints knowledge ANALYST_PERSONA` — Full persona details
+
+---
+
+## Quick Reference
+
+| Need | Command |
+|------|---------|
+| Full persona details | `claire domain read fivepoints knowledge ANALYST_PERSONA` |
+| FDS access (REST API) | `claire domain read fivepoints operational AZURE_DEVOPS_ACCESS` |
+| ADO attachment fetch | `claire domain read fivepoints operational ADO_ATTACHMENTS` |
+| Section analysis | `claire analyze --branch <branch> --section <N> --fds-note "<spec>"` |
+| Face Sheet section patterns | `claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS` |
+| Hand off to developer | `claire fivepoints transition --role analyst --issue <N>` |
+| Search domain knowledge | `claire domain search <keyword>` |
+| Read a specific domain doc | `claire domain read fivepoints <category> <name>` |
+| Wait for response | `Bash(command: "claire wait --issue <N>", run_in_background: true)` |

--- a/domain/persona/fivepoints-dev-pipeline.md
+++ b/domain/persona/fivepoints-dev-pipeline.md
@@ -77,3 +77,31 @@ If you encounter something missing or unclear in the analyst's specs:
 - `flyway verify` — Verify migration files against base branch
 - `claire domain search <keyword>` — Search across all domains
 - `claire context <keyword>` — Search for relevant context
+
+---
+
+## Quick Reference
+
+| Need | Command |
+|------|---------|
+| Start local TFI One stack | `claire fivepoints test-env-start` |
+| Install pre-commit hooks | `claire fivepoints install-hooks` |
+| Run the 5 gates | `claire domain read fivepoints operational DEVELOPER_GATES` |
+| Verify Flyway migrations | `flyway verify` |
+| Create GitHub PR (gatekeeper review) | `gh pr create --base staging --title "<title>" --body "Closes #<N>"` |
+| One-shot PR activity wait | `claire fivepoints wait` |
+| PR status + build + votes | `claire fivepoints pr-status --pr <N>` |
+| List PR comment threads | `claire fivepoints pr-comments --pr <N>` |
+| Reply to a PR thread | `claire fivepoints reply --pr <N> --thread <T> --body "<msg>"` |
+| Approve a PR | `claire fivepoints reply --pr <N> --approve` |
+| Fetch build/pipeline log | `claire fivepoints build-log --pr <N>` |
+| Record dual validation proof | `claire fivepoints validation-proof` |
+| PAT-gated ADO push (dev → ADO) | `claire fivepoints ado-transition --issue <N>` |
+| Rebase without ForcePush perm | `claire fivepoints rebase-no-force` |
+| Swagger verification guide | `claire domain read fivepoints operational SWAGGER_VERIFICATION` |
+| FDS / ADO REST access | `claire domain read fivepoints operational AZURE_DEVOPS_ACCESS` |
+| Pipeline workflow overview | `claire domain read fivepoints operational PIPELINE_WORKFLOW` |
+| Dev pipeline checklist | `claire domain read fivepoints operational CHECKLIST_DEV_PIPELINE` |
+| Code review workflow | `claire domain read fivepoints operational CODE_REVIEW_WORKFLOW` |
+| Search domain knowledge | `claire domain search <keyword>` |
+| Read a specific domain doc | `claire domain read fivepoints <category> <name>` |

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -242,3 +242,35 @@ If you encounter something missing or unclear in the analyst's specs:
 - `flyway verify` — Verify migration files against base branch
 - `claire domain search <keyword>` — Search across all domains
 - `claire context <keyword>` — Search for relevant context
+
+---
+
+## Quick Reference
+
+| Need | Command |
+|------|---------|
+| Start local TFI One stack | `claire fivepoints test-env-start` |
+| Install pre-commit hooks | `claire fivepoints install-hooks` |
+| Run the 5 gates | `claire domain read fivepoints operational DEVELOPER_GATES` |
+| Verify Flyway migrations | `flyway verify` |
+| Continuous PR monitor (after PR) | `Bash(command: "claire fivepoints ado-watch --pr <N>", run_in_background: true)` |
+| One-shot PR activity wait | `claire fivepoints wait` |
+| PR status + build + votes | `claire fivepoints pr-status --pr <N>` |
+| List PR comment threads | `claire fivepoints pr-comments --pr <N>` |
+| Reply to a PR thread | `claire fivepoints reply --pr <N> --thread <T> --body "<msg>"` |
+| Approve a PR | `claire fivepoints reply --pr <N> --approve` |
+| Fetch build/pipeline log | `claire fivepoints build-log --pr <N>` |
+| Record dual validation proof | `claire fivepoints validation-proof` |
+| PAT-gated ADO push (dev → ADO) | `claire fivepoints ado-transition --issue <N>` |
+| Push + watch ADO PR to merge | `claire fivepoints ado-push --issue <N>` |
+| Rebase without ForcePush perm | `claire fivepoints rebase-no-force` |
+| Finish an existing PR end-to-end | `claire fivepoints land` |
+| Swagger verification guide | `claire domain read fivepoints operational SWAGGER_VERIFICATION` |
+| Frontend video proof recording | `claire domain read video_proof technical PLAYWRIGHT_PATTERNS` |
+| Backend/terminal video proof | `claire domain read video_proof technical BACKEND_RECORDING` |
+| Pipeline workflow overview | `claire domain read fivepoints operational PIPELINE_WORKFLOW` |
+| Code review workflow | `claire domain read fivepoints operational CODE_REVIEW_WORKFLOW` |
+| ADO → GitHub bridge (daemon) | `claire fivepoints bridge {start\|stop\|status\|logs}` |
+| ADO → GitHub issue creation (Gmail) | `claire fivepoints azure-issue-bridge` |
+| Search domain knowledge | `claire domain search <keyword>` |
+| Read a specific domain doc | `claire domain read fivepoints <category> <name>` |

--- a/domain/persona/fivepoints-tester.md
+++ b/domain/persona/fivepoints-tester.md
@@ -67,3 +67,25 @@ Outside of these cases, continue through to completion (Swagger, E2E, proof reco
 - `claire domain read video_proof technical PLAYWRIGHT_PATTERNS` — Frontend proof recording (MANDATORY)
 - `claire domain read video_proof technical BACKEND_RECORDING` — Terminal/API proof recording
 - `claire domain read` — Read FDS/requirements
+
+---
+
+## Quick Reference
+
+| Need | Command |
+|------|---------|
+| Start local TFI One stack | `claire fivepoints test-env-start` |
+| Swagger verification guide | `claire domain read fivepoints operational SWAGGER_VERIFICATION` |
+| Record dual validation proof | `claire fivepoints validation-proof` |
+| Frontend video proof (Playwright) | `claire domain read video_proof technical PLAYWRIGHT_PATTERNS` |
+| Backend/terminal video proof | `claire domain read video_proof technical BACKEND_RECORDING` |
+| Tester checklist | `claire domain read fivepoints operational CHECKLIST_TESTER` |
+| E2E testing patterns | `claire domain read fivepoints technical E2E_TESTING` |
+| Send back to dev (TEST fail only) | `claire fivepoints transition --role tester --next dev --issue <N>` |
+| Push to ADO + create PR (on pass) | `claire fivepoints ado-push --issue <N>` |
+| PR status + build + votes | `claire fivepoints pr-status --pr <N>` |
+| One-shot PR activity wait | `claire fivepoints wait` |
+| Fetch build/pipeline log | `claire fivepoints build-log --pr <N>` |
+| FDS / ADO REST access | `claire domain read fivepoints operational AZURE_DEVOPS_ACCESS` |
+| Search domain knowledge | `claire domain search <keyword>` |
+| Read a specific domain doc | `claire domain read fivepoints <category> <name>` |


### PR DESCRIPTION
## Summary

Adds a `## Quick Reference` Markdown table at the end of each fivepoints persona, matching the Claire persona format (see `CLAUDE.md`). Agents now have a scannable, role-appropriate entry point to the fivepoints command surface.

## What changed

- **`fivepoints-analyst.md`** — analyst commands (section analysis, FDS access via `AZURE_DEVOPS_ACCESS`, Face Sheet patterns, transition to dev)
- **`fivepoints-dev.md`** — full dev command surface: `ado-watch / ado-transition / ado-push / pr-status / pr-comments / reply / wait / build-log / validation-proof / land / rebase-no-force / test-env-start / install-hooks / bridge / azure-issue-bridge`, plus `flyway verify` and the relevant domain-doc pointers
- **`fivepoints-dev-pipeline.md`** — same surface as dev, pipeline-oriented (uses `ado-transition`, no `ado-watch`)
- **`fivepoints-tester.md`** — tester commands (`test-env-start`, Swagger verification, video proof recording, `transition --next dev`, `ado-push`)

Each row follows the Claire format: `\| Need \| Command \|` with short description + command.

## Acceptance criteria

- [x] Each fivepoints persona contains a Quick Reference section listing fivepoints commands
- [x] Each command has a one-line description of its usage
- [x] `claire domain read fivepoints ...` pointers are up-to-date
- [x] Format matches the Claire persona (Markdown table)
- [x] `claire verify-templates --full` passes (128/128 tests)

## Verification Log

\`\`\`
$ claire verify-templates --full
...
============================= 128 passed in 27.01s =============================
✓ All template tests passed
\`\`\`

Command list sourced from `claire fivepoints --help` (16 commands).

Closes #33