### PR TITLE
docs(checklists): apply ISSUE_REPO_ROUTING to analyst/dev/tester (closes #35)

### DIFF
--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -181,5 +181,16 @@ EOF
       ⚠️ This step is MANDATORY. The E2E test asserts a Tier [1-5] comment exists before transition.
 - [ ] Execute: claire fivepoints transition --role analyst --issue <N>
       ↳ Transition complete? → STOP HERE
+- [ ] Post-session retrospective — pick the correct target repo when filing improvement issues:
+      When `claire wait` returns the retrospective prompt, walk the 4-question decision flow:
+      `claire domain read claire knowledge ISSUE_REPO_ROUTING`
+      Always pass `--github-repo <owner/name>` explicitly to `claire issue create`.
+      The pre-flight warning fires if the flag disagrees with the cwd-detected repo —
+      heed it; cwd auto-detection has silently mis-routed plugin issues into core before.
+      Quick guide for analyst-side retrospectives:
+        • FDS handling, section detection, analyst persona, ADO attachment workflow,
+          fivepoints checklist content → `CLAIRE-Fivepoints/claire-plugin`
+        • TFI One application bugs (endpoints, UI, migrations) → `CLAIRE-Fivepoints/fivepoints`
+        • Claire core (bash/python architecture, generic personas, hooks) → `claire-labs/claire`
 - [ ] 🚨 Execute: claire stop   ← MANDATORY. Session ends here.
 ```

--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -207,8 +207,22 @@ EOF
           and confirmed the GitHub issue is closed.
       → TaskUpdate(<task_10_id>, status="completed")
 
-- [ ] [11/12] Stop test environment + execute claire stop:
+- [ ] [11/12] Post-session retrospective + stop test environment + execute claire stop:
       ⚠️  Only after step [10/12] is completed and ADO has closed the GitHub issue.
+
+      Retrospective — pick the correct target repo when filing improvement issues:
+      When `claire wait` returns the retrospective prompt, walk the 4-question decision flow:
+      `claire domain read claire knowledge ISSUE_REPO_ROUTING`
+      Always pass `--github-repo <owner/name>` explicitly to `claire issue create`.
+      The pre-flight warning fires if the flag disagrees with the cwd-detected repo —
+      heed it; cwd auto-detection has silently mis-routed plugin issues into core before.
+      Quick guide for dev-side retrospectives:
+        • Dev checklists, gates, FDS cross-check protocol, ADO transition, fivepoints commands
+          → `CLAIRE-Fivepoints/claire-plugin`
+        • TFI One application code (endpoints, migrations, web UI) → `CLAIRE-Fivepoints/fivepoints`
+        • Claire core (bash/python architecture, generic personas, hooks) → `claire-labs/claire`
+
+      Tear down + stop:
       kill $API_PID $VITE_PID        # PIDs printed by test-env-start.sh
       docker stop tfione-sqlserver
       Execute: claire stop

--- a/domain/operational/CHECKLIST_TESTER.md
+++ b/domain/operational/CHECKLIST_TESTER.md
@@ -119,7 +119,21 @@ TaskCreate(title="[8/8] Stop test environment + claire stop")
       - [ ] If the cause is transient (network/ADO outage): wait and retry [7/8]
       - [ ] Do NOT run `claire stop` until ado-push succeeds
 
-- [ ] [8/8] Stop test environment, then execute claire stop:
+- [ ] [8/8] Post-session retrospective + stop test environment + execute claire stop:
+      Retrospective — pick the correct target repo when filing improvement issues:
+      When `claire wait` returns the retrospective prompt, walk the 4-question decision flow:
+      `claire domain read claire knowledge ISSUE_REPO_ROUTING`
+      Always pass `--github-repo <owner/name>` explicitly to `claire issue create`.
+      The pre-flight warning fires if the flag disagrees with the cwd-detected repo —
+      heed it; cwd auto-detection has silently mis-routed plugin issues into core before.
+      Quick guide for tester-side retrospectives:
+        • Playwright patterns for TFI One, Swagger verification, tester checklist, proof recording
+          specific to TFI One → `CLAIRE-Fivepoints/claire-plugin`
+        • TFI One application bugs uncovered by tests (endpoints, UI, migrations)
+          → `CLAIRE-Fivepoints/fivepoints`
+        • Claire core (generic Playwright helpers, video proof engine, hooks) → `claire-labs/claire`
+
+      Tear down + stop:
       kill $API_PID $VITE_PID        # PIDs printed by test-env-start.sh
       docker stop tfione-sqlserver   # stop SQL Server container
       Execute: claire stop


### PR DESCRIPTION
## Summary

Follow-up to core PR `claire-labs/claire#3324` (merged as `#3333`). Adds a **post-session retrospective** step to each fivepoints pipeline checklist that:

1. Points at the new 4-question decision flow (`claire domain read claire knowledge ISSUE_REPO_ROUTING`).
2. Requires `--github-repo <owner/name>` to be passed explicitly to `claire issue create` — avoiding the silent cwd-detection mis-routing that produced `claire-labs/claire#3323` (re-filed correctly in this repo as `#27`).
3. Gives each role a short, concrete lookup table so retrospectives pick the right target repo without re-reading the full doc.

No hardcoded `--repo claire-labs/claire` defaults are introduced; none existed in these three files before this change.

## Files changed

- `domain/operational/CHECKLIST_ANALYST.md` — new retrospective bullet before final `claire stop`
- `domain/operational/CHECKLIST_DEV_PIPELINE.md` — retrospective folded into `[11/12]` alongside tear-down + `claire stop` (no step-count change)
- `domain/operational/CHECKLIST_TESTER.md` — retrospective folded into `[8/8]` alongside tear-down + `claire stop` (no step-count change)

## Acceptance criteria

- [x] All three checklists reference `ISSUE_REPO_ROUTING` in their retrospective section
- [x] No remaining hardcoded `--repo claire-labs/claire` defaults in those files
- [x] Core doc exists upstream: `claire-labs/claire/30_universe/domains/claire/knowledge/ISSUE_REPO_ROUTING.md` (verified via `gh api`, 5968 bytes)
- [ ] Runtime acceptance (next retrospective files to the correct plugin repo) — to be observed on the next real session; not exercisable in a docs-only PR

## Verification Log

Docs-only PR — no `.sh` / `.py` touched, no runtime behavior changes. Verification consists of the three diffs shown in the PR and the presence of the referenced upstream doc.

```text
$ git diff --stat HEAD^ HEAD
 domain/operational/CHECKLIST_ANALYST.md      | 11 +++++++++++
 domain/operational/CHECKLIST_DEV_PIPELINE.md | 16 +++++++++++++++-
 domain/operational/CHECKLIST_TESTER.md       | 16 +++++++++++++++-
 3 files changed, 41 insertions(+), 2 deletions(-)

$ gh api repos/claire-labs/claire/contents/30_universe/domains/claire/knowledge/ISSUE_REPO_ROUTING.md --jq '{name, path, size}'
{"name":"ISSUE_REPO_ROUTING.md","path":"30_universe/domains/claire/knowledge/ISSUE_REPO_ROUTING.md","size":5968}

$ grep -rn "claire-labs/claire" domain/operational/CHECKLIST_ANALYST.md domain/operational/CHECKLIST_DEV_PIPELINE.md domain/operational/CHECKLIST_TESTER.md
domain/operational/CHECKLIST_ANALYST.md:192:        • Claire core (bash/python architecture, generic personas, hooks) → `claire-labs/claire`
domain/operational/CHECKLIST_DEV_PIPELINE.md:222:        • Claire core (bash/python architecture, generic personas, hooks) → `claire-labs/claire`
domain/operational/CHECKLIST_TESTER.md:135:        • Claire core (generic Playwright helpers, video proof engine, hooks) → `claire-labs/claire`
```

The only remaining mentions of `claire-labs/claire` are in the "claire-core → file there" branches of the new lookup tables — those are not hardcoded defaults; they are one leaf of the 4-question decision flow.

## Cross-references

- Core PR: `claire-labs/claire#3324` → merged as `#3333`
- Prior mis-routing incident: `claire-labs/claire#3323` (closed, re-filed as `CLAIRE-Fivepoints/claire-plugin#27`)
- Closes: `#35`