### PR TITLE
feat(azure-issue-bridge): per-PBI logs for every skip decision (closes #44)

### DIFF
--- a/domain/scripts/azure_issue_bridge/bridge.py
+++ b/domain/scripts/azure_issue_bridge/bridge.py
@@ -355,7 +355,7 @@ def create_github_issue(work_item: WorkItem) -> str:
         raise RuntimeError(f"gh issue create failed: {result.stderr.strip()}")
 
     issue_url = result.stdout.strip()
-    logger.info("Created GitHub issue: %s", issue_url)
+    logger.info("Created GitHub issue for PBI #%s: %s", work_item.id, issue_url)
     return issue_url
 
 
@@ -462,7 +462,12 @@ def fetch_work_item_metadata(pbi_ids: list[str]) -> dict[str, dict[str, Any]]:
 
     try:
         data = json.loads(result.stdout)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "fetch_work_item_metadata: failed to JSON-decode ADO response (%s) — raw: %r",
+            exc,
+            result.stdout[:500],
+        )
         return {}
 
     metadata: dict[str, dict[str, Any]] = {}
@@ -658,7 +663,9 @@ def triage_emails(emails: list[Any]) -> list[TriageDecision]:
         #   - state not in _ACTIVE_STATES → unrecognised value → state_unknown
         if pbi_id not in metadata:
             logger.warning(
-                "PBI #%s — state unknown (metadata fetch failed), skipping", pbi_id
+                "PBI #%s — state unknown: metadata not returned by ADO API "
+                "(see prior warnings for fetch error), skipping",
+                pbi_id,
             )
             decisions.append(
                 TriageDecision(
@@ -673,8 +680,10 @@ def triage_emails(emails: list[Any]) -> list[TriageDecision]:
             ado_state: str = metadata[pbi_id].get("state") or ""
             if not ado_state:
                 logger.warning(
-                    "PBI #%s — state field empty (API returned no state), skipping",
+                    "PBI #%s — state field empty (state=%r, metadata=%s), skipping",
                     pbi_id,
+                    ado_state,
+                    metadata[pbi_id],
                 )
                 decisions.append(
                     TriageDecision(
@@ -714,6 +723,9 @@ def triage_emails(emails: list[Any]) -> list[TriageDecision]:
 
         # Rule 1a: skip parents whose children are also in this batch
         if not skipped and pbi_id in parents_with_children_in_batch:
+            logger.info(
+                "PBI #%s: skipped — parent of child(ren) in batch", pbi_id
+            )
             decisions.append(
                 TriageDecision(
                     pbi_id=pbi_id,

--- a/domain/scripts/azure_issue_bridge/tests/test_fetch_metadata.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_fetch_metadata.py
@@ -14,8 +14,11 @@ Tests cover:
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from azure_issue_bridge.bridge import fetch_work_item_metadata
 
@@ -82,6 +85,28 @@ class TestFetchWorkItemMetadata:
             result = fetch_work_item_metadata(["10856"])
 
         assert result == {}
+
+    def test_json_decode_error_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Bad JSON response → the failure must be logged (not swallowed silently)."""
+        with (
+            patch("subprocess.run", return_value=_mock_run("not-valid-json")),
+            patch("azure_issue_bridge.bridge._get_pat", return_value="fake"),
+            caplog.at_level(logging.WARNING, logger="azure_issue_bridge.bridge"),
+        ):
+            fetch_work_item_metadata(["10856"])
+
+        matches = [
+            r
+            for r in caplog.records
+            if "metadata" in r.getMessage().lower()
+            and ("json" in r.getMessage().lower() or "decode" in r.getMessage().lower())
+        ]
+        assert matches, (
+            "Expected a warning when JSON decoding fails. "
+            f"Got: {[r.getMessage() for r in caplog.records]}"
+        )
 
     def test_state_field_missing_returns_empty_string(self) -> None:
         """If System.State is absent from response, state defaults to ''."""

--- a/domain/scripts/azure_issue_bridge/tests/test_triage.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_triage.py
@@ -11,6 +11,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -696,3 +697,131 @@ class TestUnconditionalTypeGate:
         assert decisions[0].action == "skip"
         assert decisions[0].skip_reason == "non_task_type"
         mock_fetch_children.assert_not_called()
+
+
+class TestSkipDecisionLogging:
+    """Every skip decision must emit a per-PBI log line with enough detail to diagnose."""
+
+    def test_parent_has_children_logs_per_pbi(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Rule 1a skip must log per-PBI, not only the batch-level summary."""
+        emails = [
+            make_email("Product Backlog Item 10399 - parent", message_id="msg-001"),
+            make_email("Task 10852 - child", message_id="msg-002"),
+        ]
+        metadata = {
+            "10399": {
+                "type": "Product Backlog Item",
+                "parent_id": None,
+                "state": "To Do",
+            },
+            "10852": {"type": "Task", "parent_id": "10399", "state": "To Do"},
+        }
+
+        with (
+            patch(
+                "azure_issue_bridge.bridge.fetch_work_item_metadata",
+                return_value=metadata,
+            ),
+            patch(
+                "azure_issue_bridge.bridge.fetch_ado_child_ids",
+                return_value=[],
+            ),
+            patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ),
+            caplog.at_level(logging.INFO, logger="azure_issue_bridge.bridge"),
+        ):
+            decisions = triage_emails(emails)
+
+        by_id = {d.pbi_id: d for d in decisions}
+        assert by_id["10399"].skip_reason == "parent_has_children"
+
+        # Must be the PER-PBI line, not the batch-level summary at :634-638
+        # ("Parent work items skipped (children present in batch): #10399").
+        # The per-PBI line starts with "PBI #10399" and names it as a parent skip.
+        per_pbi_log = [
+            r
+            for r in caplog.records
+            if r.getMessage().startswith("PBI #10399")
+            and "parent" in r.getMessage().lower()
+        ]
+        assert per_pbi_log, (
+            "Expected a per-PBI log line starting with 'PBI #10399' for the parent-has-children skip. "
+            f"Got: {[r.getMessage() for r in caplog.records]}"
+        )
+
+    def test_state_unknown_log_explains_cause(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """state_unknown (pbi missing from metadata) must log why — not just the pbi_id."""
+        emails = [make_email("Task 10856 - missing from metadata")]
+
+        with (
+            patch(
+                "azure_issue_bridge.bridge.fetch_work_item_metadata",
+                return_value={},
+            ),
+            patch(
+                "azure_issue_bridge.bridge.fetch_ado_child_ids",
+                return_value=[],
+            ),
+            patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ),
+            caplog.at_level(logging.WARNING, logger="azure_issue_bridge.bridge"),
+        ):
+            triage_emails(emails)
+
+        # Must say more than "metadata fetch failed" — should point at the ADO API
+        # so ops can correlate with fetch_work_item_metadata warnings upstream.
+        matches = [
+            r
+            for r in caplog.records
+            if "10856" in r.getMessage() and "ADO API" in r.getMessage()
+        ]
+        assert matches, (
+            "Expected state_unknown log to reference the ADO API as the source of the miss. "
+            f"Got: {[r.getMessage() for r in caplog.records]}"
+        )
+
+    def test_state_empty_log_includes_value_and_metadata(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """state_empty must surface the actual returned value (empty) AND the metadata row."""
+        emails = [make_email("Task 10852 - empty state")]
+        metadata = {
+            "10852": {"type": "Task", "parent_id": "10399", "state": ""},
+        }
+
+        with (
+            patch(
+                "azure_issue_bridge.bridge.fetch_work_item_metadata",
+                return_value=metadata,
+            ),
+            patch(
+                "azure_issue_bridge.bridge.fetch_ado_child_ids",
+                return_value=[],
+            ),
+            patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ),
+            caplog.at_level(logging.WARNING, logger="azure_issue_bridge.bridge"),
+        ):
+            triage_emails(emails)
+
+        matches = [
+            r
+            for r in caplog.records
+            if "10852" in r.getMessage()
+            and "state=" in r.getMessage()
+            and "Task" in r.getMessage()
+        ]
+        assert matches, (
+            "Expected state_empty log to include state=<value> and metadata row. "
+            f"Got: {[r.getMessage() for r in caplog.records]}"
+        )


### PR DESCRIPTION
## Summary

Closes #44 — child of claire-labs/claire#3351 (audit of decision logging across all daemons).

Three log gaps fixed in `domain/scripts/azure_issue_bridge/bridge.py`:

1. **Parent-has-children per-PBI log** (`:716`) — the decision is now logged on its own line at the decision point, alongside the existing batch-level summary. Grepping for a single pbi_id now surfaces the reason.
2. **State-unknown / state-empty logs** (`:660-661`, `:675-677`) — now include the actual returned value (state-empty) and the full metadata row, or explicitly reference the ADO API miss (state-unknown). `JSONDecodeError` in `fetch_work_item_metadata` now emits a warning instead of returning silently, so the underlying fetch error is never hidden.
3. **Self-contained issue-create log** (`:358`) — now names the PBI id on the same line as the issue URL; no more cross-referencing timestamps with `"Processing PBI #%s"` to correlate.

## Tests

+4 log-assertion tests (3 in `test_triage.py::TestSkipDecisionLogging`, 1 in `test_fetch_metadata.py`). All 56 tests pass. Each new test was first confirmed to fail for the right reason before the implementation landed (TDD).

## Verification Log

**Command:** `python -m pytest domain/scripts/azure_issue_bridge/tests/ --no-cov -v`
**Context:** worktree `issue-44`, fresh checkout of this branch

```
domain/scripts/azure_issue_bridge/tests/test_concurrent_lock.py ..           [  3%]
domain/scripts/azure_issue_bridge/tests/test_fetch_metadata.py ..........    [ 21%]
domain/scripts/azure_issue_bridge/tests/test_triage.py ................................................ [100%]

============================== 56 passed in 0.05s ==============================
```

**Dogfood — mixed triage batch (all three log changes visible):**

```
$ PYTHONPATH=domain/scripts python -c "<triage_emails with 4 PBIs>"
INFO azure_issue_bridge.bridge: Parent work items skipped (children present in batch): #10399
INFO azure_issue_bridge.bridge: PBI #10399: skipped — parent of child(ren) in batch
WARNING azure_issue_bridge.bridge: PBI #10900 — state unknown: metadata not returned by ADO API (see prior warnings for fetch error), skipping
WARNING azure_issue_bridge.bridge: PBI #10901 — state field empty (state='', metadata={'type': 'Task', 'parent_id': None, 'state': ''}), skipping
```

**Dogfood — JSON decode warning + self-contained issue-create log:**

```
WARNING azure_issue_bridge.bridge: fetch_work_item_metadata: failed to JSON-decode ADO response (Expecting value: line 1 column 1 (char 0)) — raw: 'not-valid-json'
INFO azure_issue_bridge.bridge: Created GitHub issue for PBI #10852: https://github.com/o/r/issues/42
```

## Success criteria (from issue)

- [x] \`azure-issue-bridge.log\` has a per-PBI entry for every skip decision
- [x] State-unknown / state-empty logs include the value or underlying error
- [x] Issue creation log is self-contained (pbi_id + issue URL on one line)