### PR TITLE
fix(analyst): add worktree-binding pre-flight as step 0

### DIFF
--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -6,6 +6,42 @@ keywords: [fivepoints, analyst, pipeline, checklist, role]
 updated: 2026-04-19
 ---
 
+
+> ## 🎯 Work repo — `CLAIRE-Fivepoints/fivepoints`
+>
+> The analyst picks up issues from **`CLAIRE-Fivepoints/fivepoints`** — that is the
+> one repo where every analyst-facing issue lives and where worktrees are created
+> (`~/projects/fivepoints/.claire/worktrees/issue-<N>-…/`). The plugin repo
+> (`CLAIRE-Fivepoints/claire-plugin`) holds these persona/checklist files but is
+> **not** where analyst work happens.
+>
+> ### ⚡ Pre-flight — Verify worktree binding (BEFORE anything else)
+>
+> Run this **before** any `gh`, `claire wait`, `claire context`, or file read.
+> `gh` auto-detects the repo from `git remote`, so a mis-bound worktree silently
+> routes every command to the wrong repo (see plugin #47, claire #3431).
+>
+> ```bash
+> expected="CLAIRE-Fivepoints/fivepoints"
+> actual=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+)(\.git)?$#\1#' | sed 's/\.git$//')
+> [[ "$actual" == "$expected" ]] || {
+>   echo "❌ BLOCKER: worktree remote is '$actual', expected '$expected'"
+>   echo "   Do NOT run gh, do NOT read issues, do NOT write code."
+>   exit 1
+> }
+> ```
+>
+> **On mismatch — HARD STOP.** Post a blocker on the origin issue using an
+> explicit `--repo` flag (never rely on auto-detection), then `claire wait`:
+>
+> ```bash
+> gh issue comment <N> --repo CLAIRE-Fivepoints/fivepoints \
+>   --body "🚨 Worktree remote mismatch — refusing to proceed. Actual origin: $actual"
+> claire wait --issue <N>
+> ```
+>
+> Do not resume work until the spawn is fixed and respawned.
+
 ## Your Checklist (MANDATORY — follow in order)
 
 ```

--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -6,6 +6,42 @@ keywords: [persona, fivepoints, analyst, pipeline, role]
 updated: 2026-04-19
 ---
 
+
+> ## 🎯 Work repo — `CLAIRE-Fivepoints/fivepoints`
+>
+> The analyst picks up issues from **`CLAIRE-Fivepoints/fivepoints`** — that is the
+> one repo where every analyst-facing issue lives and where worktrees are created
+> (`~/projects/fivepoints/.claire/worktrees/issue-<N>-…/`). The plugin repo
+> (`CLAIRE-Fivepoints/claire-plugin`) holds these persona/checklist files but is
+> **not** where analyst work happens.
+>
+> ### ⚡ Pre-flight — Verify worktree binding (BEFORE anything else)
+>
+> Run this **before** any `gh`, `claire wait`, `claire context`, or file read.
+> `gh` auto-detects the repo from `git remote`, so a mis-bound worktree silently
+> routes every command to the wrong repo (see plugin #47, claire #3431).
+>
+> ```bash
+> expected="CLAIRE-Fivepoints/fivepoints"
+> actual=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+)(\.git)?$#\1#' | sed 's/\.git$//')
+> [[ "$actual" == "$expected" ]] || {
+>   echo "❌ BLOCKER: worktree remote is '$actual', expected '$expected'"
+>   echo "   Do NOT run gh, do NOT read issues, do NOT write code."
+>   exit 1
+> }
+> ```
+>
+> **On mismatch — HARD STOP.** Post a blocker on the origin issue using an
+> explicit `--repo` flag (never rely on auto-detection), then `claire wait`:
+>
+> ```bash
+> gh issue comment <N> --repo CLAIRE-Fivepoints/fivepoints \
+>   --body "🚨 Worktree remote mismatch — refusing to proceed. Actual origin: $actual"
+> claire wait --issue <N>
+> ```
+>
+> Do not resume work until the spawn is fixed and respawned.
+
 ## Persona: Five Points Analyst (Pipeline Role)
 
 > **Pipeline role: `role:analyst`** — You are the analyst. Your job is to read the


### PR DESCRIPTION
Closes #47

## Summary

Adds a prominent **Work repo** header + worktree-binding pre-flight check at the top of the analyst persona and checklist. The block:

1. Declares `CLAIRE-Fivepoints/fivepoints` as the one repo where analyst-facing issues live
2. Clarifies the plugin repo (`CLAIRE-Fivepoints/claire-plugin`) only holds these persona/checklist files — analyst work does not happen here
3. Provides a bash snippet that HARD STOPs the agent if the worktree remote doesn't match the expected repo
4. Explains how to post a blocker with an explicit `--repo` flag (never rely on `gh` auto-detection)

## Why

`gh` auto-detects the repo from `git remote`. A mis-bound worktree silently routes every command to the wrong repo — the exact failure mode described in issue #47 and claire #3431. Personas should never trust the environment without verifying.

## Scope

**Analyst only** (per owner direction in issue). Dev + tester deferred.

## Files changed

- `domain/persona/fivepoints-analyst.md` — block prepended before "## Persona: Five Points Analyst"
- `domain/operational/CHECKLIST_ANALYST.md` — block prepended before "## Your Checklist"

## Validation

Dogfooded on this very session: this PR was authored from a session where the spawn gave the agent a worktree bound to `claire-labs/claire` (not `CLAIRE-Fivepoints/claire-plugin`). The pre-flight check in the new block, when run against that broken worktree, correctly identifies the mismatch and would HARD STOP a future analyst before any damage. Evidence on the issue itself: the agent posted the analysis using an explicit `--repo CLAIRE-Fivepoints/claire-plugin` flag and refused to push/commit until a correctly-bound worktree was created.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)