### PR TITLE
fix(ado-fetch-attachments): parse shell-sourceable .env syntax (closes #50)

### DIFF
--- a/domain/scripts/ado_common.sh
+++ b/domain/scripts/ado_common.sh
@@ -61,6 +61,26 @@ _ado_client_config_get() {
     yq eval "${yq_path} // \"\"" "$config" 2>/dev/null
 }
 
+# Read a KEY=VALUE pair from a shell-sourceable .env file.
+# Tolerates an optional `export ` prefix and strips matched surrounding
+# single/double quotes, matching what `source <file>` would produce.
+# Usage: _ado_env_get <file> <key>
+# Prints the value on stdout (empty if not found).
+_ado_env_get() {
+    local file="$1"
+    local key="$2"
+    [[ -f "$file" ]] || return 0
+    local line
+    line=$(grep -E "^(export[[:space:]]+)?${key}=" "$file" 2>/dev/null | head -1 || true)
+    [[ -z "$line" ]] && return 0
+    local value="${line#*=}"
+    # Strip matched surrounding single or double quotes
+    if [[ "$value" =~ ^\"(.*)\"$ ]] || [[ "$value" =~ ^\'(.*)\'$ ]]; then
+        value="${BASH_REMATCH[1]}"
+    fi
+    printf '%s\n' "$value"
+}
+
 # Initialize Azure DevOps connection.
 # PAT priority:
 #   0. AZURE_DEVOPS_WRITE_PAT env var (write access, for ado-push)
@@ -93,7 +113,7 @@ ado_init() {
     # 0b. AZURE_DEVOPS_WRITE_PAT from ~/.config/claire/.env
     if [[ -z "$effective_pat" && -f "$config_env" ]]; then
         local write_pat
-        write_pat=$(grep -E '^AZURE_DEVOPS_WRITE_PAT=' "$config_env" 2>/dev/null | head -1 | cut -d= -f2- || true)
+        write_pat=$(_ado_env_get "$config_env" AZURE_DEVOPS_WRITE_PAT)
         if [[ -n "$write_pat" ]]; then
             effective_pat="$write_pat"
             export AZURE_DEVOPS_WRITE_PAT="$write_pat"
@@ -117,7 +137,7 @@ ado_init() {
     # 3. ~/.config/claire/.env (AZURE_DEVOPS_DEV_PAT, then AZURE_DEVOPS_PAT)
     if [[ -z "$effective_pat" && -f "$config_env" ]]; then
         local dev_pat
-        dev_pat=$(grep -E '^AZURE_DEVOPS_DEV_PAT=' "$config_env" 2>/dev/null | head -1 | cut -d= -f2-)
+        dev_pat=$(_ado_env_get "$config_env" AZURE_DEVOPS_DEV_PAT)
         if [[ -n "$dev_pat" ]]; then
             effective_pat="$dev_pat"
             export AZURE_DEVOPS_DEV_PAT="$dev_pat"
@@ -130,7 +150,7 @@ ado_init() {
 
     if [[ -z "$effective_pat" && -f "$config_env" ]]; then
         local config_pat
-        config_pat=$(grep -E '^AZURE_DEVOPS_PAT=' "$config_env" 2>/dev/null | head -1 | cut -d= -f2-)
+        config_pat=$(_ado_env_get "$config_env" AZURE_DEVOPS_PAT)
         if [[ -n "$config_pat" ]]; then
             effective_pat="$config_pat"
             export AZURE_DEVOPS_PAT="$config_pat"

--- a/domain/scripts/ado_common.sh
+++ b/domain/scripts/ado_common.sh
@@ -74,7 +74,10 @@ _ado_env_get() {
     line=$(grep -E "^(export[[:space:]]+)?${key}=" "$file" 2>/dev/null | head -1 || true)
     [[ -z "$line" ]] && return 0
     local value="${line#*=}"
-    # Strip matched surrounding single or double quotes
+    # Trim leading/trailing whitespace, then strip matched surrounding quotes
+    # (mirrors _read_env_file in ado_client.py so both parsers share one contract).
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
     if [[ "$value" =~ ^\"(.*)\"$ ]] || [[ "$value" =~ ^\'(.*)\'$ ]]; then
         value="${BASH_REMATCH[1]}"
     fi

--- a/domain/scripts/ado_fetch_attachments/ado_client.py
+++ b/domain/scripts/ado_fetch_attachments/ado_client.py
@@ -41,6 +41,12 @@ class Attachment:
 
 
 def _read_env_file(path: Path = _ENV_FILE) -> dict[str, str]:
+    """Parse a `.env` file that may be shell-sourceable.
+
+    Handles the `export KEY=VALUE` prefix and surrounding single/double
+    quotes on the value, matching what `source ~/.config/claire/.env`
+    would produce.
+    """
     if not path.is_file():
         return {}
     result: dict[str, str] = {}
@@ -50,7 +56,13 @@ def _read_env_file(path: Path = _ENV_FILE) -> dict[str, str]:
             if not line or line.startswith("#") or "=" not in line:
                 continue
             key, _, value = line.partition("=")
-            result[key.strip()] = value.strip()
+            key = key.strip()
+            if key.startswith("export ") or key.startswith("export\t"):
+                key = key[len("export "):].strip()
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            result[key] = value
     except OSError as e:
         logger.warning("Could not read env file %s: %s", path, e)
     return result

--- a/domain/scripts/ado_fetch_attachments/cli.py
+++ b/domain/scripts/ado_fetch_attachments/cli.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 from .ado_client import (
+    _ENV_FILE,
     AdoConfig,
     download_attachment,
     fetch_work_item_relations,
@@ -209,8 +210,13 @@ def main(argv: list[str] | None = None) -> int:
     pat = resolve_pat()
     if not pat:
         print(
-            "ERROR: No Azure DevOps PAT found. "
-            "Set AZURE_DEVOPS_PAT or AZURE_DEVOPS_DEV_PAT.",
+            "ERROR: No Azure DevOps PAT found. Lookup order (first hit wins):\n"
+            "  1. AZURE_DEVOPS_WRITE_PAT (environment)\n"
+            "  2. AZURE_DEVOPS_DEV_PAT   (environment)\n"
+            "  3. AZURE_DEVOPS_PAT       (environment)\n"
+            f"  4. Same keys in {_ENV_FILE}\n"
+            "Set one of the environment variables or add the key to the "
+            ".env file (supports `export KEY=VALUE` and quoted values).",
             file=sys.stderr,
         )
         return 2

--- a/domain/scripts/ado_fetch_attachments/tests/test_ado_client.py
+++ b/domain/scripts/ado_fetch_attachments/tests/test_ado_client.py
@@ -59,6 +59,31 @@ class TestResolvePat:
         )
         assert resolve_pat(env={}, env_file=env_file) == "ok"
 
+    def test_env_file_handles_export_prefix(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("export AZURE_DEVOPS_PAT=shellform\n")
+        assert resolve_pat(env={}, env_file=env_file) == "shellform"
+
+    def test_env_file_handles_export_with_tabs(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("export\tAZURE_DEVOPS_PAT=tabform\n")
+        assert resolve_pat(env={}, env_file=env_file) == "tabform"
+
+    def test_env_file_strips_double_quotes(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text('AZURE_DEVOPS_PAT="quoted-value"\n')
+        assert resolve_pat(env={}, env_file=env_file) == "quoted-value"
+
+    def test_env_file_strips_single_quotes(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("AZURE_DEVOPS_PAT='quoted-value'\n")
+        assert resolve_pat(env={}, env_file=env_file) == "quoted-value"
+
+    def test_env_file_export_with_quotes(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text('export AZURE_DEVOPS_DEV_PAT="write-token"\n')
+        assert resolve_pat(env={}, env_file=env_file) == "write-token"
+
 
 class TestFilterAttachments:
     def test_keeps_only_attached_files(self):

--- a/domain/scripts/ado_fetch_attachments/tests/test_cli.py
+++ b/domain/scripts/ado_fetch_attachments/tests/test_cli.py
@@ -166,3 +166,24 @@ class TestCli:
             ]
         )
         assert rc == 2
+
+    def test_missing_pat_lists_lookup_paths(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(cli_module, "resolve_pat", lambda: None)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        cli_module.main(
+            [
+                "--pbi",
+                "1",
+                "--diff-only",
+                "--cache-dir",
+                str(cache_dir),
+                "--staging-dir",
+                str(tmp_path / "s"),
+            ]
+        )
+        err = capsys.readouterr().err
+        assert "AZURE_DEVOPS_WRITE_PAT" in err
+        assert "AZURE_DEVOPS_DEV_PAT" in err
+        assert "AZURE_DEVOPS_PAT" in err
+        assert ".config/claire/.env" in err


### PR DESCRIPTION
## Summary

Closes #50.

The command already had a `~/.config/claire/.env` fallback in `resolve_pat()`, but the parser was too strict: lines of the form `export AZURE_DEVOPS_PAT=<value>` (the canonical shell-sourceable form used in that file) were parsed with `key = "export AZURE_DEVOPS_PAT"` after `partition("=")`, so the lookup silently missed every key and the CLI failed with the misleading `"No Azure DevOps PAT found. Set AZURE_DEVOPS_PAT or AZURE_DEVOPS_DEV_PAT."`.

## Changes

- `ado_client.py::_read_env_file` — strip optional `export ` (or `export\t`) prefix from the key and strip matched surrounding single/double quotes from the value. Matches what `source ~/.config/claire/.env` would produce.
- `cli.py` — when no PAT is discoverable, print the full lookup order **and** the `.env` file path that was consulted, so the operator knows where to put the token.
- Tests: 5 new cases on `resolve_pat` (export prefix, tab separator, single + double quotes, export+quotes) + 1 new CLI test asserting the error message lists all lookup paths. All 38 tests pass.

## Out of scope

`domain/scripts/ado_common.sh` has the same class of bug (its `grep -E '^AZURE_DEVOPS_PAT='` patterns don't match `export AZURE_DEVOPS_PAT=...` either). Different surface (bash, other commands) — I kept this PR focused on `ado-fetch-attachments` and will file a follow-up issue after this merges.

## Verification Log

Command: `PYTHONPATH=domain/scripts python3 -m ado_fetch_attachments.cli --pbi 17113 --diff-only --cache-dir domain/knowledge`
Context: env vars `AZURE_DEVOPS_PAT`, `AZURE_DEVOPS_DEV_PAT`, `AZURE_DEVOPS_WRITE_PAT` all unset — PAT had to come from `~/.config/claire/.env`, which starts with `export AZURE_DEVOPS_PAT=...`.

```
[pbi] #17113 — FivePointsTechnology/TFIOne
[pbi] found 1 attachment(s)
[download] 4 - Client Management(1).docx → /Users/andreperez/TFIOneGit/.fds-cache/17113/4_-_Client_Management_1_.docx
[drift] cached fce51da058cb5f94acef0476294e0667 != fresh f636b255be9f7e3ab3760b7d2b5f312e
[sections] fresh=299 cached=299 added=2 removed=2
[images]   extracted=196
[diff-only] no file writes, no issue
```

Exit code `1` = drift detected (expected for this PBI). Before the fix, this command exited `2` with "No Azure DevOps PAT found" despite the PAT sitting in `~/.config/claire/.env`.

Improved error message (when no PAT is discoverable anywhere):

```
ERROR: No Azure DevOps PAT found. Lookup order (first hit wins):
  1. AZURE_DEVOPS_WRITE_PAT (environment)
  2. AZURE_DEVOPS_DEV_PAT   (environment)
  3. AZURE_DEVOPS_PAT       (environment)
  4. Same keys in /Users/andreperez/.config/claire/.env
Set one of the environment variables or add the key to the .env file (supports `export KEY=VALUE` and quoted values).
```

Test suite:

```
============================== 38 passed in 0.38s ==============================
```

## Test plan

- [x] `pytest domain/scripts/ado_fetch_attachments/tests/` — all 38 pass
- [x] Dogfooded with env vars cleared — command resolves PAT from `.env` and completes the drift diff against PBI #17113
- [x] Dogfooded the error path — no PAT anywhere → new error message prints the full lookup order