### PR TITLE
fix(persona): resolve analyst repo refs at runtime via $CLAIRE_WAIT_REPO

### DIFF
--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -8,6 +8,14 @@ updated: 2026-04-19
 
 ## Your Checklist (MANDATORY — follow in order)
 
+> **About `$CLAIRE_WAIT_REPO`:** every spawned session receives this env var
+> (set by `claire spawn` / `claire-plugin fivepoints azure-issue-bridge`) with
+> the authoritative target repo in `owner/name` form — e.g.
+> `CLAIRE-Fivepoints/fivepoints` for a production session, or
+> `claire-labs/fivepoints-test` for the staging pipeline. Commands below use
+> it verbatim (`--repo "$CLAIRE_WAIT_REPO"`) so they resolve to the correct
+> repo at runtime without any template substitution.
+
 ```
 - [ ] Load domain context:
       claire domain read fivepoints knowledge ANALYST_PERSONA
@@ -58,7 +66,7 @@ updated: 2026-04-19
         ✅ Enough detail to describe what the UI should show and what the API should return
         ✅ No contradictions between the ADO description and the current FDS
       If ANY of these are missing or unclear → post ONE focused question on the GitHub issue:
-        gh issue comment <N> --repo CLAIRE-Fivepoints/fivepoints \
+        gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
           --body "**Analyst needs clarification before proceeding:**\n\n<specific question>"
         claire wait --issue <N>
       ⚠️ HARD STOP: Do NOT create a branch or write specs until the request is clear.
@@ -126,7 +134,7 @@ EOF
       From the extracted `FDS_<NAME>.md` in staging (not a committed cache —
       it is regenerated every fetch), identify the section title + page range
       + its sha256 from the manifest. Post it as a comment on the GitHub issue:
-      gh issue comment <N> --repo claire-labs/fivepoints-test \
+      gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
         --body "**FDS Section:** <section title> (pages X-Y, sha256 \`<short>\`)"
       ⚠️ MANDATORY — E2E test checks for this comment before transition.
       ⚠️ The section title must match the one quoted in the Read Receipt — the
@@ -141,11 +149,11 @@ EOF
          have already created a branch (and possibly an associated PR) for this task.
          Reusing that work preserves context and avoids duplicate branches.
 
-      existing_branch=$(gh api repos/CLAIRE-Fivepoints/fivepoints-test/branches \
+      existing_branch=$(gh api "repos/$CLAIRE_WAIT_REPO/branches" \
         --paginate \
         --jq ".[] | select(.name | startswith(\"feature/{ticket-id}-\")) | .name" \
         | head -1)
-      existing_pr=$(gh pr list --repo CLAIRE-Fivepoints/fivepoints-test \
+      existing_pr=$(gh pr list --repo "$CLAIRE_WAIT_REPO" \
         --search "head:feature/{ticket-id}-" --state all \
         --json number,state,headRefName -q '.[0]')
 
@@ -163,10 +171,10 @@ EOF
         IF existing_pr is non-empty → MANDATORY: read prior context before re-analyzing:
           pr_number=$(echo "$existing_pr" | jq -r .number)
           pr_state=$(echo "$existing_pr" | jq -r .state)
-          gh pr view "$pr_number" --repo CLAIRE-Fivepoints/fivepoints-test --comments
-          gh pr diff "$pr_number" --repo CLAIRE-Fivepoints/fivepoints-test
+          gh pr view "$pr_number" --repo "$CLAIRE_WAIT_REPO" --comments
+          gh pr diff "$pr_number" --repo "$CLAIRE_WAIT_REPO"
           # Post on the GitHub issue so the user knows we are not re-analyzing from scratch:
-          gh issue comment <N> --repo claire-labs/fivepoints-test \
+          gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
             --body "Found existing PR #$pr_number (state: $pr_state) — reusing branch \`$existing_branch\` instead of creating new"
           ⚠️ You MUST read the PR comments and diff before writing any new specs.
              Re-analyzing from scratch destroys the previous analyst's context.
@@ -175,17 +183,17 @@ EOF
         git checkout -b feature/{ticket-id}-{description}
         git push -u github feature/{ticket-id}-{description}
         # Verify push succeeded:
-        gh api repos/CLAIRE-Fivepoints/fivepoints-test/branches/feature/{ticket-id}-{description} --jq '.name'
+        gh api "repos/$CLAIRE_WAIT_REPO/branches/feature/{ticket-id}-{description}" --jq '.name'
         branch_was_reused=no
 
-      ⚠️ Push to fivepoints-test (GitHub), NOT to ADO
+      ⚠️ Push to the GitHub mirror (`github` remote), NOT to ADO (`origin` remote)
       ⚠️ {ticket-id} = the ADO task ID directly assigned to you (from the GitHub issue title),
          NOT the parent PBI ID.
          Example: if issue says "Task #10901 (PBI #10847)", use 10901 — not 10847.
          ✅ feature/10901-description   ❌ feature/10847-description
 - [ ] Post branch name as comment on the GitHub issue (indicate new vs reused):
       branch_name=$(git rev-parse --abbrev-ref HEAD)
-      gh issue comment <N> --repo claire-labs/fivepoints-test \
+      gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
         --body "Branch: \`$branch_name\` (reused: $branch_was_reused)"
       ⚠️ MANDATORY — transition guard requires branch name in issue comments
       ⚠️ The "(reused: yes/no)" suffix tells downstream personas whether prior work exists

--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -82,6 +82,13 @@ Read this before starting — it has scope guard rules and detailed patterns.
 
 ## Your Checklist (MANDATORY — follow in order)
 
+> **About `$CLAIRE_WAIT_REPO`:** every spawned session receives this env var
+> (set by `claire spawn` / the azure-issue-bridge) with the authoritative
+> target repo in `owner/name` form — e.g. `CLAIRE-Fivepoints/fivepoints` for
+> a production session, or `claire-labs/fivepoints-test` for the staging
+> pipeline. Commands below use it verbatim (`--repo "$CLAIRE_WAIT_REPO"`) so
+> they resolve to the correct repo at runtime.
+
 ```
 - [ ] Load domain context:
       claire domain read fivepoints knowledge ANALYST_PERSONA
@@ -132,7 +139,7 @@ Read this before starting — it has scope guard rules and detailed patterns.
         ✅ Enough detail to describe what the UI should show and what the API should return
         ✅ No contradictions between the ADO description and the current FDS
       If ANY of these are missing or unclear → post ONE focused question on the GitHub issue:
-        gh issue comment <N> --repo CLAIRE-Fivepoints/fivepoints \
+        gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
           --body "**Analyst needs clarification before proceeding:**\n\n<specific question>"
         claire wait --issue <N>
       ⚠️ HARD STOP: Do NOT create a branch or write specs until the request is clear.
@@ -200,7 +207,7 @@ EOF
       From the extracted `FDS_<NAME>.md` in staging (not a committed cache —
       it is regenerated every fetch), identify the section title + page range
       + its sha256 from the manifest. Post it as a comment on the GitHub issue:
-      gh issue comment <N> --repo claire-labs/fivepoints-test \
+      gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
         --body "**FDS Section:** <section title> (pages X-Y, sha256 \`<short>\`)"
       ⚠️ MANDATORY — E2E test checks for this comment before transition.
       ⚠️ The section title must match the one quoted in the Read Receipt — the
@@ -215,11 +222,11 @@ EOF
          have already created a branch (and possibly an associated PR) for this task.
          Reusing that work preserves context and avoids duplicate branches.
 
-      existing_branch=$(gh api repos/CLAIRE-Fivepoints/fivepoints-test/branches \
+      existing_branch=$(gh api "repos/$CLAIRE_WAIT_REPO/branches" \
         --paginate \
         --jq ".[] | select(.name | startswith(\"feature/{ticket-id}-\")) | .name" \
         | head -1)
-      existing_pr=$(gh pr list --repo CLAIRE-Fivepoints/fivepoints-test \
+      existing_pr=$(gh pr list --repo "$CLAIRE_WAIT_REPO" \
         --search "head:feature/{ticket-id}-" --state all \
         --json number,state,headRefName -q '.[0]')
 
@@ -237,10 +244,10 @@ EOF
         IF existing_pr is non-empty → MANDATORY: read prior context before re-analyzing:
           pr_number=$(echo "$existing_pr" | jq -r .number)
           pr_state=$(echo "$existing_pr" | jq -r .state)
-          gh pr view "$pr_number" --repo CLAIRE-Fivepoints/fivepoints-test --comments
-          gh pr diff "$pr_number" --repo CLAIRE-Fivepoints/fivepoints-test
+          gh pr view "$pr_number" --repo "$CLAIRE_WAIT_REPO" --comments
+          gh pr diff "$pr_number" --repo "$CLAIRE_WAIT_REPO"
           # Post on the GitHub issue so the user knows we are not re-analyzing from scratch:
-          gh issue comment <N> --repo claire-labs/fivepoints-test \
+          gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
             --body "Found existing PR #$pr_number (state: $pr_state) — reusing branch \`$existing_branch\` instead of creating new"
           ⚠️ You MUST read the PR comments and diff before writing any new specs.
              Re-analyzing from scratch destroys the previous analyst's context.
@@ -249,17 +256,17 @@ EOF
         git checkout -b feature/{ticket-id}-{description}
         git push -u github feature/{ticket-id}-{description}
         # Verify push succeeded:
-        gh api repos/CLAIRE-Fivepoints/fivepoints-test/branches/feature/{ticket-id}-{description} --jq '.name'
+        gh api "repos/$CLAIRE_WAIT_REPO/branches/feature/{ticket-id}-{description}" --jq '.name'
         branch_was_reused=no
 
-      ⚠️ Push to fivepoints-test (GitHub), NOT to ADO
+      ⚠️ Push to the GitHub mirror (`github` remote), NOT to ADO (`origin` remote)
       ⚠️ {ticket-id} = the ADO task ID directly assigned to you (from the GitHub issue title),
          NOT the parent PBI ID.
          Example: if issue says "Task #10901 (PBI #10847)", use 10901 — not 10847.
          ✅ feature/10901-description   ❌ feature/10847-description
 - [ ] Post branch name as comment on the GitHub issue (indicate new vs reused):
       branch_name=$(git rev-parse --abbrev-ref HEAD)
-      gh issue comment <N> --repo claire-labs/fivepoints-test \
+      gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
         --body "Branch: \`$branch_name\` (reused: $branch_was_reused)"
       ⚠️ MANDATORY — transition guard requires branch name in issue comments
       ⚠️ The "(reused: yes/no)" suffix tells downstream personas whether prior work exists


### PR DESCRIPTION
## Summary

Closes #57.

Replaces every hardcoded `claire-labs/fivepoints-test` and `CLAIRE-Fivepoints/fivepoints-test` string in runnable `gh` / `gh api` commands with `"$CLAIRE_WAIT_REPO"` — the env var the spawn consumer already injects (`consumer.py:703`) with the authoritative target repo in `owner/name` form. Analyst sessions spawned against the real `CLAIRE-Fivepoints/fivepoints` repo now post comments, list branches, and view PRs against the correct repo instead of the legacy staging repo.

**Files touched** (plugin-only):
- `domain/persona/fivepoints-analyst.md` — 9 command occurrences updated + preamble added
- `domain/operational/CHECKLIST_ANALYST.md` — 7 command occurrences updated + preamble added

Also fixes a misleading narrative line (`Push to fivepoints-test (GitHub)` → `Push to the GitHub mirror (\`github\` remote)`) that was only accurate for staging sessions.

## Why not the `{{TARGET_REPO}}` placeholder the issue proposed

Traced the render path in `claire-labs/claire` (`10_systems/claire_py/template/generator.py`):

1. `render()` iterates `variables.items()` in insertion order and calls `.replace()` once per key.
2. `PERSONA_SECTION` is added **last** (intentionally, per the `#3291` comment at `generator.py:1278-1281`, so literal `{{SESSION_CHECKLIST}}` in persona docs isn't recursively expanded).
3. Any `{{FOO}}` token inside the persona body is inserted into the template *after* the iterator has already passed `FOO` — it stays literal.
4. Existing `{{REPO_NAME}}` returns the bare name (`fivepoints`) from `git remote get-url origin` split-tail — can't feed `gh --repo`.

Introducing `{{TARGET_REPO}}` properly therefore needs changes in **claire-labs/claire** (new variable + pre-substitute persona body). That's a separate PR in a separate repo.

Using `$CLAIRE_WAIT_REPO` instead:
- Plugin-only fix (no claire-core change required).
- Resolved by bash at command-run time, not by the template engine at spawn time — robust against spawn payload races.
- Matches the existing pattern in every other runtime script in this plugin (`ado-push.sh`, `land.sh`, `transition.sh`, `reset-pipeline.sh`, `ado_agent.py`).
- Zero risk of unsubstituted-placeholder artifacts breaking `claire verify-templates`.

Full reasoning posted on the issue: https://github.com/CLAIRE-Fivepoints/claire-plugin/issues/57#issuecomment-4276997221

## Scope

Only touches the analyst persona + checklist. The dev/tester personas and `CHECKLIST_DEV_PIPELINE` / `CHECKLIST_TESTER` have `CLAIRE-Fivepoints/fivepoints` mentions only in narrative retrospective-routing text, not in runnable commands — left untouched to keep the PR tight.

## Verification Log

Rendered output check (after temporarily copying worktree files into the installed plugin so `claire preview` sees them — normal behavior, `claire preview` reads from `.claire/plugins/<plugin>/`, not the worktree):

```
$ claire preview --persona fivepoints-analyst
✅ fivepoints-analyst [template] → /tmp/CLAIRE.fivepoints-analyst.md

$ grep -cn "fivepoints-test" /tmp/CLAIRE.fivepoints-analyst.md
1

$ grep -n "fivepoints-test" /tmp/CLAIRE.fivepoints-analyst.md
86:> a production session, or `claire-labs/fivepoints-test` for the staging

$ grep -cn "CLAIRE_WAIT_REPO" /tmp/CLAIRE.fivepoints-analyst.md
11
```

→ The only remaining `fivepoints-test` match is in the preamble I added, which intentionally documents `CLAIRE_WAIT_REPO` values as examples (this is narrative, not a runnable command). Every runnable `gh` / `gh api` command now uses `"$CLAIRE_WAIT_REPO"`.

Template verification suite:
```
$ claire verify-templates
...
📋 Persona: fivepoints-pipeline-dev
  ✅ No unsubstituted placeholders
  ✅ Section present: '## Current Task'
  ✅ Section present: 'Checklist'
  ✅ Persona-specific content present ('fivepoints')

==================================================
✅ All template verification checks passed.
```

Bash syntax check for the new command form (sanity-check that `"$CLAIRE_WAIT_REPO"` interpolates cleanly inside `gh api "repos/$CLAIRE_WAIT_REPO/..."` paths):
```
$ bash -n <(representative command block with CLAIRE_WAIT_REPO="CLAIRE-Fivepoints/fivepoints")
bash syntax check: 0
```

**Context:** worktree at `/Users/andreperez/claire/.claire/plugins/fivepoints/.claire/worktrees/issue-57-bug-persona-fivepoints-analyst`, branch `issue-57`.

## Test plan

- [ ] Spawn on `CLAIRE-Fivepoints/fivepoints#<real-PBI>` → generated CLAUDE.md contains zero `fivepoints-test` in command lines, 11+ `CLAIRE_WAIT_REPO` refs.
- [ ] Analyst session runs its `gh` commands against the real repo (verify via posted-comment URL resolving to `CLAIRE-Fivepoints/fivepoints`, not `claire-labs/fivepoints-test`).
- [ ] Spawn on `claire-labs/fivepoints-test#<N>` (legacy staging) → same commands still resolve correctly because `CLAIRE_WAIT_REPO=claire-labs/fivepoints-test` for that session.
- [ ] `claire verify-templates --persona fivepoints-analyst` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)