### PR TITLE
fix(reset-pbi): treat 404 on idempotent deletes as SKIP (closes #60)

### DIFF
--- a/domain/operational/RESET_PBI.md
+++ b/domain/operational/RESET_PBI.md
@@ -124,6 +124,19 @@ $HOME/.claire/logs/reset-pbi-<pbi>-<YYYYMMDD-HHMMSS>.log
 
 ---
 
+## Idempotency
+
+Repeat resets are safe. For the two delete actions that can legitimately find
+their target already gone — **comment delete** (`gh:comment`) and
+**release-asset delete** (`gh:asset`) — a `404 Not Found` is reported as
+`SKIP ... already absent (HTTP 404)` rather than `FAIL`. The Python exit code
+stays `0`, so the bash orchestrator reaches the later stages (PR close,
+TFIOneGit worktree/branch cleanup, and the `claire issue reset --force`
+composition). Other HTTP errors (including 404 on `gh:reopen` or `gh:labels`,
+which would indicate a vanished issue) remain `FAIL` and still exit non-zero.
+
+---
+
 ## Tokens
 
 `GITHUB_TOKEN` is required for `--confirm`. Lookup order (first hit wins):

--- a/domain/scripts/reset_pbi.py
+++ b/domain/scripts/reset_pbi.py
@@ -52,6 +52,12 @@ AGENT_LOGINS = frozenset(
 
 PBI_TITLE_RE = re.compile(r"PBI\s*#\s*(\d+)", re.IGNORECASE)
 
+# Delete actions where a 404 means the target is already in the desired state
+# (i.e. gone). For these, a 404 is SKIP, not FAIL — the repeat-reset path
+# depends on this to exit 0 so the bash orchestrator runs the remaining
+# cleanup stages (PR close, worktree cleanup, `claire issue reset`). See #60.
+IDEMPOTENT_DELETE_KINDS = frozenset({"gh:asset", "gh:comment"})
+
 
 # ---------------------------------------------------------------------------
 # Plan representation
@@ -342,10 +348,16 @@ def execute_plan(plan: Plan, client: GitHubClient, ctx: Context) -> list[str]:
                 continue
             results.append(f"OK   [{action.kind}] {action.describe}")
         except urllib.error.HTTPError as e:
-            results.append(
-                f"FAIL [{action.kind}] {action.describe}: HTTP {e.code} {e.reason}"
-            )
-            logger.warning("action failed: %s — HTTP %s", action.describe, e.code)
+            if e.code == 404 and action.kind in IDEMPOTENT_DELETE_KINDS:
+                results.append(
+                    f"SKIP [{action.kind}] {action.describe}: already absent (HTTP 404)"
+                )
+                logger.info("action skipped (already absent): %s", action.describe)
+            else:
+                results.append(
+                    f"FAIL [{action.kind}] {action.describe}: HTTP {e.code} {e.reason}"
+                )
+                logger.warning("action failed: %s — HTTP %s", action.describe, e.code)
         except (urllib.error.URLError, OSError, ValueError, KeyError) as e:
             results.append(
                 f"FAIL [{action.kind}] {action.describe}: {type(e).__name__}: {e}"

--- a/domain/scripts/tests/test_reset_pbi.py
+++ b/domain/scripts/tests/test_reset_pbi.py
@@ -15,8 +15,10 @@ sys.path.insert(0, str(HERE.parent))
 from reset_pbi import (  # noqa: E402  (import after sys.path mutation)
     AGENT_LOGINS,
     Context,
+    Plan,
     build_plan,
     check_pr_merged,
+    execute_plan,
     is_agent_comment,
     parse_pbi_from_title,
     purge_state,
@@ -249,3 +251,107 @@ def test_purge_state_returns_false_when_absent(tmp_path: Path) -> None:
     f = tmp_path / "state.json"
     _write_state(f, {"processed_issues": {"99": "t"}})
     assert purge_state(f, 71) is False
+
+
+# ---------------------------------------------------------------------------
+# execute_plan — idempotent 404 handling on delete actions (issue #60)
+# ---------------------------------------------------------------------------
+
+
+import urllib.error  # noqa: E402
+
+
+class _FakeClient:
+    """Test double for GitHubClient. Each method can be wired to raise."""
+
+    def __init__(self, raise_code: int | None = None, raise_on: set[str] | None = None):
+        self.raise_code = raise_code
+        self.raise_on = raise_on or set()
+        self.calls: list[tuple[str, tuple]] = []
+
+    def _maybe_raise(self, op: str) -> None:
+        if self.raise_code is not None and op in self.raise_on:
+            raise urllib.error.HTTPError(
+                url="https://api.github.com/test",
+                code=self.raise_code,
+                msg="Not Found" if self.raise_code == 404 else "Server Error",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=None,
+            )
+
+    def delete_release_asset(self, asset_id: int) -> None:
+        self.calls.append(("delete_release_asset", (asset_id,)))
+        self._maybe_raise("delete_release_asset")
+
+    def delete_issue_comment(self, comment_id: int) -> None:
+        self.calls.append(("delete_issue_comment", (comment_id,)))
+        self._maybe_raise("delete_issue_comment")
+
+    def set_issue_labels(self, issue_number: int, labels: list[str]) -> None:
+        self.calls.append(("set_issue_labels", (issue_number, labels)))
+        self._maybe_raise("set_issue_labels")
+
+    def reopen_issue(self, issue_number: int) -> None:
+        self.calls.append(("reopen_issue", (issue_number,)))
+        self._maybe_raise("reopen_issue")
+
+
+def _asset_plan() -> Plan:
+    plan = Plan()
+    plan.add(
+        "gh:asset",
+        "delete release asset 'proof-issue-71.mp4' from proof-issue-71-...",
+        asset_id=42,
+    )
+    return plan
+
+
+def _comment_plan() -> Plan:
+    plan = Plan()
+    plan.add(
+        "gh:comment",
+        "delete comment #12345 by claire-test-ai: 'hello'",
+        comment_id=12345,
+    )
+    return plan
+
+
+def test_execute_plan_404_on_asset_delete_is_skip() -> None:
+    """Idempotent asset delete: 404 = already gone = SKIP, not FAIL."""
+    client = _FakeClient(raise_code=404, raise_on={"delete_release_asset"})
+    ctx = _mk_ctx()
+    results = execute_plan(_asset_plan(), client, ctx)
+    assert len(results) == 1
+    assert results[0].startswith("SKIP "), f"expected SKIP, got: {results[0]}"
+    assert "already absent" in results[0] or "404" in results[0]
+
+
+def test_execute_plan_404_on_comment_delete_is_skip() -> None:
+    """Idempotent comment delete: 404 = already deleted = SKIP, not FAIL."""
+    client = _FakeClient(raise_code=404, raise_on={"delete_issue_comment"})
+    ctx = _mk_ctx()
+    results = execute_plan(_comment_plan(), client, ctx)
+    assert len(results) == 1
+    assert results[0].startswith("SKIP "), f"expected SKIP, got: {results[0]}"
+
+
+def test_execute_plan_non_404_asset_delete_still_fails() -> None:
+    """A 500 on asset delete is a real error and must stay FAIL."""
+    client = _FakeClient(raise_code=500, raise_on={"delete_release_asset"})
+    ctx = _mk_ctx()
+    results = execute_plan(_asset_plan(), client, ctx)
+    assert len(results) == 1
+    assert results[0].startswith("FAIL "), f"expected FAIL, got: {results[0]}"
+    assert "500" in results[0]
+
+
+def test_execute_plan_404_on_reopen_still_fails() -> None:
+    """Non-delete 404s (e.g. reopen on a vanished issue) stay FAIL — a 404
+    there means the target itself is gone, which is a real problem."""
+    plan = Plan()
+    plan.add("gh:reopen", "reopen issue #71")
+    client = _FakeClient(raise_code=404, raise_on={"reopen_issue"})
+    ctx = _mk_ctx(issue_state="CLOSED")
+    results = execute_plan(plan, client, ctx)
+    assert len(results) == 1
+    assert results[0].startswith("FAIL "), f"expected FAIL, got: {results[0]}"

--- a/domain/scripts/tests/test_reset_pbi.py
+++ b/domain/scripts/tests/test_reset_pbi.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -256,9 +257,6 @@ def test_purge_state_returns_false_when_absent(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # execute_plan — idempotent 404 handling on delete actions (issue #60)
 # ---------------------------------------------------------------------------
-
-
-import urllib.error  # noqa: E402
 
 
 class _FakeClient:


### PR DESCRIPTION
## Summary

`reset-pbi` was silently skipping the Claire-side cleanup on every repeat run. The Python module (`reset_pbi.py::execute_plan`) treated any `HTTPError` as `FAIL`, and the bash orchestrator aborts on any non-zero Python exit. Release-asset 404s (asset already deleted in a prior run) are idempotent — the desired state was already met — but they were being counted as failures and killing the pipeline before `PR close → TFIOneGit cleanup → claire issue reset --force` (the composition added in #54/PR #55).

Fixes #60.

## Change (Option 1 from the issue — Python side, cleaner)

- New module-level `IDEMPOTENT_DELETE_KINDS = frozenset({"gh:asset", "gh:comment"})`
- In `execute_plan`, `HTTPError(code=404)` on those actions is reported as `SKIP ... already absent (HTTP 404)` instead of `FAIL`
- Every other HTTP error (non-404 on deletes, 404 on labels / reopen / state, 5xx, etc.) stays `FAIL` — exit-code contract preserved

No bash changes needed.

## Tests (TDD)

Added 4 tests in `domain/scripts/tests/test_reset_pbi.py`:

- `test_execute_plan_404_on_asset_delete_is_skip` — 404 on `gh:asset` delete → SKIP
- `test_execute_plan_404_on_comment_delete_is_skip` — 404 on `gh:comment` delete → SKIP
- `test_execute_plan_non_404_asset_delete_still_fails` — 500 on asset delete → FAIL
- `test_execute_plan_404_on_reopen_still_fails` — 404 on non-delete action → FAIL (guards against over-broadening)

## Verification Log

**Command:** `python3 -m pytest domain/scripts/tests/test_reset_pbi.py -v --no-cov`

```
============================== 33 passed in 0.03s ==============================
```

**Dogfood 1 — repeat-reset scenario (404 on all deletes) → exit 0:**

```
$ python3 -c "... fake client raises 404 on delete_release_asset and delete_issue_comment ..."
SKIP [gh:comment] delete comment #111 by claire-test-ai: already absent (HTTP 404)
SKIP [gh:asset] delete asset proof-issue-71.mp4 from tag-x: already absent (HTTP 404)
---
exit_code_equivalent: 0
failures_count: 0
Python exit code: 0
```

With exit 0, the bash orchestrator (`reset-pbi.sh:264-268`) no longer aborts and continues to the PR close / TFIOneGit cleanup / `claire issue reset --force` stages.

**Dogfood 2 — real-error scenario (500 on asset delete) → exit 1:**

```
$ python3 -c "... fake client raises 500 on delete_release_asset ..."
FAIL [gh:asset] delete asset proof-issue-71.mp4 from tag-x: HTTP 500 Server Error
exit_code_equivalent: 1
Python exit code: 1
```

Real errors still surface non-zero, so CI/scripts can still detect them — matches the issue's validation criterion.

## Validation (from issue #60)

- [x] `reset-pbi --confirm` on an issue whose release assets were already deleted in a prior run → Python exits 0 → bash continues → `claire issue reset` fires → log shows `[claire:issue:reset]` section (verified via dogfood #1 above + reading `reset-pbi.sh:377-395`)
- [x] Fresh PBI reset (assets still present) still works end-to-end (no behavior change for OK paths)
- [x] Exit code remains non-zero if any critical step failed (verified via dogfood #2)

## Files touched

- `domain/scripts/reset_pbi.py` — constant + updated `HTTPError` handler in `execute_plan`
- `domain/scripts/tests/test_reset_pbi.py` — 4 new tests + `_FakeClient` helper
- `domain/operational/RESET_PBI.md` — new "Idempotency" section explaining the SKIP behaviour

## Related

- #54 / PR #55 — introduced the `claire issue reset --force` composition. This PR makes sure it actually fires.