### PR TITLE
fix(persona): add ORDER OVERRIDE so FDS is read before analysis comment (closes #65)

### DIFF
--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -6,6 +6,39 @@ keywords: [fivepoints, analyst, pipeline, checklist, role]
 updated: 2026-04-19
 ---
 
+## 🛑 ORDER OVERRIDE (fivepoints-analyst only)
+
+The generic kernel checklist (`00_kernel/checklist-work.md`) says the analysis
+comment is your **first** GitHub action on the issue. That rule is **SUPERSEDED**
+for the fivepoints analyst role. The analysis comment without FDS grounding is a
+ghost comment — it duplicates the scripted `🟢 Session …` heartbeat without
+adding understanding. The agent-side proof-of-life (`🤖 Started the analysis on
+#<N>.`) must arrive *with* FDS content, not before it.
+
+For this role, the order is:
+
+1. Heartbeat — scripted, already posted by `claire start` (nothing to do).
+2. Read the GitHub issue body + the ADO work item.
+3. **FDS fetch-on-use + manifest** ← HARD STOP before any analysis comment.
+4. Read the target FDS section in full.
+5. THEN post the analysis comment. It MUST open with
+   `🤖 Started the analysis on #<N>.` and carry:
+   - Understanding grounded in the FDS (section title + path + 5-10 verbatim labels)
+   - Planned approach citing specific FDS sections
+   - Open questions (write "None" if the plan is clear)
+
+An analysis comment posted BEFORE step 3 is invalid. If you notice the generic
+checklist prompting you to post earlier, ignore it — this override wins.
+
+Note: the **FDS Read Receipt** comment (further down in the checklist) is a
+separate audit-trail artifact and remains mandatory. The analysis comment is
+proof-of-reasoning; the receipt is proof-of-reading. Both must be posted; the
+receipt can either be folded into the analysis comment or posted alongside it,
+as long as its body starts with `**FDS Read Receipt**` (the dev role's
+cross-check greps for that prefix).
+
+---
+
 ## Your Checklist (MANDATORY — follow in order)
 
 > **About `$CLAIRE_WAIT_REPO`:** every spawned session receives this env var

--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -19,8 +19,9 @@ For this role, the order is:
 
 1. Heartbeat — scripted, already posted by `claire start` (nothing to do).
 2. Read the GitHub issue body + the ADO work item.
-3. **FDS fetch-on-use + manifest** ← HARD STOP before any analysis comment.
-4. Read the target FDS section in full.
+3. **FDS fetch-on-use + manifest** (`claire fivepoints ado-fetch-attachments
+   --pbi <parent-pbi> --print-manifest`) ← HARD STOP before any analysis comment.
+4. Read the target FDS section in full (`cat ~/TFIOneGit/.fds-cache/<parent-pbi>/FDS_<NAME>.md`).
 5. THEN post the analysis comment. It MUST open with
    `🤖 Started the analysis on #<N>.` and carry:
    - Understanding grounded in the FDS (section title + path + 5-10 verbatim labels)

--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -80,6 +80,39 @@ Read this before starting — it has scope guard rules and detailed patterns.
 
 ---
 
+## 🛑 ORDER OVERRIDE (fivepoints-analyst only)
+
+The generic kernel checklist (`00_kernel/checklist-work.md`) says the analysis
+comment is your **first** GitHub action on the issue. That rule is **SUPERSEDED**
+for the fivepoints analyst role. The analysis comment without FDS grounding is a
+ghost comment — it duplicates the scripted `🟢 Session …` heartbeat without
+adding understanding. The agent-side proof-of-life (`🤖 Started the analysis on
+#<N>.`) must arrive *with* FDS content, not before it.
+
+For this role, the order is:
+
+1. Heartbeat — scripted, already posted by `claire start` (nothing to do).
+2. Read the GitHub issue body + the ADO work item.
+3. **FDS fetch-on-use + manifest** ← HARD STOP before any analysis comment.
+4. Read the target FDS section in full.
+5. THEN post the analysis comment. It MUST open with
+   `🤖 Started the analysis on #<N>.` and carry:
+   - Understanding grounded in the FDS (section title + path + 5-10 verbatim labels)
+   - Planned approach citing specific FDS sections
+   - Open questions (write "None" if the plan is clear)
+
+An analysis comment posted BEFORE step 3 is invalid. If you notice the generic
+checklist prompting you to post earlier, ignore it — this override wins.
+
+Note: the **FDS Read Receipt** comment (further down in the checklist) is a
+separate audit-trail artifact and remains mandatory. The analysis comment is
+proof-of-reasoning; the receipt is proof-of-reading. Both must be posted; the
+receipt can either be folded into the analysis comment or posted alongside it,
+as long as its body starts with `**FDS Read Receipt**` (the dev role's
+cross-check greps for that prefix).
+
+---
+
 ## Your Checklist (MANDATORY — follow in order)
 
 > **About `$CLAIRE_WAIT_REPO`:** every spawned session receives this env var

--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -93,8 +93,9 @@ For this role, the order is:
 
 1. Heartbeat — scripted, already posted by `claire start` (nothing to do).
 2. Read the GitHub issue body + the ADO work item.
-3. **FDS fetch-on-use + manifest** ← HARD STOP before any analysis comment.
-4. Read the target FDS section in full.
+3. **FDS fetch-on-use + manifest** (`claire fivepoints ado-fetch-attachments
+   --pbi <parent-pbi> --print-manifest`) ← HARD STOP before any analysis comment.
+4. Read the target FDS section in full (`cat ~/TFIOneGit/.fds-cache/<parent-pbi>/FDS_<NAME>.md`).
 5. THEN post the analysis comment. It MUST open with
    `🤖 Started the analysis on #<N>.` and carry:
    - Understanding grounded in the FDS (section title + path + 5-10 verbatim labels)

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -89,6 +89,42 @@ If you encounter something missing or unclear in the analyst's specs:
 
 ---
 
+### 🛑 ORDER OVERRIDE (fivepoints-dev only)
+
+The generic kernel checklist (`00_kernel/checklist-work.md`) says the analysis
+comment is your **first** GitHub action on the issue. That rule is **SUPERSEDED**
+for the fivepoints dev role. An analysis posted before the FDS has been read is
+a ghost comment — it duplicates the scripted `🟢 Session …` heartbeat without
+adding understanding. The agent-side proof-of-life (`🤖 Started the analysis on
+#<N>.`) must arrive *with* FDS content, not before it.
+
+For this role, the order is:
+
+1. Heartbeat — scripted, already posted by `claire start` (nothing to do).
+2. Load domain context + read the GitHub issue body.
+3. **FDS fetch-on-use + manifest** (`claire fivepoints ado-fetch-attachments
+   --pbi <parent-pbi> --print-manifest`) ← HARD STOP before any analysis comment.
+4. Read the target FDS section in full. If an analyst session ran first, also
+   locate their `**FDS Read Receipt**` comment (distrust-by-default: compute the
+   delta between their specs and what you just read in the FDS).
+5. THEN post the analysis comment. It MUST open with
+   `🤖 Started the analysis on #<N>.` and carry:
+   - Understanding grounded in the FDS (section title + path + verbatim labels)
+   - Delta vs the analyst's specs, if any (missed / renamed / added) — this is
+     where the Distrust-by-Default cross-check lives
+   - Planned approach and files to touch
+   - Open questions (write "None" if the plan is clear)
+
+An analysis comment posted BEFORE step 3 is invalid. If you notice the generic
+checklist prompting you to post earlier, ignore it — this override wins.
+
+The Scope Confirmation posted in [1.5/11] is a separate audit artifact
+(section_path + section_sha256 + screens/labels) and remains mandatory. The
+analysis comment is proof-of-reasoning; the Scope Confirmation is
+proof-of-reading against the FDS.
+
+---
+
 ### SESSION START — Create All Tasks First (MANDATORY)
 
 Before doing ANY work, create all 11 checklist tasks so each step is auditable:

--- a/domain/persona/fivepoints-tester.md
+++ b/domain/persona/fivepoints-tester.md
@@ -79,6 +79,35 @@ The original "End-to-End Execution" rule (continue through to completion unless 
 
 ---
 
+### 🛑 ORDER OVERRIDE (fivepoints-tester only)
+
+The generic kernel checklist (`00_kernel/checklist-work.md`) says the analysis
+comment is your **first** GitHub action on the issue. That rule is **SUPERSEDED**
+for the fivepoints tester role. An analysis posted before the FDS has been read
+is a ghost comment — it duplicates the scripted `🟢 Session …` heartbeat
+without adding understanding. The agent-side proof-of-life (`🤖 Started the
+analysis on #<N>.`) must arrive *with* FDS content, not before it.
+
+For this role, the order is:
+
+1. Heartbeat — scripted, already posted by `claire start` (nothing to do).
+2. Read the GitHub issue body + locate the analyst's `**FDS Read Receipt**` comment.
+3. **FDS fetch-on-use + manifest** (`claire fivepoints ado-fetch-attachments
+   --pbi <parent-pbi> --print-manifest`) ← HARD STOP before any analysis comment.
+4. Read the target FDS section in full — the tester tests *against the FDS*,
+   not against the dev's implementation. Treat the FDS as the acceptance spec.
+5. THEN post the analysis comment. It MUST open with
+   `🤖 Started the analysis on #<N>.` and carry:
+   - Understanding grounded in the FDS (section title + path + verbatim labels)
+   - Planned E2E test coverage mapped to FDS obligations (per-label assertions)
+   - Adversarial cases you will try (edge cases, error states) beyond happy path
+   - Open questions (write "None" if the plan is clear)
+
+An analysis comment posted BEFORE step 3 is invalid. If you notice the generic
+checklist prompting you to post earlier, ignore it — this override wins.
+
+---
+
 ### SESSION START — Create All Tasks First (MANDATORY)
 
 Before doing ANY work, create all 8 checklist tasks so each step is auditable:


### PR DESCRIPTION
## Summary
- Generic kernel checklist (`00_kernel/checklist-work.md`) says *"analysis comment = first GitHub action"*, which fivepoints pipeline personas inherit. Result: agents post the analysis BEFORE fetching the FDS — the FDS content never lands in the analysis.
- Fix: add a `🛑 ORDER OVERRIDE` block to each fat pipeline persona + the analyst checklist. The override explicitly supersedes the generic rule and requires FDS fetch + section read to complete BEFORE the analysis comment.
- Role-specific content per persona:
  - **analyst** — FDS grounding + verbatim labels + plan (Read Receipt remains a separate artifact, still mandatory)
  - **dev** — FDS + analyst Read Receipt delta + plan (distrust-by-default cross-check)
  - **tester** — FDS as acceptance spec + coverage plan + adversarial cases

## Files touched
- `domain/operational/CHECKLIST_ANALYST.md`
- `domain/persona/fivepoints-analyst.md`
- `domain/persona/fivepoints-dev.md`
- `domain/persona/fivepoints-tester.md`

## Verification Log

```
$ claire verify-templates
...
📋 Persona: fivepoints-pipeline-dev
  ✅ No unsubstituted placeholders
  ✅ Section present: '## Current Task'
  ✅ Section present: 'Checklist'
  ✅ Persona-specific content present ('fivepoints')

==================================================
✅ All template verification checks passed.

$ grep -c "🛑 ORDER OVERRIDE" domain/operational/CHECKLIST_ANALYST.md domain/persona/fivepoints-analyst.md domain/persona/fivepoints-dev.md domain/persona/fivepoints-tester.md
domain/operational/CHECKLIST_ANALYST.md:1
domain/persona/fivepoints-analyst.md:1
domain/persona/fivepoints-dev.md:1
domain/persona/fivepoints-tester.md:1
```

Context: fresh worktree `issue-65-bug-fivepoints-analyst-checkli`, `claire verify-templates` run after edits to confirm every persona still renders cleanly.

## Runtime validation (out of scope for this PR)
The acceptance criterion (*spawn on a fresh fivepoints PBI → first analysis comment includes FDS section name + verbatim labels*) requires a live PBI session. The fix is to the instruction the agent reads at spawn time — it cannot be simulated from this worktree. It will be verified by the next analyst session spawned against a PBI with an FDS attachment.

Closes #65.