### PR TITLE
feat(repo-reset): wipe content + strip+rename PRs to archive tombstones

### DIFF
--- a/domain/commands/repo-reset.sh
+++ b/domain/commands/repo-reset.sh
@@ -217,32 +217,49 @@ echo "[repo-reset] mode=$MODE repo=$REPO ado_ref=$ADO_REF keep_prs=$KEEP_PRS" >>
 
 echo "── Collecting inventories via gh..."
 
+# All inventory fetches: die loud on failure. Silent `|| echo "[]"` is
+# contradictory under `set -euo pipefail` — it would let network outages,
+# expired tokens, scope drops, or rate limits masquerade as a clean repo
+# and lead to a "no actions" plan that actually hides missed data.
+
 # Branches (non-main)
-BRANCHES_JSON=$(gh api --paginate "/repos/${REPO}/branches" \
-    --jq '[.[] | .name | select(. != "main")]' 2>/dev/null || echo "[]")
+if ! BRANCHES_JSON=$(gh api --paginate "/repos/${REPO}/branches" \
+    --jq '[.[] | .name | select(. != "main")]' 2>&1); then
+    die "branches inventory fetch failed: $BRANCHES_JSON"
+fi
 
 # Tags
-TAGS_JSON=$(gh api --paginate "/repos/${REPO}/tags" \
-    --jq '[.[] | .name]' 2>/dev/null || echo "[]")
+if ! TAGS_JSON=$(gh api --paginate "/repos/${REPO}/tags" \
+    --jq '[.[] | .name]' 2>&1); then
+    die "tags inventory fetch failed: $TAGS_JSON"
+fi
 
 # Issues (all states, PRs excluded)
-ISSUES_JSON=$(gh api --paginate "/repos/${REPO}/issues?state=all" \
+if ! ISSUES_JSON=$(gh api --paginate "/repos/${REPO}/issues?state=all" \
     --jq '[.[] | select(.pull_request == null) | {number: .number, node_id: .node_id, title: .title}]' \
-    2>/dev/null || echo "[]")
+    2>&1); then
+    die "issues inventory fetch failed: $ISSUES_JSON"
+fi
 
 # PRs (all states)
-PRS_JSON=$(gh pr list --repo "$REPO" --state all --limit 500 \
+if ! PRS_JSON=$(gh pr list --repo "$REPO" --state all --limit 500 \
     --json number,state,title \
     --jq '[.[] | {number: .number, state: .state, title: .title}]' \
-    2>/dev/null || echo "[]")
+    2>&1); then
+    die "PR inventory fetch failed: $PRS_JSON"
+fi
 
 # Releases
-RELEASES_JSON=$(gh api --paginate "/repos/${REPO}/releases" \
-    --jq '[.[] | {id: .id, tag_name: .tag_name}]' 2>/dev/null || echo "[]")
+if ! RELEASES_JSON=$(gh api --paginate "/repos/${REPO}/releases" \
+    --jq '[.[] | {id: .id, tag_name: .tag_name}]' 2>&1); then
+    die "releases inventory fetch failed: $RELEASES_JSON"
+fi
 
 # Workflow runs
-RUNS_JSON=$(gh api --paginate "/repos/${REPO}/actions/runs?per_page=100" \
-    --jq '[.workflow_runs[]?.id]' 2>/dev/null || echo "[]")
+if ! RUNS_JSON=$(gh api --paginate "/repos/${REPO}/actions/runs?per_page=100" \
+    --jq '[.workflow_runs[]?.id]' 2>&1); then
+    die "workflow runs inventory fetch failed: $RUNS_JSON"
+fi
 
 # PR issue-comments (discussion comments), filtered to agent-authored
 # in Python. We fetch per-PR and concatenate.
@@ -251,10 +268,12 @@ if [[ "$KEEP_PRS" == false ]]; then
     PR_NUMBERS=$(jq -r '.[].number' <<<"$PRS_JSON")
     accum="[]"
     for pr in $PR_NUMBERS; do
-        pr_comments=$(gh api --paginate \
+        if ! pr_comments=$(gh api --paginate \
             "/repos/${REPO}/issues/${pr}/comments" \
             --jq "[.[] | {id: .id, pr_number: ${pr}, author_login: .user.login}]" \
-            2>/dev/null || echo "[]")
+            2>&1); then
+            die "PR #${pr} comments fetch failed: $pr_comments"
+        fi
         accum=$(jq -s '.[0] + .[1]' <(echo "$accum") <(echo "$pr_comments"))
     done
     PR_COMMENTS_JSON="$accum"

--- a/domain/commands/repo-reset.sh
+++ b/domain/commands/repo-reset.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fivepoints repo-reset — Factory-reset the fivepoints test mirror to a clean
+# state derived from ADO/<ref>, without deleting the repo itself.
+#
+# Architecture:
+#   * Bash (this file) — orchestration: arg parsing, token resolution,
+#     machine.yml guardrail, git force-push of `main` via ~/TFIOneGit,
+#     pre-fetching JSON inventories via gh.
+#   * Python (domain/scripts/repo_reset.py) — logic: plan build + execute
+#     (REST + GraphQL wipe of issues, PRs, branches, tags, releases, runs).
+#
+# See `claire fivepoints repo-reset --help` for the option list and the
+# corresponding domain doc: `claire domain read fivepoints operational REPO_RESET`.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPTS_DIR="$PLUGIN_ROOT/domain/scripts"
+PY_MODULE="$SCRIPTS_DIR/repo_reset.py"
+
+DEFAULT_TFIONE_PATH="${TFIONE_REPO_PATH:-$HOME/TFIOneGit}"
+DEFAULT_ADO_REF="dev"
+
+MODE=""          # dry-run | confirm
+KEEP_PRS=false
+ADO_REF="$DEFAULT_ADO_REF"
+TFIONE_PATH="$DEFAULT_TFIONE_PATH"
+
+show_help() {
+    cat <<'EOF'
+Usage: claire fivepoints repo-reset (--dry-run | --confirm) [options]
+
+Factory-reset the fivepoints test mirror (CLAIRE-Fivepoints/fivepoints) to a
+clean state derived from ADO/dev. Repo settings (labels, branch protection,
+webhooks, Actions secrets, collaborators) are preserved; content is wiped.
+
+Mode (exactly one required):
+  --dry-run           Print the plan and exit — no mutations
+  --confirm           Execute the plan (destructive)
+
+Options:
+  --keep-prs          Skip PR strip+rename and PR comment cleanup
+  --ado-ref REF       ADO ref to reset `main` to (default: dev)
+  --tfione-path PATH  TFIOneGit clone path (default: $TFIONE_REPO_PATH or ~/TFIOneGit)
+
+What gets reset (when --confirm):
+  1. main                — force-pushed to ADO/<ado-ref> tip
+  2. All non-main branches — deleted (REST)
+  3. All tags             — deleted (REST)
+  4. All issues           — deleted (GraphQL deleteIssue, admin only)
+  5. All releases         — deleted (assets cascade)
+  6. All workflow runs    — deleted (REST)
+  7. All PRs              — title -> [archived-repo-reset-<iso>], body
+                            replaced, state -> closed (GitHub has no PR delete
+                            API, so strip+rename is the neutralization path).
+                            Skipped under --keep-prs.
+  8. Agent-authored PR    — deleted (skipped under --keep-prs)
+     discussion comments
+
+What's preserved:
+  * Labels, branch protection, webhooks, Actions secrets, collaborators,
+    repo-level settings.
+
+Guardrails:
+  * Refuses to run on any repo other than machine.yml:fivepoints_test_repo
+  * --confirm requires GITHUB_ADMIN_TOKEN (delete_repo + admin:org scopes)
+  * main is force-pushed only from a clean TFIOneGit clone
+  * Every action is logged to $HOME/.claire/logs/repo-reset-<timestamp>.log
+
+Examples:
+  claire fivepoints repo-reset --dry-run
+  claire fivepoints repo-reset --confirm
+  claire fivepoints repo-reset --confirm --keep-prs
+  claire fivepoints repo-reset --confirm --ado-ref release/v1.2.3
+
+Setup (one-time):
+  Add to ~/.claire/machine.yml:
+      fivepoints_test_repo: CLAIRE-Fivepoints/fivepoints
+EOF
+}
+
+show_agent_help() {
+    cat <<'EOF'
+# fivepoints repo-reset — Agent Help
+
+## Purpose
+Wipe all content (issues, PRs, branches, tags, releases, workflow runs) from
+the configured fivepoints test mirror and reset main to ADO/<ado-ref>, while
+preserving repo settings. For factory-reset between pipeline validation cycles.
+
+## When to use
+* The test mirror is too polluted for per-PBI resets to be worth running
+* Starting a fresh validation session from a known-clean baseline
+
+## Modes (exactly one required)
+--dry-run     Print the plan, make no changes
+--confirm     Execute the plan (destructive)
+
+## Options
+--keep-prs          Preserve existing PRs instead of strip+rename
+--ado-ref REF       ADO source ref (default: dev)
+--tfione-path PATH  TFIOneGit clone path
+
+## Required env
+GITHUB_ADMIN_TOKEN    Token with delete_repo + admin:org scopes.
+                      Read from env or ~/.config/claire/github_manager.env.
+                      --confirm fails loud if missing.
+
+## Guardrails (abort conditions)
+* machine.yml:fivepoints_test_repo unset            -> exit 2
+* Target repo != fivepoints_test_repo              -> exit 2
+* --confirm without GITHUB_ADMIN_TOKEN             -> exit 4
+* TFIOneGit clone missing (for force-push of main) -> exit 5
+
+## Produces
+Log at: $HOME/.claire/logs/repo-reset-<timestamp>.log
+
+## Composes
+* Per-PBI scope: prefer `claire fivepoints reset-pbi --pbi <id> --issue <n>`
+* This command subsumes what reset-pbi does, applied repo-wide.
+
+## Never does
+* Delete the repo itself (settings are preserved)
+* Touch any repo other than machine.yml:fivepoints_test_repo
+* Push to ADO's `origin` remote
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)       MODE="dry-run"; shift ;;
+        --confirm)       MODE="confirm"; shift ;;
+        --keep-prs)      KEEP_PRS=true; shift ;;
+        --ado-ref)       ADO_REF="$2"; shift 2 ;;
+        --tfione-path)   TFIONE_PATH="$2"; shift 2 ;;
+        --help|-h)       show_help; exit 0 ;;
+        --agent-help)    show_agent_help; exit 0 ;;
+        *) die "Unknown argument: $1 (see --help)" ;;
+    esac
+done
+
+[[ -n "$MODE" ]] || die "one of --dry-run / --confirm is required"
+
+# ── machine.yml guardrail ────────────────────────────────────────────────────
+# The configured test repo is the ONLY repo this command will touch. If the
+# key is unset we refuse — zero chance of nuking production.
+
+ALLOWED_REPO=$(python3 -m claire_py.machine.cli read-field fivepoints_test_repo 2>/dev/null || true)
+
+if [[ -z "$ALLOWED_REPO" ]]; then
+    cat >&2 <<EOF
+ERROR: machine.yml does not define 'fivepoints_test_repo'.
+
+Add to ~/.claire/machine.yml:
+    fivepoints_test_repo: CLAIRE-Fivepoints/fivepoints
+
+Without this key, repo-reset refuses to run — by design.
+EOF
+    exit 2
+fi
+
+REPO="$ALLOWED_REPO"
+OWNER="${REPO%/*}"
+NAME="${REPO#*/}"
+
+# ── Token resolution ────────────────────────────────────────────────────────
+# GITHUB_ADMIN_TOKEN is distinct from GITHUB_TOKEN (manager token) because
+# deleteIssue + deleting workflow runs requires admin:org scope.
+
+if [[ -z "${GITHUB_ADMIN_TOKEN:-}" ]]; then
+    for env_file in ~/.config/claire/github_manager.env ~/.config/claire/.env; do
+        [[ -f "$env_file" ]] || continue
+        tok=$(grep -E '^GITHUB_ADMIN_TOKEN=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2- || true)
+        if [[ -n "$tok" ]]; then
+            export GITHUB_ADMIN_TOKEN="$tok"
+            break
+        fi
+    done
+fi
+
+if [[ "$MODE" == "confirm" && -z "${GITHUB_ADMIN_TOKEN:-}" ]]; then
+    die "--confirm requires GITHUB_ADMIN_TOKEN (delete_repo + admin:org scopes)"
+fi
+
+# gh uses GITHUB_TOKEN for read-only inventory fetching; fall back to the
+# admin token if the regular one isn't set.
+if [[ -z "${GITHUB_TOKEN:-}" && -n "${GITHUB_ADMIN_TOKEN:-}" ]]; then
+    export GITHUB_TOKEN="$GITHUB_ADMIN_TOKEN"
+fi
+
+# ── Paths + log file ────────────────────────────────────────────────────────
+
+TS=$(date +%Y%m%d-%H%M%S)
+LOG_DIR="$HOME/.claire/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/repo-reset-${TS}.log"
+
+echo "=== fivepoints repo-reset ==="
+echo "Repo:       $REPO"
+echo "Mode:       $MODE"
+echo "ADO ref:    $ADO_REF"
+echo "Keep PRs:   $KEEP_PRS"
+echo "TFIOneGit:  $TFIONE_PATH"
+echo "Log file:   $LOG_FILE"
+echo ""
+
+echo "[repo-reset] mode=$MODE repo=$REPO ado_ref=$ADO_REF keep_prs=$KEEP_PRS" >>"$LOG_FILE"
+
+# ── Collect inventories via gh ──────────────────────────────────────────────
+# Everything here is read-only. Results are passed to Python as JSON.
+
+echo "── Collecting inventories via gh..."
+
+# Branches (non-main)
+BRANCHES_JSON=$(gh api --paginate "/repos/${REPO}/branches" \
+    --jq '[.[] | .name | select(. != "main")]' 2>/dev/null || echo "[]")
+
+# Tags
+TAGS_JSON=$(gh api --paginate "/repos/${REPO}/tags" \
+    --jq '[.[] | .name]' 2>/dev/null || echo "[]")
+
+# Issues (all states, PRs excluded)
+ISSUES_JSON=$(gh api --paginate "/repos/${REPO}/issues?state=all" \
+    --jq '[.[] | select(.pull_request == null) | {number: .number, node_id: .node_id, title: .title}]' \
+    2>/dev/null || echo "[]")
+
+# PRs (all states)
+PRS_JSON=$(gh pr list --repo "$REPO" --state all --limit 500 \
+    --json number,state,title \
+    --jq '[.[] | {number: .number, state: .state, title: .title}]' \
+    2>/dev/null || echo "[]")
+
+# Releases
+RELEASES_JSON=$(gh api --paginate "/repos/${REPO}/releases" \
+    --jq '[.[] | {id: .id, tag_name: .tag_name}]' 2>/dev/null || echo "[]")
+
+# Workflow runs
+RUNS_JSON=$(gh api --paginate "/repos/${REPO}/actions/runs?per_page=100" \
+    --jq '[.workflow_runs[]?.id]' 2>/dev/null || echo "[]")
+
+# PR issue-comments (discussion comments), filtered to agent-authored
+# in Python. We fetch per-PR and concatenate.
+PR_COMMENTS_JSON="[]"
+if [[ "$KEEP_PRS" == false ]]; then
+    PR_NUMBERS=$(jq -r '.[].number' <<<"$PRS_JSON")
+    accum="[]"
+    for pr in $PR_NUMBERS; do
+        pr_comments=$(gh api --paginate \
+            "/repos/${REPO}/issues/${pr}/comments" \
+            --jq "[.[] | {id: .id, pr_number: ${pr}, author_login: .user.login}]" \
+            2>/dev/null || echo "[]")
+        accum=$(jq -s '.[0] + .[1]' <(echo "$accum") <(echo "$pr_comments"))
+    done
+    PR_COMMENTS_JSON="$accum"
+fi
+
+echo "  branches:      $(jq 'length' <<<"$BRANCHES_JSON")"
+echo "  tags:          $(jq 'length' <<<"$TAGS_JSON")"
+echo "  issues:        $(jq 'length' <<<"$ISSUES_JSON")"
+echo "  PRs:           $(jq 'length' <<<"$PRS_JSON")"
+echo "  releases:      $(jq 'length' <<<"$RELEASES_JSON")"
+echo "  workflow runs: $(jq 'length' <<<"$RUNS_JSON")"
+echo "  PR comments:   $(jq 'length' <<<"$PR_COMMENTS_JSON")"
+echo ""
+
+{
+    echo "[inventory] branches=$(jq 'length' <<<"$BRANCHES_JSON")"
+    echo "[inventory] tags=$(jq 'length' <<<"$TAGS_JSON")"
+    echo "[inventory] issues=$(jq 'length' <<<"$ISSUES_JSON")"
+    echo "[inventory] prs=$(jq 'length' <<<"$PRS_JSON")"
+    echo "[inventory] releases=$(jq 'length' <<<"$RELEASES_JSON")"
+    echo "[inventory] workflow_runs=$(jq 'length' <<<"$RUNS_JSON")"
+    echo "[inventory] pr_comments=$(jq 'length' <<<"$PR_COMMENTS_JSON")"
+} >>"$LOG_FILE"
+
+# ── Force-push main (orchestration: git on local clone) ─────────────────────
+# We do this BEFORE the Python wipe so that open PRs (about to be archived)
+# don't show stale diffs against an outdated main during the brief overlap.
+
+echo "── main reset: $REPO:main -> ADO/${ADO_REF}"
+if [[ "$MODE" == "confirm" ]]; then
+    if [[ ! -d "$TFIONE_PATH/.git" && ! -f "$TFIONE_PATH/.git" ]]; then
+        echo "ERROR: TFIOneGit clone not found at $TFIONE_PATH"
+        echo "  Set TFIONE_REPO_PATH or pass --tfione-path to a clone with both 'origin' (ADO) and 'github' remotes."
+        echo "[git] FAIL: TFIOneGit clone missing at $TFIONE_PATH" >>"$LOG_FILE"
+        exit 5
+    fi
+
+    # Confirm 'github' remote exists and points at our allowed repo.
+    github_url=$(git -C "$TFIONE_PATH" remote get-url github 2>/dev/null || true)
+    if [[ -z "$github_url" ]]; then
+        echo "ERROR: TFIOneGit clone has no 'github' remote."
+        echo "[git] FAIL: no 'github' remote in $TFIONE_PATH" >>"$LOG_FILE"
+        exit 5
+    fi
+    # Coarse match: owner/name must appear in the remote URL.
+    if [[ "$github_url" != *"$REPO"* ]]; then
+        echo "ERROR: 'github' remote is $github_url — does not match allowed $REPO"
+        echo "[git] FAIL: remote mismatch url=$github_url allowed=$REPO" >>"$LOG_FILE"
+        exit 5
+    fi
+
+    echo "  fetching origin (ADO)..."
+    git -C "$TFIONE_PATH" fetch origin "$ADO_REF" >>"$LOG_FILE" 2>&1 || {
+        echo "  ERROR: could not fetch origin/$ADO_REF"
+        exit 5
+    }
+    echo "  force-pushing origin/$ADO_REF -> github:main"
+    git -C "$TFIONE_PATH" push github "+refs/remotes/origin/${ADO_REF}:refs/heads/main" \
+        >>"$LOG_FILE" 2>&1 || {
+        echo "  ERROR: push to github:main failed (see $LOG_FILE)"
+        exit 5
+    }
+    echo "  main force-pushed."
+else
+    echo "  [dry-run] would force-push origin/$ADO_REF -> github:main from $TFIONE_PATH"
+    echo "[git] dry-run: would push origin/$ADO_REF -> github:main" >>"$LOG_FILE"
+fi
+echo ""
+
+# ── Hand off content wipe to Python ─────────────────────────────────────────
+
+PY_ARGS=(
+    --repo "$REPO"
+    --allowed-repo "$ALLOWED_REPO"
+    --log-file "$LOG_FILE"
+    --branches-json "$BRANCHES_JSON"
+    --tags-json "$TAGS_JSON"
+    --issues-json "$ISSUES_JSON"
+    --prs-json "$PRS_JSON"
+    --releases-json "$RELEASES_JSON"
+    --runs-json "$RUNS_JSON"
+    --pr-comments-json "$PR_COMMENTS_JSON"
+)
+if [[ "$KEEP_PRS" == true ]]; then
+    PY_ARGS+=(--keep-prs)
+fi
+if [[ "$MODE" == "dry-run" ]]; then
+    PY_ARGS+=(--dry-run)
+else
+    PY_ARGS+=(--confirm)
+fi
+
+set +e
+PYTHONPATH="$SCRIPTS_DIR" python3 "$PY_MODULE" "${PY_ARGS[@]}"
+PY_RC=$?
+set -e
+
+if [[ $PY_RC -ne 0 ]]; then
+    echo ""
+    echo "ERROR: repo_reset (Python) exited with code $PY_RC (see $LOG_FILE)"
+    exit "$PY_RC"
+fi
+
+echo ""
+if [[ "$MODE" == "dry-run" ]]; then
+    echo "=== DRY RUN complete — no changes applied ==="
+else
+    echo "=== Reset complete ==="
+fi
+echo "Log: $LOG_FILE"

--- a/domain/operational/REPO_RESET.md
+++ b/domain/operational/REPO_RESET.md
@@ -1,0 +1,194 @@
+---
+domain: fivepoints
+category: operational
+name: REPO_RESET
+title: "Five Points — Factory Reset the Fivepoints Test Mirror (repo-reset)"
+keywords: [fivepoints, repo-reset, factory-reset, wipe, tombstone, archive, pr-archive, strip-rename, content-wipe, pipeline, tfi-one, ado, main-reset, guardrails]
+updated: 2026-04-19
+---
+
+# Five Points — Factory Reset the Test Mirror (`repo-reset`)
+
+Resets the **whole fivepoints test mirror** (`CLAIRE-Fivepoints/fivepoints`)
+to a clean state derived from ADO `dev`, without deleting the repo itself.
+Use this to start a fresh pipeline validation cycle from a known baseline
+when per-PBI cleanup is no longer worth the bookkeeping.
+
+`repo-reset` subsumes what `reset-pbi` would do for every PBI present — same
+shape, repo-wide scope.
+
+---
+
+## Command
+
+```bash
+claire fivepoints repo-reset (--dry-run | --confirm)
+                             [--keep-prs]
+                             [--ado-ref <branch|sha>]
+                             [--tfione-path PATH]
+```
+
+Mode (exactly one):
+
+| Arg | Meaning |
+|---|---|
+| `--dry-run` | Render the plan, make no mutations |
+| `--confirm` | Execute the plan (destructive) |
+
+Options:
+
+| Arg | Default | Purpose |
+|---|---|---|
+| `--keep-prs` | off | Skip PR strip+rename and PR comment cleanup |
+| `--ado-ref <ref>` | `dev` | ADO source ref to reset `main` to (branch, tag, or sha) |
+| `--tfione-path PATH` | `$TFIONE_REPO_PATH` or `~/TFIOneGit` | TFIOneGit clone that holds the `origin` (ADO) and `github` (mirror) remotes |
+
+---
+
+## What gets wiped
+
+| # | Bucket | Mechanism |
+|---|---|---|
+| 1 | `main` | Force-pushed to `ADO/<ado-ref>` tip via the local TFIOneGit clone's `github` remote |
+| 2 | Non-`main` branches | REST `DELETE /repos/<o>/<n>/git/refs/heads/<name>` |
+| 3 | Tags | REST `DELETE /repos/<o>/<n>/git/refs/tags/<name>` |
+| 4 | Issues | GraphQL `deleteIssue` mutation (admin token required) |
+| 5 | Releases (and assets) | REST `DELETE /repos/<o>/<n>/releases/<id>` (assets cascade) |
+| 6 | Workflow runs | REST `DELETE /repos/<o>/<n>/actions/runs/<id>` |
+| 7 | PRs | **Strip + rename** — see below. Skipped under `--keep-prs`. |
+| 8 | Agent-authored PR comments | REST `DELETE /repos/<o>/<n>/issues/comments/<id>`. Skipped under `--keep-prs`. |
+
+### Why strip+rename PRs, not delete
+
+GitHub's API **does not expose PR deletion**: `DELETE /repos/<o>/<n>/pulls/<n>`
+returns 404, and no GraphQL `deletePullRequest` mutation exists. Instead we
+neutralize each PR into an inert **tombstone**:
+
+* **Title** → `[archived-repo-reset-<iso-timestamp>]`
+* **Body** → `This PR was archived during a factory repo reset. Original content is no longer authoritative.`
+* **State** → `closed`
+
+After this transformation, agent searches like `gh pr list --search "PBI #18839"`
+or `--search "head:feature/18839-*"` return zero matches. The PR number stays
+in the repo as an audit record; its semantic signal is gone.
+
+---
+
+## What's preserved
+
+* Labels
+* Branch protection rules
+* Webhooks
+* Actions secrets
+* Collaborators
+* Repo-level settings (merge policies, issue templates, etc.)
+
+### Why not `gh repo delete`
+
+Tempting but rejected: re-provisioning labels/protection/webhooks/secrets/
+collaborators on every reset is operationally painful and error-prone.
+Content-only wipe is the deliberate tradeoff.
+
+---
+
+## Setup (one-time)
+
+Add to `~/.claire/machine.yml`:
+
+```yaml
+fivepoints_test_repo: CLAIRE-Fivepoints/fivepoints
+```
+
+Without this key, `repo-reset` refuses to run — by design.
+
+---
+
+## Required env
+
+| Var | Scope | Purpose |
+|---|---|---|
+| `GITHUB_ADMIN_TOKEN` | required for `--confirm` | Token with `delete_repo` + `admin:org` scopes. Resolved from env or `~/.config/claire/github_manager.env`. |
+
+The admin token is distinct from the manager `GITHUB_TOKEN` because the
+GraphQL `deleteIssue` mutation and `DELETE /actions/runs/<id>` both require
+admin scope.
+
+---
+
+## Guardrails
+
+* **Refuses if `fivepoints_test_repo` is unset** in `machine.yml` → exit 2
+* **Refuses if the configured repo differs from the allowed repo** → exit 2
+  (Python re-checks what bash already passed, belt-and-suspenders.)
+* **Refuses `--confirm` without `GITHUB_ADMIN_TOKEN`** → exit 4
+* **Refuses to force-push `main` without a clean TFIOneGit clone** → exit 5
+  (The clone must have both an `origin` remote pointing at ADO and a `github`
+  remote pointing at the allowed repo.)
+* Every mutation is logged to `~/.claire/logs/repo-reset-<YYYYMMDD-HHMMSS>.log`
+
+---
+
+## Relationship to the per-PBI reset
+
+* **`reset-pbi`** — per-PBI scope. Cleans one PBI's branches, worktrees, PR,
+  agent comments, labels, and the issue's github-manager state.
+* **`repo-reset`** — whole-repo scope. Wipes everything and force-resets
+  `main` to ADO/<ref>.
+
+They compose by scope, not by chaining: `repo-reset` is what you run when
+you would otherwise `reset-pbi` every open PBI individually.
+
+---
+
+## Idempotency
+
+The delete operations (branches, tags, issues, releases, runs, PR comments)
+treat HTTP 404 as SKIP, not FAIL — rerunning `repo-reset --confirm` after a
+partial failure is safe.
+
+PR archive is a mutation, not a delete: a 404 there means the PR itself
+vanished (unusual), and is surfaced as a FAIL for investigation.
+
+---
+
+## Validation checks
+
+After `--confirm`:
+
+```bash
+# Zero issues remain
+gh issue list --repo $REPO --state all | wc -l   # -> 0
+
+# Only tombstone PRs remain
+gh pr list --repo $REPO --state all --json title \
+    --jq '[.[] | select(.title | startswith("[archived-repo-reset-")) | .] | length'
+# -> should equal total PR count
+
+# Only main remains
+gh api /repos/$REPO/branches --jq '[.[] | .name]'
+# -> ["main"]
+
+# main matches ADO/<ado-ref>
+git -C ~/TFIOneGit rev-parse origin/<ado-ref>
+git -C ~/TFIOneGit rev-parse github/main
+# -> same sha
+
+# Settings still present
+gh api /repos/$REPO/labels --jq 'length'        # > 0
+gh api /repos/$REPO/hooks --jq 'length'         # unchanged
+gh api /repos/$REPO/branches/main/protection    # still returns protection
+```
+
+---
+
+## Architecture
+
+* **Bash orchestrator** (`domain/commands/repo-reset.sh`) — flag parsing,
+  token resolution, machine.yml guardrail, `gh` inventory pre-fetch, git
+  force-push of `main`, hand-off to Python.
+* **Python logic** (`domain/scripts/repo_reset.py`) — builds and executes
+  the plan via the REST + GraphQL client (urllib only, no subprocess, per
+  DEV_RULES #2).
+
+Tests: `domain/scripts/tests/test_repo_reset.py` — plan building,
+guardrails, tombstone format, idempotent 404 handling.

--- a/domain/scripts/repo_reset.py
+++ b/domain/scripts/repo_reset.py
@@ -1,0 +1,608 @@
+"""
+repo_reset — Whole-repo factory reset for the fivepoints test mirror.
+
+Resets `CLAIRE-Fivepoints/fivepoints` (the TFI One GitHub mirror) to a clean
+state derived from ADO/<ref>, without deleting the repo itself. Settings
+(labels, branch protection, webhooks, Actions secrets, collaborators) are
+preserved; content (issues, PRs, branches, tags, releases, workflow runs)
+is wiped.
+
+The bash orchestrator (domain/commands/repo-reset.sh) owns:
+  * Force-pushing `main` to the ADO ref (via ~/TFIOneGit local clone)
+  * Pre-fetching the JSON inventories (branches, tags, issues, PRs, releases,
+    workflow runs) via `gh`
+  * The `fivepoints_test_repo` guardrail from machine.yml
+
+This Python module owns:
+  * Plan building from the pre-fetched inventories
+  * Plan execution via the REST + GraphQL clients (urllib only — no subprocess,
+    per DEV_RULES #2)
+
+PR deletion note: GitHub's API does not expose PR deletion (REST DELETE /pulls/N
+returns 404; no GraphQL mutation exists). Instead we strip the title and body
+into a `[archived-repo-reset-<iso>]` tombstone and close the PR, so agent
+searches (`gh pr list --search "PBI #18839"`) return zero matches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Shared with reset_pbi — authors whose PR/issue comments are considered
+# agent-authored and deleted as part of the wipe.
+AGENT_LOGINS = frozenset(
+    {
+        "claire-test-ai",
+        "claire-plugin-gatekeeper-ai",
+        "myclaire-ai",
+        "claire-gatekeeper-ai",
+    }
+)
+
+# 404 on any of these means the target is already gone — SKIP, not FAIL.
+IDEMPOTENT_DELETE_KINDS = frozenset(
+    {
+        "gh:branch-delete",
+        "gh:tag-delete",
+        "gh:release-delete",
+        "gh:run-delete",
+        "gh:pr-comment-delete",
+        "gh:issue-delete",
+    }
+)
+
+TOMBSTONE_BODY = (
+    "This PR was archived during a factory repo reset. "
+    "Original content is no longer authoritative."
+)
+
+
+def tombstone_title(timestamp_iso: str) -> str:
+    """Title for a strip+rename tombstone. Stable format — grepped by tests."""
+    return f"[archived-repo-reset-{timestamp_iso}]"
+
+
+# ---------------------------------------------------------------------------
+# Plan representation (same shape as reset_pbi.Plan / Action)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Action:
+    kind: str
+    describe: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Plan:
+    actions: list[Action] = field(default_factory=list)
+
+    def add(self, kind: str, describe: str, **payload: Any) -> None:
+        self.actions.append(Action(kind=kind, describe=describe, payload=payload))
+
+    def render(self) -> str:
+        if not self.actions:
+            return "  (no actions)"
+        return "\n".join(f"  [{a.kind}] {a.describe}" for a in self.actions)
+
+
+# ---------------------------------------------------------------------------
+# GitHub client (REST + GraphQL, urllib-based)
+# ---------------------------------------------------------------------------
+
+
+class GitHubClient:
+    """Authenticated REST + GraphQL client for repo-reset.
+
+    One client per run; the caller supplies a token with `delete_repo` and
+    `admin:org` scopes so the GraphQL `deleteIssue` mutation is authorized.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        repo: str,
+        *,
+        base_url: str = "https://api.github.com",
+    ):
+        if not token:
+            raise ValueError("GitHub admin token is required")
+        if "/" not in repo:
+            raise ValueError(f"repo must be 'owner/name', got {repo!r}")
+        self._token = token
+        self._repo = repo
+        self._owner, self._name = repo.split("/", 1)
+        self._base_url = base_url.rstrip("/")
+
+    # ---- low-level request helpers ----
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+    ) -> Any:
+        url = f"{self._base_url}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("Authorization", f"Bearer {self._token}")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if body is not None:
+            req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            raw = resp.read()
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw.decode(errors="replace")
+
+    def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self._base_url}/graphql"
+        body = json.dumps({"query": query, "variables": variables}).encode()
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("Authorization", f"Bearer {self._token}")
+        req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            raw = resp.read()
+        payload = json.loads(raw) if raw else {}
+        if payload.get("errors"):
+            # Surface GraphQL errors as HTTPError-like so the executor can
+            # classify them alongside REST failures.
+            messages = "; ".join(
+                e.get("message", "?") for e in payload["errors"]
+            )
+            raise urllib.error.HTTPError(
+                url=url,
+                code=422,
+                msg=f"GraphQL error: {messages}",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=None,
+            )
+        return payload.get("data", {})
+
+    # ---- refs (branches, tags) ----
+
+    def delete_branch(self, name: str) -> None:
+        # Ref name is URL-escaped only minimally; branches like feat/foo work
+        # without extra escaping because GitHub accepts slashes in the path.
+        self._request(
+            "DELETE", f"/repos/{self._repo}/git/refs/heads/{name}"
+        )
+
+    def delete_tag(self, name: str) -> None:
+        self._request(
+            "DELETE", f"/repos/{self._repo}/git/refs/tags/{name}"
+        )
+
+    # ---- issues ----
+
+    def delete_issue(self, node_id: str) -> None:
+        """GraphQL deleteIssue — admin token required."""
+        query = """
+        mutation($id: ID!) {
+            deleteIssue(input: {issueId: $id}) {
+                clientMutationId
+            }
+        }
+        """
+        self._graphql(query, {"id": node_id})
+
+    # ---- pulls ----
+
+    def archive_pr(self, pr_number: int, title: str, body: str) -> None:
+        """Strip-rename a PR into a tombstone and close it in a single call."""
+        self._request(
+            "PATCH",
+            f"/repos/{self._repo}/pulls/{pr_number}",
+            {"title": title, "body": body, "state": "closed"},
+        )
+
+    def delete_pr_issue_comment(self, comment_id: int) -> None:
+        """Delete a PR issue-comment (PR discussion comment, not review comment)."""
+        self._request(
+            "DELETE", f"/repos/{self._repo}/issues/comments/{comment_id}"
+        )
+
+    # ---- releases ----
+
+    def delete_release(self, release_id: int) -> None:
+        self._request(
+            "DELETE", f"/repos/{self._repo}/releases/{release_id}"
+        )
+
+    # ---- workflow runs ----
+
+    def delete_workflow_run(self, run_id: int) -> None:
+        self._request(
+            "DELETE", f"/repos/{self._repo}/actions/runs/{run_id}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Context + plan building
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Context:
+    repo: str
+    allowed_repo: str
+    keep_prs: bool
+    timestamp_iso: str
+    branches: list[str]          # non-main branch names
+    tags: list[str]              # tag names
+    issues: list[dict[str, Any]] # each: {number, node_id, title}
+    prs: list[dict[str, Any]]    # each: {number, state, title}
+    releases: list[dict[str, Any]]  # each: {id, tag_name}
+    workflow_runs: list[int]     # run ids
+    pr_comments: list[dict[str, Any]]  # each: {id, pr_number, author_login}
+
+
+def verify_repo_allowed(repo: str, allowed_repo: str) -> tuple[bool, str]:
+    """Guardrail — refuse to operate on anything other than the configured repo.
+
+    Returns (True, "") if allowed. On mismatch returns (False, reason).
+    """
+    if not allowed_repo:
+        return False, (
+            "machine.yml does not define 'fivepoints_test_repo' — "
+            "refusing to operate (configure it before running repo-reset)"
+        )
+    if repo != allowed_repo:
+        return False, (
+            f"repo {repo!r} is not the configured test repo "
+            f"(machine.yml:fivepoints_test_repo={allowed_repo!r}) — refusing"
+        )
+    return True, ""
+
+
+def is_agent_author(login: str) -> bool:
+    return login in AGENT_LOGINS
+
+
+def build_plan(ctx: Context) -> Plan:
+    """Compute the ordered reset plan for ``ctx``.
+
+    Order is chosen so that downstream cleanup doesn't invalidate upstream
+    references:
+      1. PR archive (while head branches still exist)
+      2. PR agent-comment cleanup
+      3. Issue delete (GraphQL)
+      4. Workflow run delete
+      5. Release delete
+      6. Tag delete
+      7. Branch delete (non-main; main is already force-pushed by bash)
+    """
+    plan = Plan()
+
+    # 1. PR strip + rename (unless --keep-prs)
+    if not ctx.keep_prs:
+        tombstone = tombstone_title(ctx.timestamp_iso)
+        for pr in ctx.prs:
+            plan.add(
+                "gh:pr-archive",
+                f"archive PR #{pr['number']} (was {pr.get('state', '?')}: "
+                f"{(pr.get('title') or '')[:50]!r}) -> {tombstone}",
+                pr_number=pr["number"],
+                title=tombstone,
+                body=TOMBSTONE_BODY,
+            )
+
+    # 2. PR agent-authored discussion comments (unless --keep-prs)
+    if not ctx.keep_prs:
+        for c in ctx.pr_comments:
+            if not is_agent_author(c.get("author_login", "")):
+                continue
+            plan.add(
+                "gh:pr-comment-delete",
+                f"delete PR #{c.get('pr_number', '?')} comment #{c['id']} "
+                f"by {c.get('author_login', '?')}",
+                comment_id=c["id"],
+            )
+
+    # 3. Issues — all of them (GraphQL deleteIssue)
+    for issue in ctx.issues:
+        plan.add(
+            "gh:issue-delete",
+            f"delete issue #{issue['number']}: "
+            f"{(issue.get('title') or '')[:60]!r}",
+            node_id=issue["node_id"],
+        )
+
+    # 4. Workflow runs
+    for run_id in ctx.workflow_runs:
+        plan.add(
+            "gh:run-delete",
+            f"delete workflow run {run_id}",
+            run_id=run_id,
+        )
+
+    # 5. Releases
+    for r in ctx.releases:
+        plan.add(
+            "gh:release-delete",
+            f"delete release '{r.get('tag_name', '?')}' (id={r['id']})",
+            release_id=r["id"],
+        )
+
+    # 6. Tags
+    for tag in ctx.tags:
+        plan.add("gh:tag-delete", f"delete tag {tag}", tag=tag)
+
+    # 7. Non-main branches
+    for branch in ctx.branches:
+        if branch == "main":
+            continue
+        plan.add(
+            "gh:branch-delete", f"delete branch {branch}", branch=branch
+        )
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Plan execution
+# ---------------------------------------------------------------------------
+
+
+def execute_plan(
+    plan: Plan, client: GitHubClient
+) -> list[str]:
+    """Execute every action. Returns per-action result strings.
+
+    Delete actions get idempotent 404 -> SKIP treatment (same pattern as
+    reset_pbi). Mutations (PR archive) do not — a 404 there means the target
+    is gone, which is a real error worth surfacing.
+    """
+    results: list[str] = []
+    for action in plan.actions:
+        try:
+            if action.kind == "gh:pr-archive":
+                client.archive_pr(
+                    action.payload["pr_number"],
+                    action.payload["title"],
+                    action.payload["body"],
+                )
+            elif action.kind == "gh:pr-comment-delete":
+                client.delete_pr_issue_comment(action.payload["comment_id"])
+            elif action.kind == "gh:issue-delete":
+                client.delete_issue(action.payload["node_id"])
+            elif action.kind == "gh:run-delete":
+                client.delete_workflow_run(action.payload["run_id"])
+            elif action.kind == "gh:release-delete":
+                client.delete_release(action.payload["release_id"])
+            elif action.kind == "gh:tag-delete":
+                client.delete_tag(action.payload["tag"])
+            elif action.kind == "gh:branch-delete":
+                client.delete_branch(action.payload["branch"])
+            else:
+                logger.warning("unknown action kind: %s", action.kind)
+                results.append(f"SKIP {action.kind}: unknown kind")
+                continue
+            results.append(f"OK   [{action.kind}] {action.describe}")
+        except urllib.error.HTTPError as e:
+            if e.code == 404 and action.kind in IDEMPOTENT_DELETE_KINDS:
+                results.append(
+                    f"SKIP [{action.kind}] {action.describe}: "
+                    f"already absent (HTTP 404)"
+                )
+                logger.info("action skipped (already absent): %s", action.describe)
+            else:
+                results.append(
+                    f"FAIL [{action.kind}] {action.describe}: "
+                    f"HTTP {e.code} {e.reason}"
+                )
+                logger.warning(
+                    "action failed: %s — HTTP %s", action.describe, e.code
+                )
+        except (urllib.error.URLError, OSError, ValueError, KeyError) as e:
+            results.append(
+                f"FAIL [{action.kind}] {action.describe}: "
+                f"{type(e).__name__}: {e}"
+            )
+            logger.warning("action failed: %s — %s", action.describe, e)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_json_arg(value: str | None, label: str) -> Any:
+    """Load JSON from ``value`` (literal string or '@path')."""
+    if value is None:
+        return None
+    if value.startswith("@"):
+        path = Path(value[1:])
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise SystemExit(f"could not read {label} JSON from {path}: {e}")
+    if value.strip() == "":
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"invalid {label} JSON: {e}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="repo_reset",
+        description=(
+            "Whole-repo factory reset for the fivepoints test mirror. "
+            "Called by domain/commands/repo-reset.sh."
+        ),
+    )
+    p.add_argument(
+        "--repo", required=True, help="GitHub repo in owner/name form"
+    )
+    p.add_argument(
+        "--allowed-repo",
+        required=True,
+        help="Expected repo (from machine.yml:fivepoints_test_repo) — guardrail",
+    )
+    p.add_argument(
+        "--log-file", type=Path, default=None, help="Path to reset log file"
+    )
+    p.add_argument(
+        "--branches-json",
+        default="[]",
+        help="JSON list or @path of non-main branch names",
+    )
+    p.add_argument(
+        "--tags-json", default="[]", help="JSON list or @path of tag names"
+    )
+    p.add_argument(
+        "--issues-json",
+        default="[]",
+        help="JSON list or @path of {number, node_id, title}",
+    )
+    p.add_argument(
+        "--prs-json",
+        default="[]",
+        help="JSON list or @path of {number, state, title}",
+    )
+    p.add_argument(
+        "--releases-json",
+        default="[]",
+        help="JSON list or @path of {id, tag_name}",
+    )
+    p.add_argument(
+        "--runs-json",
+        default="[]",
+        help="JSON list or @path of run ids (integers)",
+    )
+    p.add_argument(
+        "--pr-comments-json",
+        default="[]",
+        help="JSON list or @path of {id, pr_number, author_login}",
+    )
+    p.add_argument(
+        "--keep-prs",
+        action="store_true",
+        help="Skip PR strip+rename and PR comment cleanup",
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Print plan and exit")
+    mode.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Execute plan (destructive). Required for any real mutation.",
+    )
+    return p
+
+
+def _write_log(log_file: Path, lines: list[str]) -> None:
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_file, "a") as f:
+        for line in lines:
+            f.write(line + "\n")
+
+
+def _collect_context(args: argparse.Namespace) -> Context:
+    branches = _load_json_arg(args.branches_json, "branches-json") or []
+    tags = _load_json_arg(args.tags_json, "tags-json") or []
+    issues = _load_json_arg(args.issues_json, "issues-json") or []
+    prs = _load_json_arg(args.prs_json, "prs-json") or []
+    releases = _load_json_arg(args.releases_json, "releases-json") or []
+    runs = _load_json_arg(args.runs_json, "runs-json") or []
+    pr_comments = (
+        _load_json_arg(args.pr_comments_json, "pr-comments-json") or []
+    )
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    return Context(
+        repo=args.repo,
+        allowed_repo=args.allowed_repo,
+        keep_prs=args.keep_prs,
+        timestamp_iso=ts,
+        branches=[b for b in branches if b != "main"],
+        tags=list(tags),
+        issues=list(issues),
+        prs=list(prs),
+        releases=list(releases),
+        workflow_runs=[int(r) for r in runs],
+        pr_comments=list(pr_comments),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    args = _build_parser().parse_args(argv)
+
+    log_lines: list[str] = [
+        f"=== repo_reset repo={args.repo} allowed={args.allowed_repo} ==="
+    ]
+
+    ok, reason = verify_repo_allowed(args.repo, args.allowed_repo)
+    if not ok:
+        print(f"ERROR: {reason}", file=sys.stderr)
+        if args.log_file:
+            _write_log(args.log_file, log_lines + [f"ERROR: {reason}"])
+        return 2
+
+    token = os.environ.get("GITHUB_ADMIN_TOKEN", "")
+    if args.confirm and not token:
+        print(
+            "ERROR: --confirm requires GITHUB_ADMIN_TOKEN in the environment "
+            "(token must have delete_repo + admin:org scopes)",
+            file=sys.stderr,
+        )
+        return 4
+
+    ctx = _collect_context(args)
+    plan = build_plan(ctx)
+
+    print(f"=== repo_reset plan ({args.repo}) ===")
+    print(plan.render())
+    log_lines.append(f"[plan] {len(plan.actions)} action(s)")
+    log_lines.extend(f"  {a.kind}: {a.describe}" for a in plan.actions)
+
+    if args.dry_run:
+        print("\n[dry-run] no changes applied")
+        log_lines.append("mode: dry-run")
+        if args.log_file:
+            _write_log(args.log_file, log_lines)
+        return 0
+
+    client = GitHubClient(token, args.repo)
+    print("\n[confirm] executing plan...")
+    results = execute_plan(plan, client)
+    for r in results:
+        print(r)
+    log_lines.append("mode: confirm")
+    log_lines.extend(results)
+    if args.log_file:
+        _write_log(args.log_file, log_lines)
+
+    failures = [r for r in results if r.startswith("FAIL")]
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/domain/scripts/repo_reset.py
+++ b/domain/scripts/repo_reset.py
@@ -164,10 +164,20 @@ class GitHubClient:
         payload = json.loads(raw) if raw else {}
         if payload.get("errors"):
             # Surface GraphQL errors as HTTPError-like so the executor can
-            # classify them alongside REST failures.
-            messages = "; ".join(
-                e.get("message", "?") for e in payload["errors"]
-            )
+            # classify them alongside REST failures. GitHub returns 200 with
+            # errors[].type == "NOT_FOUND" when a node is already gone — map
+            # that to HTTPError(404) so IDEMPOTENT_DELETE_KINDS catches it
+            # the same way REST 404s are caught (rerun-friendly contract).
+            errors = payload["errors"]
+            messages = "; ".join(e.get("message", "?") for e in errors)
+            if any(e.get("type") == "NOT_FOUND" for e in errors):
+                raise urllib.error.HTTPError(
+                    url=url,
+                    code=404,
+                    msg=messages,
+                    hdrs=None,  # type: ignore[arg-type]
+                    fp=None,
+                )
             raise urllib.error.HTTPError(
                 url=url,
                 code=422,

--- a/domain/scripts/tests/test_repo_reset.py
+++ b/domain/scripts/tests/test_repo_reset.py
@@ -1,0 +1,358 @@
+"""Unit tests for repo_reset — guardrails, plan building, execution."""
+
+from __future__ import annotations
+
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+from repo_reset import (  # noqa: E402
+    AGENT_LOGINS,
+    TOMBSTONE_BODY,
+    Context,
+    Plan,
+    build_plan,
+    execute_plan,
+    is_agent_author,
+    tombstone_title,
+    verify_repo_allowed,
+)
+
+
+# ---------------------------------------------------------------------------
+# verify_repo_allowed — guardrail
+# ---------------------------------------------------------------------------
+
+
+def test_verify_repo_allowed_match() -> None:
+    ok, reason = verify_repo_allowed(
+        "CLAIRE-Fivepoints/fivepoints", "CLAIRE-Fivepoints/fivepoints"
+    )
+    assert ok is True
+    assert reason == ""
+
+
+def test_verify_repo_allowed_mismatch_refuses() -> None:
+    ok, reason = verify_repo_allowed(
+        "CLAIRE-Fivepoints/fivepoints", "CLAIRE-Fivepoints/other-repo"
+    )
+    assert ok is False
+    assert "not the configured test repo" in reason
+    assert "other-repo" in reason
+
+
+def test_verify_repo_allowed_empty_config_refuses() -> None:
+    ok, reason = verify_repo_allowed("CLAIRE-Fivepoints/fivepoints", "")
+    assert ok is False
+    assert "fivepoints_test_repo" in reason
+
+
+# ---------------------------------------------------------------------------
+# tombstone format
+# ---------------------------------------------------------------------------
+
+
+def test_tombstone_title_format_is_stable() -> None:
+    assert tombstone_title("20260419T235959Z") == (
+        "[archived-repo-reset-20260419T235959Z]"
+    )
+
+
+def test_tombstone_title_starts_with_archive_marker() -> None:
+    assert tombstone_title("whatever").startswith("[archived-repo-reset-")
+
+
+def test_tombstone_body_is_non_empty_and_non_authoritative() -> None:
+    # Agents searching for content won't match body tombstone text.
+    assert TOMBSTONE_BODY
+    assert "no longer authoritative" in TOMBSTONE_BODY
+
+
+# ---------------------------------------------------------------------------
+# is_agent_author — reuse of AGENT_LOGINS
+# ---------------------------------------------------------------------------
+
+
+def test_is_agent_author_known_agents() -> None:
+    for login in AGENT_LOGINS:
+        assert is_agent_author(login) is True
+
+
+def test_is_agent_author_human() -> None:
+    assert is_agent_author("andreoperez") is False
+    assert is_agent_author("") is False
+
+
+# ---------------------------------------------------------------------------
+# build_plan
+# ---------------------------------------------------------------------------
+
+
+def _mk_ctx(**overrides: object) -> Context:
+    defaults: dict[str, object] = {
+        "repo": "CLAIRE-Fivepoints/fivepoints",
+        "allowed_repo": "CLAIRE-Fivepoints/fivepoints",
+        "keep_prs": False,
+        "timestamp_iso": "20260419T235959Z",
+        "branches": [],
+        "tags": [],
+        "issues": [],
+        "prs": [],
+        "releases": [],
+        "workflow_runs": [],
+        "pr_comments": [],
+    }
+    defaults.update(overrides)
+    return Context(**defaults)  # type: ignore[arg-type]
+
+
+def test_build_plan_empty_when_repo_is_clean() -> None:
+    plan = build_plan(_mk_ctx())
+    assert plan.actions == []
+
+
+def test_build_plan_order_is_pr_comments_issues_runs_releases_tags_branches() -> None:
+    """Order matters: archive PRs before their head branches are deleted."""
+    ctx = _mk_ctx(
+        branches=["feature/x", "main", "hotfix/y"],
+        tags=["v1.0"],
+        issues=[{"number": 42, "node_id": "I_kw1", "title": "bug"}],
+        prs=[{"number": 10, "state": "OPEN", "title": "wip"}],
+        releases=[{"id": 99, "tag_name": "v1.0"}],
+        workflow_runs=[1001],
+        pr_comments=[
+            {"id": 555, "pr_number": 10, "author_login": "claire-test-ai"}
+        ],
+    )
+    plan = build_plan(ctx)
+    order = [a.kind for a in plan.actions]
+    # Every major kind appears at least once.
+    assert "gh:pr-archive" in order
+    assert "gh:pr-comment-delete" in order
+    assert "gh:issue-delete" in order
+    assert "gh:run-delete" in order
+    assert "gh:release-delete" in order
+    assert "gh:tag-delete" in order
+    assert "gh:branch-delete" in order
+    # PR archive must precede branch delete (head refs still exist at rename).
+    assert order.index("gh:pr-archive") < order.index("gh:branch-delete")
+    # Issues deleted before branches too (unrelated but cheap to verify).
+    assert order.index("gh:issue-delete") < order.index("gh:branch-delete")
+
+
+def test_build_plan_archives_prs_with_tombstone_title_and_body() -> None:
+    ctx = _mk_ctx(
+        prs=[
+            {"number": 7, "state": "OPEN", "title": "feat: codegen for PBI #18839"},
+            {"number": 8, "state": "CLOSED", "title": "old hotfix"},
+        ]
+    )
+    plan = build_plan(ctx)
+    archive = [a for a in plan.actions if a.kind == "gh:pr-archive"]
+    assert [a.payload["pr_number"] for a in archive] == [7, 8]
+    for a in archive:
+        assert a.payload["title"] == "[archived-repo-reset-20260419T235959Z]"
+        assert a.payload["body"] == TOMBSTONE_BODY
+
+
+def test_build_plan_keep_prs_skips_pr_archive_and_pr_comments() -> None:
+    ctx = _mk_ctx(
+        keep_prs=True,
+        prs=[{"number": 7, "state": "OPEN", "title": "wip"}],
+        pr_comments=[
+            {"id": 555, "pr_number": 7, "author_login": "claire-test-ai"}
+        ],
+        # Unrelated buckets must still run.
+        tags=["v1.0"],
+    )
+    plan = build_plan(ctx)
+    kinds = [a.kind for a in plan.actions]
+    assert "gh:pr-archive" not in kinds
+    assert "gh:pr-comment-delete" not in kinds
+    assert "gh:tag-delete" in kinds, "non-PR buckets still run under --keep-prs"
+
+
+def test_build_plan_skips_main_from_branches() -> None:
+    ctx = _mk_ctx(branches=["main", "feature/x", "main", "chore/y"])
+    plan = build_plan(ctx)
+    branch_actions = [a for a in plan.actions if a.kind == "gh:branch-delete"]
+    branches = [a.payload["branch"] for a in branch_actions]
+    assert "main" not in branches
+    assert set(branches) == {"feature/x", "chore/y"}
+
+
+def test_build_plan_filters_pr_comments_to_agent_authors_only() -> None:
+    ctx = _mk_ctx(
+        pr_comments=[
+            {"id": 1, "pr_number": 7, "author_login": "claire-test-ai"},
+            {"id": 2, "pr_number": 7, "author_login": "human-reviewer"},
+            {"id": 3, "pr_number": 7, "author_login": "myclaire-ai"},
+        ]
+    )
+    plan = build_plan(ctx)
+    ids = {
+        a.payload["comment_id"]
+        for a in plan.actions
+        if a.kind == "gh:pr-comment-delete"
+    }
+    assert ids == {1, 3}
+
+
+def test_build_plan_issue_delete_uses_node_id() -> None:
+    """GraphQL deleteIssue requires node_id, not the integer number."""
+    ctx = _mk_ctx(
+        issues=[
+            {"number": 42, "node_id": "I_kw1ABCD", "title": "bug"},
+            {"number": 43, "node_id": "I_kw1EFGH", "title": "feat"},
+        ]
+    )
+    plan = build_plan(ctx)
+    deletes = [a for a in plan.actions if a.kind == "gh:issue-delete"]
+    assert [a.payload["node_id"] for a in deletes] == ["I_kw1ABCD", "I_kw1EFGH"]
+
+
+# ---------------------------------------------------------------------------
+# execute_plan — idempotent 404 handling
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    """Test double for GitHubClient. Each method can be wired to raise."""
+
+    def __init__(
+        self,
+        raise_code: int | None = None,
+        raise_on: set[str] | None = None,
+    ):
+        self.raise_code = raise_code
+        self.raise_on = raise_on or set()
+        self.calls: list[tuple[str, tuple]] = []
+
+    def _maybe_raise(self, op: str) -> None:
+        if self.raise_code is not None and op in self.raise_on:
+            raise urllib.error.HTTPError(
+                url="https://api.github.com/test",
+                code=self.raise_code,
+                msg="Not Found" if self.raise_code == 404 else "Server Error",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=None,
+            )
+
+    def delete_branch(self, name: str) -> None:
+        self.calls.append(("delete_branch", (name,)))
+        self._maybe_raise("delete_branch")
+
+    def delete_tag(self, name: str) -> None:
+        self.calls.append(("delete_tag", (name,)))
+        self._maybe_raise("delete_tag")
+
+    def delete_issue(self, node_id: str) -> None:
+        self.calls.append(("delete_issue", (node_id,)))
+        self._maybe_raise("delete_issue")
+
+    def archive_pr(self, pr_number: int, title: str, body: str) -> None:
+        self.calls.append(("archive_pr", (pr_number, title, body)))
+        self._maybe_raise("archive_pr")
+
+    def delete_pr_issue_comment(self, comment_id: int) -> None:
+        self.calls.append(("delete_pr_issue_comment", (comment_id,)))
+        self._maybe_raise("delete_pr_issue_comment")
+
+    def delete_release(self, release_id: int) -> None:
+        self.calls.append(("delete_release", (release_id,)))
+        self._maybe_raise("delete_release")
+
+    def delete_workflow_run(self, run_id: int) -> None:
+        self.calls.append(("delete_workflow_run", (run_id,)))
+        self._maybe_raise("delete_workflow_run")
+
+
+def _plan_with(kind: str, **payload: object) -> Plan:
+    plan = Plan()
+    plan.add(kind, f"test {kind}", **payload)
+    return plan
+
+
+@pytest.mark.parametrize(
+    "kind,payload,method",
+    [
+        ("gh:branch-delete", {"branch": "feature/x"}, "delete_branch"),
+        ("gh:tag-delete", {"tag": "v1.0"}, "delete_tag"),
+        ("gh:issue-delete", {"node_id": "I_xyz"}, "delete_issue"),
+        ("gh:run-delete", {"run_id": 100}, "delete_workflow_run"),
+        ("gh:release-delete", {"release_id": 55}, "delete_release"),
+        ("gh:pr-comment-delete", {"comment_id": 9}, "delete_pr_issue_comment"),
+    ],
+)
+def test_execute_plan_404_on_idempotent_delete_is_skip(
+    kind: str, payload: dict, method: str
+) -> None:
+    """All delete actions: 404 -> SKIP (idempotent rerun friendly)."""
+    client = _FakeClient(raise_code=404, raise_on={method})
+    results = execute_plan(_plan_with(kind, **payload), client)  # type: ignore[arg-type]
+    assert len(results) == 1
+    assert results[0].startswith("SKIP "), f"expected SKIP, got: {results[0]}"
+    assert "already absent" in results[0] or "404" in results[0]
+
+
+def test_execute_plan_500_on_branch_delete_stays_fail() -> None:
+    client = _FakeClient(raise_code=500, raise_on={"delete_branch"})
+    results = execute_plan(
+        _plan_with("gh:branch-delete", branch="feature/x"), client  # type: ignore[arg-type]
+    )
+    assert len(results) == 1
+    assert results[0].startswith("FAIL ")
+    assert "500" in results[0]
+
+
+def test_execute_plan_404_on_pr_archive_stays_fail() -> None:
+    """PR archive is a mutation, not a delete — 404 means the PR vanished,
+    which is a real problem worth surfacing."""
+    plan = _plan_with(
+        "gh:pr-archive",
+        pr_number=7,
+        title="[archived-repo-reset-x]",
+        body=TOMBSTONE_BODY,
+    )
+    client = _FakeClient(raise_code=404, raise_on={"archive_pr"})
+    results = execute_plan(plan, client)  # type: ignore[arg-type]
+    assert len(results) == 1
+    assert results[0].startswith("FAIL ")
+
+
+def test_execute_plan_runs_every_action_in_order() -> None:
+    client = _FakeClient()
+    plan = Plan()
+    plan.add("gh:pr-archive", "pr 7", pr_number=7, title="t", body="b")
+    plan.add("gh:pr-comment-delete", "cmt 9", comment_id=9)
+    plan.add("gh:issue-delete", "iss 42", node_id="I_x")
+    plan.add("gh:run-delete", "run 1", run_id=1)
+    plan.add("gh:release-delete", "rel 5", release_id=5)
+    plan.add("gh:tag-delete", "tag v1", tag="v1")
+    plan.add("gh:branch-delete", "br x", branch="feature/x")
+    results = execute_plan(plan, client)  # type: ignore[arg-type]
+    assert all(r.startswith("OK ") for r in results), results
+    called = [c[0] for c in client.calls]
+    assert called == [
+        "archive_pr",
+        "delete_pr_issue_comment",
+        "delete_issue",
+        "delete_workflow_run",
+        "delete_release",
+        "delete_tag",
+        "delete_branch",
+    ]
+
+
+def test_execute_plan_unknown_kind_is_skip_not_fail() -> None:
+    client = _FakeClient()
+    plan = Plan()
+    plan.add("gh:unknown", "bogus")
+    results = execute_plan(plan, client)  # type: ignore[arg-type]
+    assert results[0].startswith("SKIP ")
+    assert "unknown kind" in results[0]

--- a/domain/scripts/tests/test_repo_reset.py
+++ b/domain/scripts/tests/test_repo_reset.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import sys
 import urllib.error
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +17,7 @@ from repo_reset import (  # noqa: E402
     AGENT_LOGINS,
     TOMBSTONE_BODY,
     Context,
+    GitHubClient,
     Plan,
     build_plan,
     execute_plan,
@@ -356,3 +359,131 @@ def test_execute_plan_unknown_kind_is_skip_not_fail() -> None:
     results = execute_plan(plan, client)  # type: ignore[arg-type]
     assert results[0].startswith("SKIP ")
     assert "unknown kind" in results[0]
+
+
+# ---------------------------------------------------------------------------
+# GraphQL NOT_FOUND idempotency — issue delete path
+#
+# The _FakeClient path above proves the executor classifies 404 as SKIP, but
+# it shortcuts past the real GitHubClient._graphql mapping. These tests
+# drive the real _graphql with a urlopen stub so the NOT_FOUND -> 404
+# contract is exercised end-to-end.
+# ---------------------------------------------------------------------------
+
+
+class _FakeUrlopen:
+    """Context-manager stub for urllib.request.urlopen.
+
+    Yields a response whose .read() returns the given body. The body is a
+    pre-serialized JSON string so tests can simulate any GitHub response.
+    """
+
+    def __init__(self, body: str):
+        self._body = body.encode()
+
+    def __call__(self, req, timeout=None):  # noqa: ARG002
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _graphql_not_found_payload() -> str:
+    """A GitHub GraphQL response for a node that no longer exists.
+
+    Real shape from the API — `errors[].type == "NOT_FOUND"` and HTTP 200.
+    """
+    return json.dumps(
+        {
+            "data": None,
+            "errors": [
+                {
+                    "type": "NOT_FOUND",
+                    "path": ["deleteIssue"],
+                    "message": "Could not resolve to a node with the global id of 'I_kwDOxxxxx'.",
+                }
+            ],
+        }
+    )
+
+
+def _graphql_other_error_payload() -> str:
+    """A GitHub GraphQL response for a non-idempotency error (e.g. bad scope)."""
+    return json.dumps(
+        {
+            "errors": [
+                {
+                    "type": "FORBIDDEN",
+                    "message": "Resource not accessible by integration",
+                }
+            ]
+        }
+    )
+
+
+def test_graphql_maps_not_found_to_http_404() -> None:
+    """NOT_FOUND -> HTTPError(404) so IDEMPOTENT_DELETE_KINDS catches it."""
+    client = GitHubClient("test-token", "owner/repo")
+    fake = _FakeUrlopen(_graphql_not_found_payload())
+    with patch("urllib.request.urlopen", fake):
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            client.delete_issue("I_kwDOxxxxx")
+    assert exc_info.value.code == 404, (
+        f"expected 404 (idempotent), got {exc_info.value.code}"
+    )
+
+
+def test_graphql_maps_other_errors_to_http_422() -> None:
+    """Non-NOT_FOUND GraphQL errors stay as 422 (real failure)."""
+    client = GitHubClient("test-token", "owner/repo")
+    fake = _FakeUrlopen(_graphql_other_error_payload())
+    with patch("urllib.request.urlopen", fake):
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            client.delete_issue("I_kwDOxxxxx")
+    assert exc_info.value.code == 422
+
+
+def test_execute_plan_graphql_not_found_on_issue_delete_is_skip() -> None:
+    """End-to-end: GraphQL NOT_FOUND on gh:issue-delete -> SKIP in execute_plan.
+
+    This is the test that would have caught the gatekeeper-flagged bug: the
+    _FakeClient version skipped the _graphql layer entirely.
+    """
+    client = GitHubClient("test-token", "owner/repo")
+    fake = _FakeUrlopen(_graphql_not_found_payload())
+    plan = Plan()
+    plan.add(
+        "gh:issue-delete",
+        "delete issue #42: 'gone'",
+        node_id="I_kwDOxxxxx",
+    )
+    with patch("urllib.request.urlopen", fake):
+        results = execute_plan(plan, client)
+    assert len(results) == 1
+    assert results[0].startswith("SKIP "), (
+        f"expected SKIP (idempotent rerun), got: {results[0]}"
+    )
+
+
+def test_execute_plan_graphql_forbidden_on_issue_delete_stays_fail() -> None:
+    """End-to-end: GraphQL FORBIDDEN stays FAIL (not a delete-idempotency case)."""
+    client = GitHubClient("test-token", "owner/repo")
+    fake = _FakeUrlopen(_graphql_other_error_payload())
+    plan = Plan()
+    plan.add(
+        "gh:issue-delete",
+        "delete issue #42: 'scope error'",
+        node_id="I_kwDOxxxxx",
+    )
+    with patch("urllib.request.urlopen", fake):
+        results = execute_plan(plan, client)
+    assert len(results) == 1
+    assert results[0].startswith("FAIL "), (
+        f"expected FAIL (real error), got: {results[0]}"
+    )

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -95,6 +95,10 @@ commands:
     script: "domain/commands/reset-pbi.sh"
     description: "Factory reset a single PBI (branches, worktrees, PR, agent comments, labels, state, release assets) so the pipeline can replay from zero"
 
+  - name: "fivepoints repo-reset"
+    script: "domain/commands/repo-reset.sh"
+    description: "Factory-reset the fivepoints test mirror — wipe content (issues, PRs, branches, tags, releases, runs) and strip+rename PRs into archive tombstones; repo settings preserved"
+
   - name: "fivepoints install-hooks"
     script: "domain/commands/install-hooks.sh"
     description: "Install TFI One pre-commit hook into TFIOneGit (branch naming, no GRANT/DENY, no d.ts, no biz logic tests)"


### PR DESCRIPTION
Closes #64

## Summary

New command `claire fivepoints repo-reset` that factory-resets the fivepoints test mirror (`CLAIRE-Fivepoints/fivepoints`) to a clean state derived from ADO/`<ref>`, without deleting the repo itself. Content is wiped; settings (labels, branch protection, webhooks, Actions secrets, collaborators) are preserved.

### What it wipes
1. `main` — force-pushed to `ADO/<ado-ref>` tip via `~/TFIOneGit` clone
2. Non-`main` branches (REST)
3. Tags (REST)
4. Issues (GraphQL `deleteIssue`, admin only)
5. Releases + assets (cascade)
6. Workflow runs (REST)
7. PRs — **strip + rename** into `[archived-repo-reset-<iso>]` tombstones, body replaced, state closed (skipped under `--keep-prs`)
8. Agent-authored PR discussion comments (skipped under `--keep-prs`)

### Why strip+rename instead of delete
GitHub has no PR delete API — `DELETE /pulls/<n>` returns 404 and no GraphQL `deletePullRequest` mutation exists. The tombstone neutralizes each PR so agent searches like `gh pr list --search "PBI #18839"` return zero matches. PR numbers remain as audit records; semantic signal is gone.

### Architecture (mirrors `reset-pbi`)
- **Bash** (`domain/commands/repo-reset.sh`) — flag parsing, token resolution, machine.yml guardrail, `gh` inventory fetch, git force-push of `main`, hand-off to Python.
- **Python** (`domain/scripts/repo_reset.py`) — plan build + execute via REST + GraphQL client (urllib only, no subprocess).
- Tests (`domain/scripts/tests/test_repo_reset.py`) — 25 tests: plan building, guardrails, tombstone format, idempotent 404 handling.
- Domain doc (`domain/operational/REPO_RESET.md`).

### Guardrails
- Refuses to run on any repo other than `machine.yml:fivepoints_test_repo` (exit 2)
- `--confirm` requires `GITHUB_ADMIN_TOKEN` with `delete_repo` + `admin:org` (exit 4)
- Force-push of `main` only from a clean TFIOneGit clone (exit 5)
- Delete actions: HTTP 404 → SKIP (idempotent rerun friendly)

### Setup (one-time, per REPO_RESET domain doc)
```yaml
# ~/.claire/machine.yml
fivepoints_test_repo: CLAIRE-Fivepoints/fivepoints
```

## Verification Log

Command: `bash domain/commands/repo-reset.sh --dry-run`
Context: `CLAIRE-Fivepoints/fivepoints` test repo, `GITHUB_TOKEN` from `~/.config/claire/github_manager.env`, no `GITHUB_ADMIN_TOKEN` (dry-run does not require it).

```
=== fivepoints repo-reset ===
Repo:       CLAIRE-Fivepoints/fivepoints
Mode:       dry-run
ADO ref:    dev
Keep PRs:   false
TFIOneGit:  /Users/andreperez/TFIOneGit
Log file:   /Users/andreperez/.claire/logs/repo-reset-20260419-194431.log

── Collecting inventories via gh...
  branches:      14
  tags:          1
  issues:        60
  PRs:           14
  releases:      2
  workflow runs: 1
  PR comments:   26

── main reset: CLAIRE-Fivepoints/fivepoints:main -> ADO/dev
  [dry-run] would force-push origin/dev -> github:main from /Users/andreperez/TFIOneGit

=== repo_reset plan (CLAIRE-Fivepoints/fivepoints) ===
  [gh:pr-archive] archive PR #69 (was CLOSED: 'feat: add Check 6 — No Orphan PermissionCode Enum ') -> [archived-repo-reset-20260419T234439Z]
  [gh:pr-archive] archive PR #68 (was CLOSED: 'feat: FDS 16.9 — Implement Adoptive Placement Hist') -> [archived-repo-reset-20260419T234439Z]
  ... (14 PR-archive actions total)
  [gh:pr-comment-delete] delete PR #69 comment #4210412770 by claire-test-ai
  [gh:pr-comment-delete] delete PR #68 comment #4128182938 by myclaire-ai
  ... (17 PR-comment-delete actions, filtered to AGENT_LOGINS only)
  [gh:issue-delete] delete issue #73: '1 - Code Gen (PBI #18841)'
  [gh:issue-delete] delete issue #72: '1 - Code Gen (PBI #18842)'
  ... (60 issue-delete actions)
  [gh:run-delete] delete workflow run <id>
  [gh:release-delete] delete release 'v1.0' (id=...)
  [gh:tag-delete] delete tag v1.0
  [gh:branch-delete] delete branch issue-66-adoptive-placement
  [gh:branch-delete] delete branch issue-61
  ... (14 branch-delete actions, 'main' excluded)

[dry-run] no changes applied

=== DRY RUN complete — no changes applied ===
```

### Guardrails dogfooded

Missing `fivepoints_test_repo` in machine.yml:
```
$ bash domain/commands/repo-reset.sh --dry-run
ERROR: machine.yml does not define 'fivepoints_test_repo'.

Add to ~/.claire/machine.yml:
    fivepoints_test_repo: CLAIRE-Fivepoints/fivepoints

Without this key, repo-reset refuses to run — by design.
(exit 2)
```

Missing mode:
```
$ bash domain/commands/repo-reset.sh
ERROR: one of --dry-run / --confirm is required
(exit 1)
```

### Tests

```
$ python3 -m pytest domain/scripts/tests/test_repo_reset.py -v
============================== 25 passed in 0.07s ==============================

$ python3 -m pytest domain/scripts/tests/ -v
============================== 58 passed in 0.10s ==============================  # 25 new + 33 reset_pbi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)