### PR TITLE
feat(pre-commit): block .fds-cache/ staging in TFIOneGit hooks

### DIFF
--- a/domain/commands/install-hooks.sh
+++ b/domain/commands/install-hooks.sh
@@ -38,8 +38,10 @@ show_help() {
     echo "    2. com.tfione.api.d.ts not staged"
     echo "    3. No GRANT/DENY in Flyway migrations"
     echo "    4. No business logic tests in com.tfione.service.test"
+    echo "    5. .fds-cache/ not staged (per-session FDS cache)"
     echo "  pre-push:"
-    echo "    5. Block push to origin (ADO) — use git push github instead"
+    echo "    6. Block push to origin (ADO) — use git push github instead"
+    echo "    7. .fds-cache/ not present in pushed commits (belt-and-suspenders)"
 }
 
 show_agent_help() {
@@ -62,9 +64,12 @@ A pre-commit hook at `.git/hooks/pre-commit` that enforces:
 2. com.tfione.api.d.ts must not be staged (generated file)
 3. No GRANT/DENY/role assignments in Flyway migrations
 4. No business logic tests in com.tfione.service.test
+5. Nothing under .fds-cache/ is staged (per-session FDS cache, PR #53)
 
 A pre-push hook at `.git/hooks/pre-push` that enforces:
-5. No push to origin (ADO) — the dev must use `git push github` only
+6. No push to origin (ADO) — the dev must use `git push github` only
+7. Nothing under .fds-cache/ appears in any pushed commit
+   (belt-and-suspenders for Check 5 in pre-commit)
 
 ## Target repos (auto-discovered)
 1. claire-labs/fivepoints   → local path from `claire repo list`
@@ -209,8 +214,10 @@ echo "    1. Branch naming:  feature/{id}-* or bugfix/{id}-*"
 echo "    2. Generated file: com.tfione.api.d.ts must not be staged"
 echo "    3. Migrations:     no GRANT/DENY/role permissions"
 echo "    4. Tests:          no business logic tests in service.test"
+echo "    5. FDS cache:      nothing under .fds-cache/ may be staged"
 echo "  pre-push:"
-echo "    5. Remote guard:   push to origin (ADO) is blocked"
+echo "    6. Remote guard:   push to origin (ADO) is blocked"
+echo "    7. FDS cache:      no pushed commit may touch .fds-cache/"
 echo ""
 echo "Results: $INSTALLED installed, $SKIPPED skipped, $FAILED failed"
 

--- a/domain/hooks/pre-commit
+++ b/domain/hooks/pre-commit
@@ -80,6 +80,20 @@ if [[ -n "$STAGED_TESTS" ]]; then
 fi
 
 # ─────────────────────────────────────────────────────────────
+# Check 5 — .fds-cache/ must not be staged
+# Rule: local FDS cache is per-session and must never be committed.
+#       Lives in ~/TFIOneGit/.fds-cache/<parent-pbi>/ (PR #53 fetch-on-use model).
+#       The TFIOneGit .gitignore is an ADO-mirrored file and cannot be modified
+#       without a cross-team ADO PR, so the guardrail lives here instead.
+# ─────────────────────────────────────────────────────────────
+if git diff --name-only --cached | grep -q "^\.fds-cache/"; then
+    ERRORS+=(".fds-cache/ must not be committed (per-session FDS cache, PR #53).")
+    ERRORS+=("  Fix: git restore --staged .fds-cache/")
+    ERRORS+=("  Why: the cache is fetched fresh from ADO on every session;")
+    ERRORS+=("       committing would freeze a stale snapshot and pollute the ADO mirror.")
+fi
+
+# ─────────────────────────────────────────────────────────────
 # Output results
 # ─────────────────────────────────────────────────────────────
 if [[ ${#ERRORS[@]} -gt 0 ]]; then

--- a/domain/hooks/pre-push
+++ b/domain/hooks/pre-push
@@ -18,7 +18,9 @@ set -euo pipefail
 REMOTE_NAME="$1"
 REMOTE_URL="$2"
 
-# Block any push to origin or to Azure DevOps URLs
+# ─────────────────────────────────────────────────────────────
+# Check 1 — Block any push to origin or to Azure DevOps URLs
+# ─────────────────────────────────────────────────────────────
 if [[ "$REMOTE_NAME" == "origin" ]] || \
    [[ "$REMOTE_URL" == *"visualstudio.com"* ]] || \
    [[ "$REMOTE_URL" == *"dev.azure.com"* ]]; then
@@ -38,5 +40,47 @@ if [[ "$REMOTE_NAME" == "origin" ]] || \
     echo ""
     exit 1
 fi
+
+# ─────────────────────────────────────────────────────────────
+# Check 2 — .fds-cache/ must not appear in any pushed commit
+# Rule: belt-and-suspenders for the pre-commit .fds-cache/ block. Catches
+#       commits that slipped through (hook bypassed with --no-verify, or hook
+#       missing/outdated from a bad install). PR #53 fetch-on-use model.
+# ─────────────────────────────────────────────────────────────
+ZERO="0000000000000000000000000000000000000000"
+
+while IFS=' ' read -r _local_ref local_sha _remote_ref remote_sha; do
+    # Branch deletion — nothing being pushed
+    if [[ "$local_sha" == "$ZERO" ]]; then
+        continue
+    fi
+
+    if [[ "$remote_sha" == "$ZERO" ]]; then
+        # New branch: inspect commits reachable from local_sha but not from
+        # any existing remote tracking ref (avoids re-scanning history).
+        range_args=("$local_sha" "--not" "--remotes")
+    else
+        # Existing branch: inspect the delta being pushed.
+        range_args=("$remote_sha..$local_sha")
+    fi
+
+    if git log "${range_args[@]}" --name-only --pretty=format: 2>/dev/null \
+        | grep -q "^\.fds-cache/"; then
+        echo ""
+        echo "╔══════════════════════════════════════════════════════════╗"
+        echo "║  🚫  TFI One Pre-Push Check FAILED                       ║"
+        echo "╚══════════════════════════════════════════════════════════╝"
+        echo ""
+        echo "  A commit in the push range touches .fds-cache/."
+        echo ""
+        echo "  Fix: remove the offending commit(s) before pushing."
+        echo "       Inspect with: git log ${range_args[*]} --name-only -- .fds-cache/"
+        echo ""
+        echo "  Why: .fds-cache/ is per-session (PR #53 fetch-on-use model);"
+        echo "       committing freezes a stale snapshot and pollutes the ADO mirror."
+        echo ""
+        exit 1
+    fi
+done
 
 exit 0


### PR DESCRIPTION
## Summary

Closes #68.

- Adds a new **Check 5** to `domain/hooks/pre-commit`: rejects any staged path under `.fds-cache/` so a stray `git add .` in `~/TFIOneGit` can't leak the per-session FDS cache into the ADO mirror.
- Adds a belt-and-suspenders **Check 2** to `domain/hooks/pre-push`: inspects the push range and rejects any commit that touches `.fds-cache/` (catches bypasses via `--no-verify` or a stale/missing hook install).
- Updates `domain/commands/install-hooks.sh` help output (`--help`, `--agent-help`, post-install summary) to advertise the new checks.

Why not just edit `.gitignore` in TFIOneGit? That file is an ADO mirror — changes go through a slow cross-team ADO PR. Keeping the guardrail in the plugin's hook keeps it inside Claire's control loop.

## Verification Log

Scratch repo with both hooks installed:

```
--- Test 1: normal file should PASS ---
✅ TFI One pre-commit checks passed.
TEST 1 PASSED: normal commit succeeded

--- Test 2: staging .fds-cache/ should BLOCK ---
🚫  TFI One Pre-Commit Check FAILED
  .fds-cache/ must not be committed (per-session FDS cache, PR #53).
    Fix: git restore --staged .fds-cache/
    Why: the cache is fetched fresh from ADO on every session;
         committing would freeze a stale snapshot and pollute the ADO mirror.
TEST 2 PASSED: commit rejected as expected

--- Test 3: after restoring .fds-cache/, commit should PASS ---
✅ TFI One pre-commit checks passed.
TEST 3 PASSED: commit succeeded after unstaging cache

--- Test 4: existing checks still fire (com.tfione.api.d.ts) ---
🚫  TFI One Pre-Commit Check FAILED
  com.tfione.api.d.ts must not be committed (generated file, in .gitignore).
TEST 4 PASSED: com.tfione.api.d.ts still blocked
```

Pre-push against a `--no-verify` bypass + remote guard:

```
--- Test A: normal push should SUCCEED ---
 * [new branch]      feature/68-test -> feature/68-test
TEST A PASSED

--- Test B: commit with .fds-cache/ (pre-commit bypassed), then push ---
🚫  TFI One Pre-Push Check FAILED
  A commit in the push range touches .fds-cache/.
  Fix: remove the offending commit(s) before pushing.
       Inspect with: git log <range> --name-only -- .fds-cache/
  Why: .fds-cache/ is per-session (PR #53 fetch-on-use model);
       committing freezes a stale snapshot and pollutes the ADO mirror.
TEST B PASSED

--- Test C: push to origin (ADO-style) should STILL block first (check 1) ---
TEST C PASSED: origin push still blocked

--- Test D: after removing the bad commit, push should succeed ---
TEST D PASSED
```

Command: hook files copied into `/tmp/<scratch>/.git/hooks/`, commits issued against a bare repo remote.
Context: fresh temp repo, plugin changes applied from this worktree (no install needed).

## Notes on scope

- Skipped the `install-hooks.sh` "warn on upgrade if the installed hook lacks Check 5" follow-up from the issue — the existing `*.bak.<timestamp>` rollback already preserves the prior hook, and the new check fires the first time anyone stages `.fds-cache/`. Happy to fold it in if the reviewer wants it here.
- `domain/operational/GIT_HOOKS.md` was intentionally **not** touched — it describes the in-repo `.githooks/` system of TFI One proper, not the plugin-installed `.git/hooks/` that this PR changes. Documentation for the plugin hooks lives inline in the hook files and in `install-hooks.sh --help`.