### PR TITLE
feat(persona): add Directive Interpretation step before FDS fetch (closes #70)

### DIFF
--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -22,6 +22,95 @@ updated: 2026-04-19
       claire domain read fivepoints operational PIPELINE_WORKFLOW
       claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
 - [ ] Read issue body (PBI reference, requirements)
+- [ ] 🎯 Directive Interpretation (MANDATORY — before FDS fetch, before any surface check):
+      Scan the PBI / issue body for **directive phrases** that constrain HOW the
+      work must be done. Triggers (non-exhaustive):
+        - "use X as your template"
+        - "follow the pattern of Y"
+        - "mirror the Z implementation"
+        - "align with the existing W module"
+        - "same structure as V"
+        - "inspired by Q"
+        - any reference to an existing sibling module/component/feature the PBI
+          points you at as a reference point
+
+      For each directive found, post an interpretation comment on the GitHub
+      issue BEFORE the FDS fetch, containing all 5 fields:
+
+        1. **Literal meaning** — the phrase, word-for-word
+        2. **Operational meaning** — what it means for code (structure? API shape?
+           file layout? lifecycle? permission gates? error handling?)
+        3. **Comparison target** — the exact file(s)/module(s) the directive
+           points at (`ls`, `git ls-tree`, or `claire reveal` output)
+        4. **Mandatory attributes** — 3–7 specific patterns from the comparison
+           target that MUST appear in the current work. Example for "use Provider
+           face sheet as template":
+             - `PermissionCode.<X>` permission gate on the root component
+             - Redux `set<Entity>` dispatch on successful load
+             - `skipToken` wrapping when permission denied
+             - Super-user bypass chain (`SUPER_USER_ROLE_CODE` + `permissionCheckBypass`)
+             - `matchPath` + `on<Entity>FaceSheetRoot` conditional render
+             - Fallback `<Alert severity="warning">` on permission denied
+             - Inline pending-documents banner (FDS rule)
+        5. **Verification plan** — the concrete grep/structural command that
+           proves match or divergence for each attribute
+
+      Use a heredoc with a flush-left `EOF` terminator:
+
+gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" --body "$(cat <<'EOF'
+**Directive Interpretation**
+- Literal meaning: "<exact phrase from PBI>"
+- Operational meaning: <what it means for code>
+- Comparison target: <file paths / modules>
+- Mandatory attributes:
+    1. <attribute 1 + short rationale>
+    2. <attribute 2 + short rationale>
+    3. <attribute 3 + short rationale>
+    ... (3 min, 7 max)
+- Verification plan:
+    - <attribute 1> → `<grep/command>`
+    - <attribute 2> → `<grep/command>`
+    - ...
+EOF
+)"
+
+      ⚠️ HARD STOP:
+        - No FDS fetch until the interpretation is posted (or the no-directive
+          line below is posted)
+        - No surface check (`ls`, `grep FDS label`) before the interpretation
+        - Existence ≠ conformity — existence checks are NOT valid until the
+          interpretation is on record
+
+      ⚠️ Ambiguity gate (ask, don't assume):
+        If a directive is present but you cannot confidently fill all 5 fields
+        (e.g. the comparison target is missing, the directive is vague, the
+        mandatory attributes could plausibly be 2 or 20 — you are guessing),
+        do NOT post a half-populated interpretation. Instead, run all three
+        of these — in order — before waiting:
+          1. Post ONE focused question on the issue:
+             gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
+               --body "**Directive Interpretation — needs clarification:**
+             Phrase: \"<exact directive phrase>\"
+             Ambiguity: <what you cannot decide confidently>
+             Options: <A / B / …>"
+          2. Ping Discord with the same question + the issue link
+             (owner notification — real-time; see persona-top Discord Ping Protocol):
+             claire discord send "Issue #<N> — Directive Interpretation ambiguous: <one-sentence summary>. Link: https://github.com/$CLAIRE_WAIT_REPO/issues/<N>"
+             ⚠️ If the disclosure guard blocks the URL (internal-reference
+                match), fall back to sending without the URL and note in the
+                message body that the link is in the GitHub comment.
+          3. Block on the response:
+             claire wait --issue <N>
+        Plausibility ≠ confirmation. One good question beats a fabricated
+        5-field block that downstream roles will trust. GitHub = audit trail,
+        Discord = real-time owner notification — both are mandatory on
+        ambiguity.
+
+      If the PBI has NO directive phrases, post the explicit line verbatim so
+      the absence is deliberate, not an oversight:
+          gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
+            --body "No directive phrases found — proceeding with standard analysis."
+
 - [ ] FDS fetch-on-use + manifest — download the fresh attachment, extract
       sections, emit the manifest you will quote in your receipt:
       ```bash

--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -12,6 +12,7 @@ Before doing ANY work, create all 11 checklist tasks so each step is auditable:
 
 ```
 TaskCreate(title="[1/11] Load context + read issue + checkout branch")
+TaskCreate(title="[1.25/11] Directive Interpretation — scan PBI for 'use X as template' / 'mirror Y' and post interpretation (or no-directive line) before FDS fetch")
 TaskCreate(title="[1.5/11] FDS Read + Scope Confirmation — read the FDS attached to the parent PBI yourself")
 TaskCreate(title="[2/11] [GATE-0] Baseline gates + deploy + verify feature does NOT yet exist")
 TaskCreate(title="[3/11] Implement requirements")
@@ -60,6 +61,108 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (issue stays open 
         to re-verify the analyst's receipt by hand — the gate does it for you.
       Reference: `claire domain read fivepoints operational ADO_ATTACHMENTS`
       → TaskUpdate(<task_1_id>, status="completed")
+
+- [ ] [1.25/11] 🎯 Directive Interpretation (MANDATORY — before [1.5/11] FDS fetch, before any surface check):
+      ⚠️  HARD STOP: Do NOT fetch the FDS, read the FDS, `ls`, or `grep` any
+          source file until this step is complete. Existence ≠ conformity —
+          a file that exists + a label that matches is NOT proof the work is
+          done if the PBI contained a directive asking for structural
+          conformity with a sibling module.
+
+      Why this step exists: on issue #71 the dev agent ran `ls face_sheet/*.tsx`
+      + `grep FDS labels` → found matches → concluded "nothing to do", and
+      missed 7 structural divergences between Client and Provider face sheets
+      (PermissionCode gate, Redux dispatch, skipToken, super-user bypass,
+      matchPath conditional, Alert fallback, pending-documents banner). The
+      directive "use Provider face sheet as template" was treated as
+      decoration when it was the contract.
+
+      Scan the PBI / issue body for **directive phrases** that constrain HOW
+      the work must be done. Triggers (non-exhaustive):
+        - "use X as your template"
+        - "follow the pattern of Y"
+        - "mirror the Z implementation"
+        - "align with the existing W module"
+        - "same structure as V"
+        - "inspired by Q"
+        - any reference to an existing sibling module/component/feature the PBI
+          points you at as a reference point
+
+      For each directive found, post an interpretation comment on the GitHub
+      issue BEFORE [1.5/11], containing all 5 fields:
+
+        1. **Literal meaning** — the phrase, word-for-word
+        2. **Operational meaning** — what it means for code (structure? API shape?
+           file layout? lifecycle? permission gates? error handling?)
+        3. **Comparison target** — the exact file(s)/module(s) the directive
+           points at (`ls`, `git ls-tree`, or `claire reveal` output)
+        4. **Mandatory attributes** — 3–7 specific patterns from the comparison
+           target that MUST appear in the current work. Example for "use Provider
+           face sheet as template":
+             - `PermissionCode.<X>` permission gate on the root component
+             - Redux `set<Entity>` dispatch on successful load
+             - `skipToken` wrapping when permission denied
+             - Super-user bypass chain (`SUPER_USER_ROLE_CODE` + `permissionCheckBypass`)
+             - `matchPath` + `on<Entity>FaceSheetRoot` conditional render
+             - Fallback `<Alert severity="warning">` on permission denied
+             - Inline pending-documents banner (FDS rule)
+        5. **Verification plan** — the concrete grep/structural command that
+           proves match or divergence for each attribute
+
+      Use a heredoc with a flush-left `EOF` terminator:
+
+gh issue comment <N> --body "$(cat <<'EOF'
+**Directive Interpretation (dev role)**
+- Literal meaning: "<exact phrase from PBI>"
+- Operational meaning: <what it means for code>
+- Comparison target: <file paths / modules>
+- Mandatory attributes:
+    1. <attribute 1 + short rationale>
+    2. <attribute 2 + short rationale>
+    3. <attribute 3 + short rationale>
+    ... (3 min, 7 max)
+- Verification plan:
+    - <attribute 1> → `<grep/command>`
+    - <attribute 2> → `<grep/command>`
+    - ...
+EOF
+)"
+
+      ⚠️ Ambiguity gate (ask, don't assume):
+        If a directive is present but you cannot confidently fill all 5 fields
+        (e.g. the comparison target is missing, the directive is vague, the
+        mandatory attributes could plausibly be 2 or 20 — you are guessing),
+        do NOT post a half-populated interpretation. Instead, run all three
+        of these — in order — before waiting:
+          1. Post ONE focused question on the issue:
+             gh issue comment <N> \
+               --body "**Directive Interpretation — needs clarification:**
+             Phrase: \"<exact directive phrase>\"
+             Ambiguity: <what you cannot decide confidently>
+             Options: <A / B / …>"
+          2. Ping Discord with the same question + the issue link
+             (owner notification — real-time; see persona-top Discord Ping Protocol):
+             claire discord send "Issue #<N> — Directive Interpretation ambiguous: <one-sentence summary>. Link: https://github.com/<owner>/<repo>/issues/<N>"
+             ⚠️ If the disclosure guard blocks the URL (internal-reference
+                match), fall back to sending without the URL and note in the
+                message body that the link is in the GitHub comment.
+          3. Block on the response:
+             claire wait --issue <N>
+        Plausibility ≠ confirmation. One good question beats a fabricated
+        5-field block that the [3/11] implementation step will treat as
+        contract. GitHub = audit trail, Discord = real-time owner
+        notification — both are mandatory on ambiguity.
+
+      If the PBI has NO directive phrases, post the explicit line verbatim so
+      the absence is deliberate, not an oversight:
+          gh issue comment <N> \
+            --body "No directive phrases found — proceeding with standard analysis."
+
+      ⚠️ The Mandatory attributes become the structural contract for [3/11]
+         (implementation). [9/11] AI-verification reads this comment and
+         checks each attribute in the shipped code — a missing attribute
+         fails verification.
+      → TaskUpdate(<task_1.25_id>, status="completed")
 
 - [ ] [1.5/11] 🚨 FDS Read + Scope Confirmation (MANDATORY — 10 minutes max, before any code):
       ⚠️  HARD STOP: Do NOT write code until this step is complete.

--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -95,6 +95,95 @@ Read this before starting — it has scope guard rules and detailed patterns.
       claire domain read fivepoints operational PIPELINE_WORKFLOW
       claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
 - [ ] Read issue body (PBI reference, requirements)
+- [ ] 🎯 Directive Interpretation (MANDATORY — before FDS fetch, before any surface check):
+      Scan the PBI / issue body for **directive phrases** that constrain HOW the
+      work must be done. Triggers (non-exhaustive):
+        - "use X as your template"
+        - "follow the pattern of Y"
+        - "mirror the Z implementation"
+        - "align with the existing W module"
+        - "same structure as V"
+        - "inspired by Q"
+        - any reference to an existing sibling module/component/feature the PBI
+          points you at as a reference point
+
+      For each directive found, post an interpretation comment on the GitHub
+      issue BEFORE the FDS fetch, containing all 5 fields:
+
+        1. **Literal meaning** — the phrase, word-for-word
+        2. **Operational meaning** — what it means for code (structure? API shape?
+           file layout? lifecycle? permission gates? error handling?)
+        3. **Comparison target** — the exact file(s)/module(s) the directive
+           points at (`ls`, `git ls-tree`, or `claire reveal` output)
+        4. **Mandatory attributes** — 3–7 specific patterns from the comparison
+           target that MUST appear in the current work. Example for "use Provider
+           face sheet as template":
+             - `PermissionCode.<X>` permission gate on the root component
+             - Redux `set<Entity>` dispatch on successful load
+             - `skipToken` wrapping when permission denied
+             - Super-user bypass chain (`SUPER_USER_ROLE_CODE` + `permissionCheckBypass`)
+             - `matchPath` + `on<Entity>FaceSheetRoot` conditional render
+             - Fallback `<Alert severity="warning">` on permission denied
+             - Inline pending-documents banner (FDS rule)
+        5. **Verification plan** — the concrete grep/structural command that
+           proves match or divergence for each attribute
+
+      Use a heredoc with a flush-left `EOF` terminator:
+
+gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" --body "$(cat <<'EOF'
+**Directive Interpretation**
+- Literal meaning: "<exact phrase from PBI>"
+- Operational meaning: <what it means for code>
+- Comparison target: <file paths / modules>
+- Mandatory attributes:
+    1. <attribute 1 + short rationale>
+    2. <attribute 2 + short rationale>
+    3. <attribute 3 + short rationale>
+    ... (3 min, 7 max)
+- Verification plan:
+    - <attribute 1> → `<grep/command>`
+    - <attribute 2> → `<grep/command>`
+    - ...
+EOF
+)"
+
+      ⚠️ HARD STOP:
+        - No FDS fetch until the interpretation is posted (or the no-directive
+          line below is posted)
+        - No surface check (`ls`, `grep FDS label`) before the interpretation
+        - Existence ≠ conformity — existence checks are NOT valid until the
+          interpretation is on record
+
+      ⚠️ Ambiguity gate (ask, don't assume):
+        If a directive is present but you cannot confidently fill all 5 fields
+        (e.g. the comparison target is missing, the directive is vague, the
+        mandatory attributes could plausibly be 2 or 20 — you are guessing),
+        do NOT post a half-populated interpretation. Instead, run all three
+        of these — in order — before waiting:
+          1. Post ONE focused question on the issue:
+             gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
+               --body "**Directive Interpretation — needs clarification:**
+             Phrase: \"<exact directive phrase>\"
+             Ambiguity: <what you cannot decide confidently>
+             Options: <A / B / …>"
+          2. Ping Discord with the same question + the issue link
+             (owner notification — real-time; see persona-top Discord Ping Protocol):
+             claire discord send "Issue #<N> — Directive Interpretation ambiguous: <one-sentence summary>. Link: https://github.com/$CLAIRE_WAIT_REPO/issues/<N>"
+             ⚠️ If the disclosure guard blocks the URL (internal-reference
+                match), fall back to sending without the URL and note in the
+                message body that the link is in the GitHub comment.
+          3. Block on the response:
+             claire wait --issue <N>
+        Plausibility ≠ confirmation. One good question beats a fabricated
+        5-field block that downstream roles will trust. GitHub = audit trail,
+        Discord = real-time owner notification — both are mandatory on
+        ambiguity.
+
+      If the PBI has NO directive phrases, post the explicit line verbatim so
+      the absence is deliberate, not an oversight:
+          gh issue comment <N> --repo "$CLAIRE_WAIT_REPO" \
+            --body "No directive phrases found — proceeding with standard analysis."
+
 - [ ] FDS fetch-on-use + manifest — download the fresh attachment, extract
       sections, emit the manifest you will quote in your receipt:
       ```bash

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -95,6 +95,7 @@ Before doing ANY work, create all 11 checklist tasks so each step is auditable:
 
 ```
 TaskCreate(title="[1/11] Load context + read issue + checkout branch")
+TaskCreate(title="[1.25/11] Directive Interpretation — scan PBI for 'use X as template' / 'mirror Y' and post interpretation (or no-directive line) before FDS fetch")
 TaskCreate(title="[1.5/11] FDS Read + Scope Confirmation — read the FDS attached to the parent PBI yourself")
 TaskCreate(title="[2/11] [GATE-0] Baseline gates + deploy + verify feature does NOT yet exist")
 TaskCreate(title="[3/11] Implement requirements")
@@ -143,6 +144,108 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (issue stays open 
         to re-verify the analyst's receipt by hand — the gate does it for you.
       Reference: `claire domain read fivepoints operational ADO_ATTACHMENTS`
       → TaskUpdate(<task_1_id>, status="completed")
+
+- [ ] [1.25/11] 🎯 Directive Interpretation (MANDATORY — before [1.5/11] FDS fetch, before any surface check):
+      ⚠️  HARD STOP: Do NOT fetch the FDS, read the FDS, `ls`, or `grep` any
+          source file until this step is complete. Existence ≠ conformity —
+          a file that exists + a label that matches is NOT proof the work is
+          done if the PBI contained a directive asking for structural
+          conformity with a sibling module.
+
+      Why this step exists: on issue #71 the dev agent ran `ls face_sheet/*.tsx`
+      + `grep FDS labels` → found matches → concluded "nothing to do", and
+      missed 7 structural divergences between Client and Provider face sheets
+      (PermissionCode gate, Redux dispatch, skipToken, super-user bypass,
+      matchPath conditional, Alert fallback, pending-documents banner). The
+      directive "use Provider face sheet as template" was treated as
+      decoration when it was the contract.
+
+      Scan the PBI / issue body for **directive phrases** that constrain HOW
+      the work must be done. Triggers (non-exhaustive):
+        - "use X as your template"
+        - "follow the pattern of Y"
+        - "mirror the Z implementation"
+        - "align with the existing W module"
+        - "same structure as V"
+        - "inspired by Q"
+        - any reference to an existing sibling module/component/feature the PBI
+          points you at as a reference point
+
+      For each directive found, post an interpretation comment on the GitHub
+      issue BEFORE [1.5/11], containing all 5 fields:
+
+        1. **Literal meaning** — the phrase, word-for-word
+        2. **Operational meaning** — what it means for code (structure? API shape?
+           file layout? lifecycle? permission gates? error handling?)
+        3. **Comparison target** — the exact file(s)/module(s) the directive
+           points at (`ls`, `git ls-tree`, or `claire reveal` output)
+        4. **Mandatory attributes** — 3–7 specific patterns from the comparison
+           target that MUST appear in the current work. Example for "use Provider
+           face sheet as template":
+             - `PermissionCode.<X>` permission gate on the root component
+             - Redux `set<Entity>` dispatch on successful load
+             - `skipToken` wrapping when permission denied
+             - Super-user bypass chain (`SUPER_USER_ROLE_CODE` + `permissionCheckBypass`)
+             - `matchPath` + `on<Entity>FaceSheetRoot` conditional render
+             - Fallback `<Alert severity="warning">` on permission denied
+             - Inline pending-documents banner (FDS rule)
+        5. **Verification plan** — the concrete grep/structural command that
+           proves match or divergence for each attribute
+
+      Use a heredoc with a flush-left `EOF` terminator:
+
+gh issue comment <N> --body "$(cat <<'EOF'
+**Directive Interpretation (dev role)**
+- Literal meaning: "<exact phrase from PBI>"
+- Operational meaning: <what it means for code>
+- Comparison target: <file paths / modules>
+- Mandatory attributes:
+    1. <attribute 1 + short rationale>
+    2. <attribute 2 + short rationale>
+    3. <attribute 3 + short rationale>
+    ... (3 min, 7 max)
+- Verification plan:
+    - <attribute 1> → `<grep/command>`
+    - <attribute 2> → `<grep/command>`
+    - ...
+EOF
+)"
+
+      ⚠️ Ambiguity gate (ask, don't assume):
+        If a directive is present but you cannot confidently fill all 5 fields
+        (e.g. the comparison target is missing, the directive is vague, the
+        mandatory attributes could plausibly be 2 or 20 — you are guessing),
+        do NOT post a half-populated interpretation. Instead, run all three
+        of these — in order — before waiting:
+          1. Post ONE focused question on the issue:
+             gh issue comment <N> \
+               --body "**Directive Interpretation — needs clarification:**
+             Phrase: \"<exact directive phrase>\"
+             Ambiguity: <what you cannot decide confidently>
+             Options: <A / B / …>"
+          2. Ping Discord with the same question + the issue link
+             (owner notification — real-time; see persona-top Discord Ping Protocol):
+             claire discord send "Issue #<N> — Directive Interpretation ambiguous: <one-sentence summary>. Link: https://github.com/<owner>/<repo>/issues/<N>"
+             ⚠️ If the disclosure guard blocks the URL (internal-reference
+                match), fall back to sending without the URL and note in the
+                message body that the link is in the GitHub comment.
+          3. Block on the response:
+             claire wait --issue <N>
+        Plausibility ≠ confirmation. One good question beats a fabricated
+        5-field block that the [3/11] implementation step will treat as
+        contract. GitHub = audit trail, Discord = real-time owner
+        notification — both are mandatory on ambiguity.
+
+      If the PBI has NO directive phrases, post the explicit line verbatim so
+      the absence is deliberate, not an oversight:
+          gh issue comment <N> \
+            --body "No directive phrases found — proceeding with standard analysis."
+
+      ⚠️ The Mandatory attributes become the structural contract for [3/11]
+         (implementation). [9/11] AI-verification reads this comment and
+         checks each attribute in the shipped code — a missing attribute
+         fails verification.
+      → TaskUpdate(<task_1.25_id>, status="completed")
 
 - [ ] [1.5/11] 🚨 FDS Read + Scope Confirmation (MANDATORY — 10 minutes max, before any code):
       ⚠️  HARD STOP: Do NOT write code until this step is complete.


### PR DESCRIPTION
## Summary

Adds a HARD STOP **Directive Interpretation** step to the fivepoints analyst and dev personas. The step forces the agent to scan PBIs for directive phrases (*"use X as your template"*, *"mirror Y"*, *"follow pattern of Z"*, …) and post a structured 5-field interpretation comment on the GitHub issue **before** any FDS fetch or surface check. Existence ≠ conformity: a file that exists + a label that matches is NOT proof the work is done when the PBI demands structural conformity with a sibling module.

Closes #70.

## Why this step exists

On `CLAIRE-Fivepoints/fivepoints#71`, the dev agent:
- Ran `ls components/client/face_sheet/*.tsx` + `grep FDS labels`
- Found matches
- Concluded *"nothing to do"*
- Missed **7 real divergences** between Client and Provider face sheets (`PermissionCode.ViewClient` gate, fallback `Alert`, super-user bypass, `skipToken`, Redux `setClient` dispatch, `matchPath` + `onFaceSheetRoot` conditional, pending-documents banner)

The directive *"Please use the facesheet implementation in the Provider section as your template"* was treated as decoration. It was the contract.

The new step makes this class of failure unreachable: the agent cannot run any surface check until the interpretation (or the explicit *"No directive phrases found"* line) is on record.

## Changes

| File | Change |
| --- | --- |
| `domain/operational/CHECKLIST_ANALYST.md` | New step inserted after *"Read issue body"*, before *"FDS fetch-on-use + manifest"* |
| `domain/persona/fivepoints-analyst.md` | Mirror of same step in the self-contained fat persona checklist |
| `domain/operational/CHECKLIST_DEV_PIPELINE.md` | New `[1.25/11]` step between `[1/11]` and `[1.5/11]` + TaskCreate line |
| `domain/persona/fivepoints-dev.md` | Mirror of `[1.25/11]` in the fat persona |

**Scope decisions** (confirmed on issue #70):
- Option **(b)** — analyst + dev, tester deferred. The original failure surfaced in a dev-role session (analyst pipeline is currently retired), so the dev persona needed the step just as much as the analyst persona.
- Insertion anchor: after *Read issue body*, before *FDS fetch* — the directive lives IN the issue body, so that's the first moment the agent has read the directive but not yet started surface analysis.

## Step content

- **6 directive-phrase triggers** (non-exhaustive): `use X as template`, `follow the pattern of Y`, `mirror Z`, `align with existing W`, `same structure as V`, `inspired by Q`, plus any reference to a sibling module/component used as a reference point.
- **5-field interpretation block**: literal meaning, operational meaning, comparison target, 3–7 mandatory attributes, per-attribute verification plan.
- **HARD STOP**: no FDS fetch, no `ls`, no `grep FDS label` before the interpretation is posted.
- **Ambiguity gate (ask, don't assume)** — if the mandatory attributes cannot be confidently derived, the step requires all three of:
  1. A focused question on the GitHub issue (audit trail)
  2. A `claire discord send` ping with the issue link (real-time owner notification — operator direction on issue #70)
  3. `claire wait --issue <N>` to block on the response
- **"No directive phrases found" line** when absent, so silence is deliberate, not an oversight.
- **Forward reference (dev only)**: the Mandatory attributes become the structural contract that `[3/11]` implementation must satisfy and `[9/11]` AI-verification will check.

## Verification Log

```
$ grep -n "Directive Interpretation" domain/operational/CHECKLIST_ANALYST.md \
                                       domain/persona/fivepoints-analyst.md \
                                       domain/operational/CHECKLIST_DEV_PIPELINE.md \
                                       domain/persona/fivepoints-dev.md
domain/operational/CHECKLIST_ANALYST.md:25:- [ ] 🎯 Directive Interpretation (MANDATORY — before FDS fetch, before any surface check):
domain/operational/CHECKLIST_ANALYST.md:61:**Directive Interpretation**
domain/operational/CHECKLIST_ANALYST.md:92:               --body "**Directive Interpretation — needs clarification:**
domain/operational/CHECKLIST_ANALYST.md:98:             claire discord send "Issue #<N> — Directive Interpretation ambiguous: ..."
domain/persona/fivepoints-analyst.md:98: <same>
domain/operational/CHECKLIST_DEV_PIPELINE.md:15: TaskCreate(title="[1.25/11] Directive Interpretation ...")
domain/operational/CHECKLIST_DEV_PIPELINE.md:65:- [ ] [1.25/11] 🎯 Directive Interpretation ...
domain/persona/fivepoints-dev.md:98:TaskCreate(title="[1.25/11] Directive Interpretation ...")
domain/persona/fivepoints-dev.md:148:- [ ] [1.25/11] 🎯 Directive Interpretation ...

$ git diff --stat HEAD~1
 domain/operational/CHECKLIST_ANALYST.md      |  89 +++++++++++++++++
 domain/operational/CHECKLIST_DEV_PIPELINE.md | 103 ++++++++++++++++++++
 domain/persona/fivepoints-analyst.md         |  89 +++++++++++++++++
 domain/persona/fivepoints-dev.md             | 103 ++++++++++++++++++
 4 files changed, 384 insertions(+)
```

Context: documentation-only change inside the plugin repo. No CLI command, no Python module, no migration. The gatekeeper reviewer (Claire Gatekeeper on plugin repos) will validate the checklist ordering and the step's anchor against `CHECKLIST_DEV_PIPELINE.md` / `fivepoints-dev.md`.

## Validation plan (from issue #70)

- [ ] Spawn a session on a PBI with *"use <X> as template"* → agent posts the interpretation comment BEFORE the FDS fetch
- [ ] Interpretation lists 3–7 mandatory attributes + a concrete verification command for each
- [ ] Spawn on a PBI with no such directive → agent posts *"No directive phrases found — proceeding with standard analysis."*
- [ ] Structural comparison surfaces divergences that surface checks would have missed
- [ ] Ambiguity case → agent posts a focused question + Discord ping + `claire wait` (never a half-populated interpretation)

These are deferred to real-pipeline dogfooding — there's no offline harness that can reproduce an analyst/dev session spawn in this repo.