### PR TITLE
fix(persona): remove vestigial SESSION_CHECKLIST doc line from fat personas (#75)

### DIFF
--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -64,8 +64,7 @@ claire domain read fivepoints knowledge ANALYST_PERSONA
 Read this before starting — it has scope guard rules and detailed patterns.
 
 > **Your session checklist is embedded below** (canonical content from
-> `operational/CHECKLIST_ANALYST`). Follow it in order — this fat persona is
-> self-contained, the generator no longer needs to substitute `{{SESSION_CHECKLIST}}` separately.
+> `operational/CHECKLIST_ANALYST`). Follow it in order.
 
 ### You DO NOT
 - Write code or implement anything

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -9,8 +9,7 @@ updated: 2026-04-19
 ## Persona: Five Points Developer
 
 > **Your session checklist is embedded below** (canonical content from
-> `operational/CHECKLIST_DEV_PIPELINE`). Follow it in order — this fat persona is
-> self-contained, the generator no longer needs to substitute `{{SESSION_CHECKLIST}}` separately.
+> `operational/CHECKLIST_DEV_PIPELINE`). Follow it in order.
 
 
 ### Distrust-by-Default on Analyst Specs (HARD RULE)

--- a/domain/persona/fivepoints-tester.md
+++ b/domain/persona/fivepoints-tester.md
@@ -13,8 +13,7 @@ updated: 2026-04-13
 > You work in an ISOLATED copy of the branch.
 
 > **Your session checklist is embedded below** (canonical content from
-> `operational/CHECKLIST_TESTER`). Follow it in order — this fat persona is
-> self-contained, the generator no longer needs to substitute `{{SESSION_CHECKLIST}}` separately.
+> `operational/CHECKLIST_TESTER`). Follow it in order.
 
 ### When You Need to Block — Discord Ping Protocol (GLOBAL)
 


### PR DESCRIPTION
## Summary

Remove the vestigial documentation sentence referencing the template variable in all three fat personas (`fivepoints-analyst.md`, `fivepoints-dev.md`, `fivepoints-tester.md`). The sentence was a relic of the fat-persona migration — operational no-op — and caused CLAUDE.md validation failures when adjacent inline code spans made the backtick-strip regex leave the placeholder exposed.

## Verification

```
$ grep -rn SESSION_CHECKLIST domain/persona/
(clean — no matches)
```

Each persona loses the "— this fat persona is self-contained, …" trailer while keeping "Your session checklist is embedded below. Follow it in order."

Unblocked today's manual spawn for this very issue (which itself was blocked by the same validation bug on its own body).

Closes #75.