### PR TITLE
fix(dev-pipeline): enforce [8/11] MP4 + [9/11] FDS Verification HARD STOPs

### DIFF
--- a/domain/commands/ado-push.sh
+++ b/domain/commands/ado-push.sh
@@ -176,8 +176,13 @@ if [[ ! "$BRANCH" =~ ^(feature|bugfix)/[0-9]+-. ]]; then
 fi
 
 # Detect repo for GitHub issue operations (must be defined before the proof gate).
-# Override by setting CLAIRE_WAIT_REPO in the environment.
-GH_REPO="${CLAIRE_WAIT_REPO:-CLAIRE-Fivepoints/fivepoints-test}"
+# Single source of truth shared with ado-transition.sh — see resolve_gh_repo
+# in ado_common.sh. Override by setting CLAIRE_WAIT_REPO.
+GH_REPO=$(resolve_gh_repo "CLAIRE-Fivepoints/fivepoints-test") || {
+    echo "❌  Cannot determine GitHub repo for proof gate." >&2
+    echo "    Set CLAIRE_WAIT_REPO=<owner/name> or run from inside the GitHub repo clone." >&2
+    exit 1
+}
 
 # HARD GATE: Both [8/11] MP4 and [9/11] FDS Verification proof must be posted on
 # the issue before ADO push. Shared check_proof_gate (in ado_common.sh) emits

--- a/domain/commands/ado-push.sh
+++ b/domain/commands/ado-push.sh
@@ -179,36 +179,15 @@ fi
 # Override by setting CLAIRE_WAIT_REPO in the environment.
 GH_REPO="${CLAIRE_WAIT_REPO:-CLAIRE-Fivepoints/fivepoints-test}"
 
-# HARD GATE: Proof must be posted in the GitHub issue before ADO push.
-# Tester must have run `claire proof record --project fivepoints` AND posted
-# the .mp4 path in the GitHub issue comment. This is verified by checking
-# the issue comments for a .mp4 link — tying proof to this specific issue.
+# HARD GATE: Both [8/11] MP4 and [9/11] FDS Verification proof must be posted on
+# the issue before ADO push. Shared check_proof_gate (in ado_common.sh) emits
+# step-named rejection messages so the dev sees exactly which checklist step
+# was skipped, and references the Discord Ping Protocol as the correct fallback.
 echo "Checking proof evidence in GitHub issue #${ISSUE_NUMBER}..."
 
-PROOF_FOUND=false
-PROOF_COMMENT=$(gh issue view "$ISSUE_NUMBER" --repo "$GH_REPO" --json comments \
-    --jq '[.comments[].body | select(contains(".mp4"))] | first // ""' \
-    2>/dev/null || echo "")
-
-if [[ -n "$PROOF_COMMENT" ]]; then
-    PROOF_FOUND=true
-fi
-
-if [[ "$PROOF_FOUND" != "true" ]]; then
-    echo "❌ HARD GATE: No MP4 proof found in GitHub issue #${ISSUE_NUMBER}." >&2
-    echo "" >&2
-    echo "The tester must record proof AND post the .mp4 path in the issue:" >&2
-    echo "" >&2
-    echo "  1. Record proof: claire domain search video mp4  (see recording instructions)" >&2
-    echo "  2. Post the .mp4 path in the issue (this is a real gh command):" >&2
-    echo "       gh issue comment ${ISSUE_NUMBER} --repo ${GH_REPO} --body 'Proof: /path/to/proof.mp4'" >&2
-    echo "  3. Re-run: claire fivepoints ado-push --issue ${ISSUE_NUMBER}" >&2
-    echo "" >&2
-    echo "❌ fivepoints ado-push requires .mp4 proof posted in issue #${ISSUE_NUMBER}." >&2
+if ! check_proof_gate "$ISSUE_NUMBER" "$GH_REPO"; then
     exit 1
 fi
-
-echo "✅ Proof verified: .mp4 evidence found in issue #${ISSUE_NUMBER} comments"
 echo ""
 
 # Install ERR trap now that ISSUE_NUMBER and GH_REPO are both known.

--- a/domain/commands/ado-transition.sh
+++ b/domain/commands/ado-transition.sh
@@ -132,12 +132,11 @@ echo "✅  Branch OK: $BRANCH"
 echo ""
 echo "[2/4] Proof gate (MP4 + FDS Verification comments on issue #${ISSUE_NUMBER})..."
 
-GH_REPO="${CLAIRE_WAIT_REPO:-$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")}"
-if [[ -z "$GH_REPO" ]]; then
+GH_REPO=$(resolve_gh_repo "CLAIRE-Fivepoints/fivepoints-test") || {
     echo "❌  Cannot determine GitHub repo for proof gate." >&2
     echo "    Set CLAIRE_WAIT_REPO=<owner/name> or run from inside the GitHub repo clone." >&2
     exit 1
-fi
+}
 
 if ! check_proof_gate "$ISSUE_NUMBER" "$GH_REPO"; then
     exit 1

--- a/domain/commands/ado-transition.sh
+++ b/domain/commands/ado-transition.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 # fivepoints ado-transition — PAT-gated ADO push for dev role
 #
 # Bash orchestration:
-#   [1/3] Verify feature branch (naming convention)
-#   [2/3] PAT gate — request AZURE_DEVOPS_WRITE_PAT if not set
-#   [3/3] Set up ADO remote + git push, then call ado_agent.py (build agent)
+#   [1/4] Verify feature branch (naming convention)
+#   [2/4] Proof gate — MP4 ([8/11]) + FDS Verification ([9/11]) on the issue
+#   [3/4] PAT gate — request AZURE_DEVOPS_WRITE_PAT if not set
+#   [4/4] Set up ADO remote + git push, then call ado_agent.py (build agent)
 #
 # Usage:
 #   claire fivepoints ado-transition --issue <N> [--branch <name>] [--target <branch>]
@@ -25,9 +26,10 @@ Usage: claire fivepoints ado-transition --issue <N> [--branch <name>] [--target 
 
 PAT-gated transition from dev to ADO. Bash orchestration + Python build agent.
 
-  [1/3] Verify feature branch (feature/XXXXX-description or bugfix/XXXXX-description)
-  [2/3] PAT gate — pause and wait for AZURE_DEVOPS_WRITE_PAT if not set
-  [3/3] Set up ADO remote + git push + call ado_agent.py (build verification agent)
+  [1/4] Verify feature branch (feature/XXXXX-description or bugfix/XXXXX-description)
+  [2/4] Proof gate — verify MP4 ([8/11]) and FDS Verification ([9/11]) comments on the issue
+  [3/4] PAT gate — pause and wait for AZURE_DEVOPS_WRITE_PAT if not set
+  [4/4] Set up ADO remote + git push + call ado_agent.py (build verification agent)
 
 Options:
   --issue <N>       GitHub issue number (required)
@@ -55,8 +57,9 @@ after ALL FDS sections are tested and proved on video.
 
 ## Checklist (printed at runtime)
 1. Verify branch naming convention
-2. PAT gate: request AZURE_DEVOPS_WRITE_PAT if not set (posts wait comment on issue)
-3. Initialize ADO connection + git push + call ado_agent.py agent
+2. Proof gate: verify MP4 + FDS Verification comments on the issue (HARD STOPs from dev checklist)
+3. PAT gate: request AZURE_DEVOPS_WRITE_PAT if not set (posts wait comment on issue)
+4. Initialize ADO connection + git push + call ado_agent.py agent
 
 ## Usage
 ```bash
@@ -105,9 +108,9 @@ echo "╚═══════════════════════�
 echo ""
 
 # ─────────────────────────────────────────────
-# [1/3] Verify feature branch
+# [1/4] Verify feature branch
 # ─────────────────────────────────────────────
-echo "[1/3] Verifying feature branch..."
+echo "[1/4] Verifying feature branch..."
 echo "      Branch: $BRANCH"
 
 if ! echo "$BRANCH" | grep -qE '^(feature|bugfix)/[0-9]+-'; then
@@ -124,10 +127,27 @@ fi
 echo "✅  Branch OK: $BRANCH"
 
 # ─────────────────────────────────────────────
-# [2/3] PAT gate
+# [2/4] Proof gate — MP4 ([8/11]) + FDS Verification ([9/11])
 # ─────────────────────────────────────────────
 echo ""
-echo "[2/3] PAT gate (checking AZURE_DEVOPS_WRITE_PAT)..."
+echo "[2/4] Proof gate (MP4 + FDS Verification comments on issue #${ISSUE_NUMBER})..."
+
+GH_REPO="${CLAIRE_WAIT_REPO:-$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")}"
+if [[ -z "$GH_REPO" ]]; then
+    echo "❌  Cannot determine GitHub repo for proof gate." >&2
+    echo "    Set CLAIRE_WAIT_REPO=<owner/name> or run from inside the GitHub repo clone." >&2
+    exit 1
+fi
+
+if ! check_proof_gate "$ISSUE_NUMBER" "$GH_REPO"; then
+    exit 1
+fi
+
+# ─────────────────────────────────────────────
+# [3/4] PAT gate
+# ─────────────────────────────────────────────
+echo ""
+echo "[3/4] PAT gate (checking AZURE_DEVOPS_WRITE_PAT)..."
 
 if [[ -z "${AZURE_DEVOPS_WRITE_PAT:-}" ]]; then
     echo ""
@@ -156,10 +176,10 @@ fi
 echo "✅  AZURE_DEVOPS_WRITE_PAT set."
 
 # ─────────────────────────────────────────────
-# [3/3] ADO remote setup + git push + transition agent
+# [4/4] ADO remote setup + git push + transition agent
 # ─────────────────────────────────────────────
 echo ""
-echo "[3/3] Setting up ADO remote and pushing branch..."
+echo "[4/4] Setting up ADO remote and pushing branch..."
 
 # Initialize ADO connection (must run from TFIOneGit clone)
 CLIENT_REPO_PATH="${FIVEPOINTS_REPO_PATH:-/Users/andreperez/TFIOneGit}"

--- a/domain/commands/test-env-start.sh
+++ b/domain/commands/test-env-start.sh
@@ -141,26 +141,59 @@ echo "[3/4] Starting frontend..."
 (cd com.tfione.web && npm run dev > /tmp/tfione-vite.log 2>&1) &
 VITE_PID=$!
 
-echo "[4/4] Waiting for services..."
+echo "[4/4] Waiting for services (heartbeat every 15s)..."
+# Heartbeat loop: poll all three services at 2s intervals, print a status line
+# every 15s. Silence for >30s previously looked identical to "script crashed" —
+# the heartbeat makes booting vs. hung vs. failed unambiguous.
 API_READY=false
-for i in $(seq 1 30); do
-    if curl -sk "https://localhost:58337/swagger/index.html" > /dev/null 2>&1; then
-        API_READY=true
-        break
-    fi
-    sleep 2
-done
-[[ "$API_READY" != "true" ]] && echo "⚠️  API not ready after 60s — check /tmp/tfione-api.log"
-
 VITE_READY=false
-for i in $(seq 1 15); do
-    if curl -sk "https://localhost:5173" > /dev/null 2>&1 || curl -sk "http://localhost:5173" > /dev/null 2>&1; then
-        VITE_READY=true
+SQL_READY=false
+WAIT_DEADLINE=60   # seconds — same as previous max for the API
+START_TS=$(date +%s)
+LAST_HEARTBEAT=$START_TS
+
+probe_sql() {
+    docker ps --filter 'name=^tfione-sqlserver$' --filter 'status=running' --format '{{.Names}}' \
+        | grep -q '^tfione-sqlserver$'
+}
+probe_api() {
+    curl -sk "https://localhost:58337/swagger/index.html" > /dev/null 2>&1
+}
+probe_vite() {
+    curl -sk "https://localhost:5173" > /dev/null 2>&1 \
+        || curl -sk "http://localhost:5173" > /dev/null 2>&1
+}
+
+status_word() { [[ "$1" == "true" ]] && echo up || echo down; }
+
+while :; do
+    NOW=$(date +%s)
+    ELAPSED=$((NOW - START_TS))
+
+    if probe_sql; then SQL_READY=true; else SQL_READY=false; fi
+    if [[ "$API_READY" != "true" ]] && probe_api; then API_READY=true; fi
+    if [[ "$VITE_READY" != "true" ]] && probe_vite; then VITE_READY=true; fi
+
+    if [[ "$API_READY" == "true" && "$VITE_READY" == "true" ]]; then
         break
+    fi
+    if [[ $ELAPSED -ge $WAIT_DEADLINE ]]; then
+        break
+    fi
+
+    if (( NOW - LAST_HEARTBEAT >= 15 )); then
+        printf '  [%ds] booting: sqlserver=%s api=%s vite=%s\n' \
+            "$ELAPSED" \
+            "$(status_word "$SQL_READY")" \
+            "$(status_word "$API_READY")" \
+            "$(status_word "$VITE_READY")"
+        LAST_HEARTBEAT=$NOW
     fi
     sleep 2
 done
-[[ "$VITE_READY" != "true" ]] && echo "⚠️  Vite not ready after 30s — check /tmp/tfione-vite.log"
+
+[[ "$API_READY" != "true" ]] && echo "⚠️  API not ready after ${WAIT_DEADLINE}s — check /tmp/tfione-api.log"
+[[ "$VITE_READY" != "true" ]] && echo "⚠️  Vite not ready after ${WAIT_DEADLINE}s — check /tmp/tfione-vite.log"
 
 echo ""
 echo "✅ Environment ready"

--- a/domain/commands/test-env-start.sh
+++ b/domain/commands/test-env-start.sh
@@ -192,7 +192,8 @@ while :; do
     sleep 2
 done
 
-[[ "$API_READY" != "true" ]] && echo "⚠️  API not ready after ${WAIT_DEADLINE}s — check /tmp/tfione-api.log"
+[[ "$SQL_READY"  != "true" ]] && echo "⚠️  SQL Server not ready after ${WAIT_DEADLINE}s — docker container did not reach 'running' state"
+[[ "$API_READY"  != "true" ]] && echo "⚠️  API not ready after ${WAIT_DEADLINE}s — check /tmp/tfione-api.log"
 [[ "$VITE_READY" != "true" ]] && echo "⚠️  Vite not ready after ${WAIT_DEADLINE}s — check /tmp/tfione-vite.log"
 
 echo ""

--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -293,12 +293,25 @@ EOF
          Test in the same worktree you implemented in. Steven Reviewer rejects
          PRs containing test artifacts, which is the guard against test
          pollution (previously achieved by the isolated-worktree boundary).
-      ./scripts/test-env-start.sh
+      claire fivepoints test-env-start  (or ./scripts/test-env-start.sh)
+      → Heartbeat fires every 15s during boot:
+        `[15s] booting: sqlserver=up api=down vite=down`
+        Silence for >30s means the script crashed (no heartbeat = no progress).
       → Wait for "✅ Environment ready — API: https://localhost:58337 | UI: http://localhost:5173"
       → If script missing: start SQL Server, dotnet run, and npm run dev manually
       ⚠️ Any test code you write (e2e specs, fixtures, Playwright projects)
          must live OUTSIDE the feature branch. Use `~/.claire/scratch/tests/<issue-N>/`
          or a `.gitignored` local path — NEVER commit them to the feature branch.
+
+      🚨 If test-env fails or times out (heartbeat shows api/vite stuck on `down`,
+         or no heartbeat = script crashed): you may NOT skip [8/11] or [9/11] as
+         a workaround. Static code analysis is NOT a substitute for a running
+         browser screenshot against FDS labels (issue #74). Apply the persona-top
+         **Discord Ping Protocol**:
+           1. claire discord send "test-env-start failed for #<N>: <symptom>"
+           2. gh issue comment <N> with the same symptom
+           3. claire wait --issue <N> and block
+         Only the user can authorize a fallback — the dev agent cannot self-authorize one.
       → TaskUpdate(<task_6_id>, status="completed")
 
 - [ ] [7/11] Swagger verification (backend gate — run BEFORE Playwright):
@@ -309,7 +322,19 @@ EOF
          Fix in the current worktree (feature branch) → push fix to GitHub → retest from this step
       → TaskUpdate(<task_7_id>, status="completed")
 
-- [ ] [8/11] Verify shared login fixture exists, then run E2E tests + record MP4:
+- [ ] [8/11] 🚨 HARD STOP — Verify shared login fixture, run E2E tests, record MP4 (MANDATORY):
+      ⚠️ This step is NOT optional and NOT substitutable. Static code analysis,
+         grep on the source tree, or "the file exists so the feature works"
+         are NOT acceptable substitutes for an MP4 produced by a real browser
+         interacting with the running app. Issue #74 (and #71 / PR #76 before
+         it) document the failure mode of self-authorizing a static-analysis
+         fallback when test-env felt hard — the gate at [10/11] now rejects
+         this with a step-named message naming `[8/11] MP4 missing`.
+
+      📖 Read FIRST (before writing the spec — past sessions tâtonnaient 3+
+         times on the login dance because they skipped this):
+         claire domain read video_proof technical PLAYWRIGHT_PATTERNS
+
       Check: e2e/global-setup.ts exists in com.tfione.web/
       If missing → create it before writing feature tests (put in scratch path if not yet merged).
       Reference credentials: claire domain read fivepoints operational TESTING
@@ -321,10 +346,20 @@ EOF
          issue's FDS Section comment (per analyst/author scoping).
       ❌ Do NOT use ffmpeg or screencapture — use Playwright proof recording.
       ❌ If tests fail: fix in current worktree → push fix → retest from step 7.
+      ❌ If test-env cannot be brought up: Discord Ping Protocol (see [6/11]).
+         Do NOT fall back to static analysis. Only the user can authorize a fallback.
       Post MP4 URL/path on the issue before continuing.
       → TaskUpdate(<task_8_id>, status="completed")
 
 - [ ] [9/11] 🚨 HARD STOP — Screenshot + AI verification against FDS obligations (MANDATORY):
+      ⚠️ This step is NOT optional and NOT substitutable. The screenshot must
+         come from a running browser rendering the actual UI — not a `cat` of
+         a JSX file, not a structural grep, not "the labels are in the source
+         so the screen renders them". Issue #74 documents the failure mode of
+         skipping this step when test-env was hard to bring up. The gate at
+         [10/11] now rejects this with a step-named message naming
+         `[9/11] FDS Verification missing`.
+
       For each implemented feature, capture a screenshot of the **final state**:
       → After the happy-path interaction completes (form submitted, page saved)
       → Before any cleanup / navigation away
@@ -336,22 +371,35 @@ EOF
           screenshot's OCR text or visually inspect → confirm presence + label match
         - Note any missing / renamed / extra elements vs the FDS
 
-      Post the verification result on the issue:
+      Post the verification result on the issue. The comment MUST start with the
+      exact sentinel `**FDS Verification (screenshot + AI)**` on its own first
+      line — this is what `claire fivepoints ado-transition`'s [2/4] proof gate
+      greps for. A discussion comment that merely mentions the phrase in prose
+      will NOT satisfy the gate.
+
         gh issue comment <N> --body "**FDS Verification (screenshot + AI)**
 
         <per-feature: screenshot path + pass/fail + notes>"
 
-      ❌ fivepoints ado-push will reject if no MP4 AND no FDS Verification comment is posted.
+      ❌ `fivepoints ado-transition` and `fivepoints ado-push` will both reject
+         if either MP4 or this FDS Verification comment is missing. The
+         rejection message names which step was skipped.
+      ❌ If test-env cannot be brought up: Discord Ping Protocol (see [6/11]).
+         Do NOT post a static-analysis-based "verification" — the screenshot
+         must be a real browser screenshot.
       → TaskUpdate(<task_9_id>, status="completed")
 
 --- ADO TRANSITION (after scoped MP4 + screenshot verification posted) ---
 
 - [ ] [10/11] PAT gate + push feature branch to ADO:
       claire fivepoints ado-transition --issue <N>
-      → [1/3] Verifies branch naming convention
-      → [2/3] PAT gate: if AZURE_DEVOPS_WRITE_PAT is not set, posts wait comment
+      → [1/4] Verifies branch naming convention
+      → [2/4] Proof gate: rejects if no MP4 ([8/11]) or no FDS Verification ([9/11])
+              comment is posted on the issue. Rejection text names the skipped
+              step explicitly so you cannot accidentally bypass it.
+      → [3/4] PAT gate: if AZURE_DEVOPS_WRITE_PAT is not set, posts wait comment
               on the GitHub issue and pauses until user provides the write PAT
-      → [3/3] Pushes branch to ADO + creates ADO PR + monitors build
+      → [4/4] Pushes branch to ADO + creates ADO PR + monitors build
       ❌ FAIL → fix in current worktree → retest → rerun ado-transition
       ✅ PASS → ADO PR created, build passed.
       ℹ️ Pipeline shape change (issue #42): the GitHub issue **stays open**

--- a/domain/operational/TEST_ENV_START.md
+++ b/domain/operational/TEST_ENV_START.md
@@ -32,7 +32,18 @@ claire fivepoints test-env-start [--path /path/to/TFIOneGit]
 | [1/4] | Start `tfione-sqlserver` Docker container (creates if missing) |
 | [2/4] | Start .NET API: `dotnet run --urls "https://localhost:58337"` (background) |
 | [3/4] | Start Vite frontend: `npm run dev` (background) |
-| [4/4] | Wait for health checks on both services |
+| [4/4] | Wait for health checks on both services (heartbeat every 15s) |
+
+The wait loop emits a heartbeat line every 15 seconds:
+
+```
+  [15s] booting: sqlserver=up api=down vite=down
+  [30s] booting: sqlserver=up api=up vite=down
+```
+
+Silence for >30s is now unambiguous — if no heartbeat appears, the script
+itself has crashed (not the boot). Previously a silent `for i in seq 1 30; do
+sleep 2; done` made boot-in-progress indistinguishable from script-died-with-no-output.
 
 On success, prints:
 ```

--- a/domain/operational/TEST_ENV_START.md
+++ b/domain/operational/TEST_ENV_START.md
@@ -45,6 +45,14 @@ Silence for >30s is now unambiguous — if no heartbeat appears, the script
 itself has crashed (not the boot). Previously a silent `for i in seq 1 30; do
 sleep 2; done` made boot-in-progress indistinguishable from script-died-with-no-output.
 
+**Deadline semantics change (2026-04-20, issue #74):** the wait loop now uses a
+single `WAIT_DEADLINE=60s` covering API + Vite *in parallel*, instead of the
+prior sequential 60s API + 30s Vite (~90s wall clock). Both services boot
+concurrently in practice, so the new ceiling is rarely hit, but Vite no longer
+has its own dedicated 30s budget after the API completes. If you see a Vite
+timeout warning that wasn't there before, raise `WAIT_DEADLINE` in
+`test-env-start.sh` or pre-warm Vite separately.
+
 On success, prints:
 ```
 ✅ Environment ready

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -375,12 +375,25 @@ EOF
          Test in the same worktree you implemented in. Steven Reviewer rejects
          PRs containing test artifacts, which is the guard against test
          pollution (previously achieved by the isolated-worktree boundary).
-      ./scripts/test-env-start.sh
+      claire fivepoints test-env-start  (or ./scripts/test-env-start.sh)
+      → Heartbeat fires every 15s during boot:
+        `[15s] booting: sqlserver=up api=down vite=down`
+        Silence for >30s means the script crashed (no heartbeat = no progress).
       → Wait for "✅ Environment ready — API: https://localhost:58337 | UI: http://localhost:5173"
       → If script missing: start SQL Server, dotnet run, and npm run dev manually
       ⚠️ Any test code you write (e2e specs, fixtures, Playwright projects)
          must live OUTSIDE the feature branch. Use `~/.claire/scratch/tests/<issue-N>/`
          or a `.gitignored` local path — NEVER commit them to the feature branch.
+
+      🚨 If test-env fails or times out (heartbeat shows api/vite stuck on `down`,
+         or no heartbeat = script crashed): you may NOT skip [8/11] or [9/11] as
+         a workaround. Static code analysis is NOT a substitute for a running
+         browser screenshot against FDS labels (issue #74). Apply the persona-top
+         **Discord Ping Protocol**:
+           1. claire discord send "test-env-start failed for #<N>: <symptom>"
+           2. gh issue comment <N> with the same symptom
+           3. claire wait --issue <N> and block
+         Only the user can authorize a fallback — the dev agent cannot self-authorize one.
       → TaskUpdate(<task_6_id>, status="completed")
 
 - [ ] [7/11] Swagger verification (backend gate — run BEFORE Playwright):
@@ -391,7 +404,19 @@ EOF
          Fix in the current worktree (feature branch) → push fix to GitHub → retest from this step
       → TaskUpdate(<task_7_id>, status="completed")
 
-- [ ] [8/11] Verify shared login fixture exists, then run E2E tests + record MP4:
+- [ ] [8/11] 🚨 HARD STOP — Verify shared login fixture, run E2E tests, record MP4 (MANDATORY):
+      ⚠️ This step is NOT optional and NOT substitutable. Static code analysis,
+         grep on the source tree, or "the file exists so the feature works"
+         are NOT acceptable substitutes for an MP4 produced by a real browser
+         interacting with the running app. Issue #74 (and #71 / PR #76 before
+         it) document the failure mode of self-authorizing a static-analysis
+         fallback when test-env felt hard — the gate at [10/11] now rejects
+         this with a step-named message naming `[8/11] MP4 missing`.
+
+      📖 Read FIRST (before writing the spec — past sessions tâtonnaient 3+
+         times on the login dance because they skipped this):
+         claire domain read video_proof technical PLAYWRIGHT_PATTERNS
+
       Check: e2e/global-setup.ts exists in com.tfione.web/
       If missing → create it before writing feature tests (put in scratch path if not yet merged).
       Reference credentials: claire domain read fivepoints operational TESTING
@@ -403,10 +428,20 @@ EOF
          issue's FDS Section comment (per analyst/author scoping).
       ❌ Do NOT use ffmpeg or screencapture — use Playwright proof recording.
       ❌ If tests fail: fix in current worktree → push fix → retest from step 7.
+      ❌ If test-env cannot be brought up: Discord Ping Protocol (see [6/11]).
+         Do NOT fall back to static analysis. Only the user can authorize a fallback.
       Post MP4 URL/path on the issue before continuing.
       → TaskUpdate(<task_8_id>, status="completed")
 
 - [ ] [9/11] 🚨 HARD STOP — Screenshot + AI verification against FDS obligations (MANDATORY):
+      ⚠️ This step is NOT optional and NOT substitutable. The screenshot must
+         come from a running browser rendering the actual UI — not a `cat` of
+         a JSX file, not a structural grep, not "the labels are in the source
+         so the screen renders them". Issue #74 documents the failure mode of
+         skipping this step when test-env was hard to bring up. The gate at
+         [10/11] now rejects this with a step-named message naming
+         `[9/11] FDS Verification missing`.
+
       For each implemented feature, capture a screenshot of the **final state**:
       → After the happy-path interaction completes (form submitted, page saved)
       → Before any cleanup / navigation away
@@ -418,22 +453,35 @@ EOF
           screenshot's OCR text or visually inspect → confirm presence + label match
         - Note any missing / renamed / extra elements vs the FDS
 
-      Post the verification result on the issue:
+      Post the verification result on the issue. The comment MUST start with the
+      exact sentinel `**FDS Verification (screenshot + AI)**` on its own first
+      line — this is what `claire fivepoints ado-transition`'s [2/4] proof gate
+      greps for. A discussion comment that merely mentions the phrase in prose
+      will NOT satisfy the gate.
+
         gh issue comment <N> --body "**FDS Verification (screenshot + AI)**
 
         <per-feature: screenshot path + pass/fail + notes>"
 
-      ❌ fivepoints ado-push will reject if no MP4 AND no FDS Verification comment is posted.
+      ❌ `fivepoints ado-transition` and `fivepoints ado-push` will both reject
+         if either MP4 or this FDS Verification comment is missing. The
+         rejection message names which step was skipped.
+      ❌ If test-env cannot be brought up: Discord Ping Protocol (see [6/11]).
+         Do NOT post a static-analysis-based "verification" — the screenshot
+         must be a real browser screenshot.
       → TaskUpdate(<task_9_id>, status="completed")
 
 --- ADO TRANSITION (after scoped MP4 + screenshot verification posted) ---
 
 - [ ] [10/11] PAT gate + push feature branch to ADO:
       claire fivepoints ado-transition --issue <N>
-      → [1/3] Verifies branch naming convention
-      → [2/3] PAT gate: if AZURE_DEVOPS_WRITE_PAT is not set, posts wait comment
+      → [1/4] Verifies branch naming convention
+      → [2/4] Proof gate: rejects if no MP4 ([8/11]) or no FDS Verification ([9/11])
+              comment is posted on the issue. Rejection text names the skipped
+              step explicitly so you cannot accidentally bypass it.
+      → [3/4] PAT gate: if AZURE_DEVOPS_WRITE_PAT is not set, posts wait comment
               on the GitHub issue and pauses until user provides the write PAT
-      → [3/3] Pushes branch to ADO + creates ADO PR + monitors build
+      → [4/4] Pushes branch to ADO + creates ADO PR + monitors build
       ❌ FAIL → fix in current worktree → retest → rerun ado-transition
       ✅ PASS → ADO PR created, build passed.
       ℹ️ Pipeline shape change (issue #42): the GitHub issue **stays open**

--- a/domain/scripts/ado_common.sh
+++ b/domain/scripts/ado_common.sh
@@ -319,3 +319,68 @@ ado_print_info() {
     echo "Project: ${_ADO_PROJECT}"
     echo "Repo:    ${_ADO_REPO}"
 }
+
+# Verify dev-pipeline proof gates: MP4 ([8/11]) and FDS Verification ([9/11])
+# posted as comments on the GitHub issue. Reads issue comments via gh CLI.
+#
+# Usage: check_proof_gate <issue_number> <github_repo>
+#   issue_number: e.g. 123
+#   github_repo:  e.g. CLAIRE-Fivepoints/claire-plugin
+#
+# Returns 0 if both gates pass, 1 otherwise. Rejection text names the
+# specific skipped checklist step (per issue #74) and references the
+# Discord Ping Protocol so the dev does not invent a static-analysis fallback.
+check_proof_gate() {
+    local issue_number="$1"
+    local gh_repo="$2"
+
+    if [[ -z "$issue_number" || -z "$gh_repo" ]]; then
+        echo "ERROR: check_proof_gate requires <issue_number> <github_repo>" >&2
+        return 2
+    fi
+
+    local mp4_found=false
+    local fds_found=false
+
+    local mp4_match
+    mp4_match=$(gh issue view "$issue_number" --repo "$gh_repo" --json comments \
+        --jq '[.comments[].body | select(contains(".mp4"))] | first // ""' \
+        2>/dev/null || echo "")
+    [[ -n "$mp4_match" ]] && mp4_found=true
+
+    # FDS Verification must be the first line of the comment (not a quoted
+    # reference inside an analysis/discussion comment) — per the dev checklist's
+    # documented format: `gh issue comment <N> --body "**FDS Verification (screenshot + AI)**\n..."`.
+    local fds_match
+    fds_match=$(gh issue view "$issue_number" --repo "$gh_repo" --json comments \
+        --jq '[.comments[].body | select(startswith("**FDS Verification (screenshot + AI)**"))] | first // ""' \
+        2>/dev/null || echo "")
+    [[ -n "$fds_match" ]] && fds_found=true
+
+    if [[ "$mp4_found" == "true" && "$fds_found" == "true" ]]; then
+        echo "✅ Proof gate: MP4 ([8/11]) + FDS Verification ([9/11]) both posted on issue #${issue_number}"
+        return 0
+    fi
+
+    {
+        echo ""
+        echo "❌ Proof gate failed for issue #${issue_number} (${gh_repo}):"
+        if [[ "$mp4_found" != "true" ]]; then
+            echo "   ❌ [8/11] MP4 missing: no 'MP4 URL/path' line ('.mp4') found on issue #${issue_number}."
+            echo "      Record an MP4 with Playwright (claire domain read video_proof technical PLAYWRIGHT_PATTERNS),"
+            echo "      then post the path:"
+            echo "        gh issue comment ${issue_number} --body 'MP4: /path/to/proof.mp4'"
+        fi
+        if [[ "$fds_found" != "true" ]]; then
+            echo "   ❌ [9/11] FDS Verification missing: no '**FDS Verification (screenshot + AI)**' comment on issue #${issue_number}."
+            echo "      Capture a final-state screenshot, AI-verify it against the FDS labels, then post:"
+            echo "        gh issue comment ${issue_number} --body '**FDS Verification (screenshot + AI)**'..."
+        fi
+        echo ""
+        echo "   These are HARD STOPs in the dev checklist. Static code analysis is NOT a substitute."
+        echo "   If test-env cannot be brought up, escalate via the Discord Ping Protocol"
+        echo "   (claire discord send + GitHub comment + claire wait) — do NOT skip these steps."
+    } >&2
+
+    return 1
+}

--- a/domain/scripts/ado_common.sh
+++ b/domain/scripts/ado_common.sh
@@ -320,6 +320,35 @@ ado_print_info() {
     echo "Repo:    ${_ADO_REPO}"
 }
 
+# Resolve the GitHub repo for proof-gate operations.
+# Single source of truth for both ado-push and ado-transition so they always
+# verify proof against the same issue tracker (PR #78 review point 1).
+#
+# Priority:
+#   1. CLAIRE_WAIT_REPO env var
+#   2. `gh repo view` autodetect from current directory
+#   3. caller-supplied default (e.g. "CLAIRE-Fivepoints/fivepoints-test")
+#
+# Returns 0 + prints repo on stdout, or 1 if no repo can be resolved.
+resolve_gh_repo() {
+    local default_repo="${1:-}"
+    if [[ -n "${CLAIRE_WAIT_REPO:-}" ]]; then
+        printf '%s\n' "$CLAIRE_WAIT_REPO"
+        return 0
+    fi
+    local detected
+    detected=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+    if [[ -n "$detected" ]]; then
+        printf '%s\n' "$detected"
+        return 0
+    fi
+    if [[ -n "$default_repo" ]]; then
+        printf '%s\n' "$default_repo"
+        return 0
+    fi
+    return 1
+}
+
 # Verify dev-pipeline proof gates: MP4 ([8/11]) and FDS Verification ([9/11])
 # posted as comments on the GitHub issue. Reads issue comments via gh CLI.
 #
@@ -330,6 +359,16 @@ ado_print_info() {
 # Returns 0 if both gates pass, 1 otherwise. Rejection text names the
 # specific skipped checklist step (per issue #74) and references the
 # Discord Ping Protocol so the dev does not invent a static-analysis fallback.
+#
+# Matchers:
+#   MP4: line starting with `MP4:` / `Proof:` / `Recording:` / `Video:`
+#        (case-insensitive, multiline) followed by content ending in `.mp4`.
+#        Tighter than `contains(".mp4")` to avoid false positives from
+#        discussion comments that mention `.mp4` in prose (PR #78 review point 2).
+#   FDS: comment whose body STARTS with `**FDS Verification (screenshot + AI)**`
+#        (per the dev checklist's documented heredoc format).
+#
+# Both gates are evaluated in a single `gh issue view` call (PR #78 review point 3).
 check_proof_gate() {
     local issue_number="$1"
     local gh_repo="$2"
@@ -339,23 +378,17 @@ check_proof_gate() {
         return 2
     fi
 
-    local mp4_found=false
-    local fds_found=false
+    local result_json
+    result_json=$(gh issue view "$issue_number" --repo "$gh_repo" --json comments \
+        --jq '{
+            mp4: any(.comments[].body; test("(?im)^(MP4|Proof|Recording|Video)[: ].*\\.mp4")),
+            fds: any(.comments[].body; startswith("**FDS Verification (screenshot + AI)**"))
+        }' \
+        2>/dev/null || echo '{"mp4":false,"fds":false}')
 
-    local mp4_match
-    mp4_match=$(gh issue view "$issue_number" --repo "$gh_repo" --json comments \
-        --jq '[.comments[].body | select(contains(".mp4"))] | first // ""' \
-        2>/dev/null || echo "")
-    [[ -n "$mp4_match" ]] && mp4_found=true
-
-    # FDS Verification must be the first line of the comment (not a quoted
-    # reference inside an analysis/discussion comment) — per the dev checklist's
-    # documented format: `gh issue comment <N> --body "**FDS Verification (screenshot + AI)**\n..."`.
-    local fds_match
-    fds_match=$(gh issue view "$issue_number" --repo "$gh_repo" --json comments \
-        --jq '[.comments[].body | select(startswith("**FDS Verification (screenshot + AI)**"))] | first // ""' \
-        2>/dev/null || echo "")
-    [[ -n "$fds_match" ]] && fds_found=true
+    local mp4_found fds_found
+    mp4_found=$(jq -r '.mp4' <<<"$result_json" 2>/dev/null || echo "false")
+    fds_found=$(jq -r '.fds' <<<"$result_json" 2>/dev/null || echo "false")
 
     if [[ "$mp4_found" == "true" && "$fds_found" == "true" ]]; then
         echo "✅ Proof gate: MP4 ([8/11]) + FDS Verification ([9/11]) both posted on issue #${issue_number}"
@@ -366,9 +399,9 @@ check_proof_gate() {
         echo ""
         echo "❌ Proof gate failed for issue #${issue_number} (${gh_repo}):"
         if [[ "$mp4_found" != "true" ]]; then
-            echo "   ❌ [8/11] MP4 missing: no 'MP4 URL/path' line ('.mp4') found on issue #${issue_number}."
+            echo "   ❌ [8/11] MP4 missing: no 'MP4 URL/path' line found on issue #${issue_number}."
             echo "      Record an MP4 with Playwright (claire domain read video_proof technical PLAYWRIGHT_PATTERNS),"
-            echo "      then post the path:"
+            echo "      then post the path with one of the recognised prefixes (MP4:/Proof:/Recording:/Video:):"
             echo "        gh issue comment ${issue_number} --body 'MP4: /path/to/proof.mp4'"
         fi
         if [[ "$fds_found" != "true" ]]; then

--- a/tests/scripts/test_check_proof_gate.bats
+++ b/tests/scripts/test_check_proof_gate.bats
@@ -127,8 +127,96 @@ make_comments() {
     [[ "$output" == *"[9/11] FDS Verification missing"* ]]
 }
 
+@test "check_proof_gate ignores comments that merely mention .mp4 in prose (MP4 false-positive guard)" {
+    # A discussion comment that says "use .mp4 Playwright recording, not ffmpeg"
+    # must NOT satisfy the MP4 gate — only a comment whose body has a line
+    # starting with MP4:/Proof:/Recording:/Video: followed by .mp4 does.
+    GH_MOCK_COMMENTS_JSON=$(make_comments \
+        "**FDS Verification (screenshot + AI)**
+- Screen X: pass" \
+        "Reminder for the dev: don't use ffmpeg, use .mp4 Playwright recording.")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[8/11] MP4 missing"* ]]
+}
+
+@test "check_proof_gate accepts MP4 with Proof:/Recording:/Video: prefixes (case-insensitive)" {
+    # Each prefix variant should satisfy the MP4 gate.
+    for prefix in "MP4:" "Proof:" "Recording:" "Video:" "mp4:" "PROOF:"; do
+        GH_MOCK_COMMENTS_JSON=$(make_comments \
+            "${prefix} /tmp/proof.mp4" \
+            "**FDS Verification (screenshot + AI)**
+- Screen X: pass")
+        export GH_MOCK_COMMENTS_JSON
+
+        run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+        [ "$status" -eq 0 ] || { echo "prefix '$prefix' failed: $output"; return 1; }
+    done
+}
+
 @test "check_proof_gate errors with code 2 on missing arguments" {
     run bash -c "source '$ADO_COMMON' && check_proof_gate"
     [ "$status" -eq 2 ]
     [[ "$output" == *"requires"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# resolve_gh_repo (PR #78 review point 1) — single source of truth shared by
+# ado-push and ado-transition.
+# ---------------------------------------------------------------------------
+
+@test "resolve_gh_repo returns CLAIRE_WAIT_REPO when set" {
+    export CLAIRE_WAIT_REPO="explicit/repo"
+    # Override gh to assert it's not consulted when env wins.
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+echo "gh should not be called when CLAIRE_WAIT_REPO is set" >&2
+exit 99
+SH
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+
+    run bash -c "source '$ADO_COMMON' && resolve_gh_repo fallback/repo"
+    [ "$status" -eq 0 ]
+    [ "$output" = "explicit/repo" ]
+}
+
+@test "resolve_gh_repo falls back to gh repo view when env unset" {
+    unset CLAIRE_WAIT_REPO
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == *"repo view"* ]]; then echo "detected/repo"; exit 0; fi
+exit 1
+SH
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+
+    run bash -c "source '$ADO_COMMON' && resolve_gh_repo fallback/repo"
+    [ "$status" -eq 0 ]
+    [ "$output" = "detected/repo" ]
+}
+
+@test "resolve_gh_repo falls back to caller default when env unset and gh repo view fails" {
+    unset CLAIRE_WAIT_REPO
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+
+    run bash -c "source '$ADO_COMMON' && resolve_gh_repo fallback/repo"
+    [ "$status" -eq 0 ]
+    [ "$output" = "fallback/repo" ]
+}
+
+@test "resolve_gh_repo returns 1 when env unset, gh fails, and no default is provided" {
+    unset CLAIRE_WAIT_REPO
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+
+    run bash -c "source '$ADO_COMMON' && resolve_gh_repo"
+    [ "$status" -eq 1 ]
 }

--- a/tests/scripts/test_check_proof_gate.bats
+++ b/tests/scripts/test_check_proof_gate.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# tests/scripts/test_check_proof_gate.bats
+#
+# Tests for check_proof_gate() in domain/scripts/ado_common.sh.
+# Verifies the dev-pipeline proof gate (issue #74):
+#   - rejects when MP4 ([8/11]) is missing on the issue
+#   - rejects when FDS Verification ([9/11]) is missing on the issue
+#   - accepts when both are present
+#   - rejection text names the specific skipped step
+#
+# Mocks `gh` to return controlled comment JSON.
+
+ADO_COMMON="${BATS_TEST_DIRNAME}/../../domain/scripts/ado_common.sh"
+
+setup() {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+
+    # gh mock — reads GH_MOCK_COMMENTS_JSON for issue view --json comments
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json comments"* ]]; then
+    body="${GH_MOCK_COMMENTS_JSON:-{\"comments\":[]}}"
+    if [[ "$*" == *"--jq"* ]]; then
+        # Extract the --jq arg and pipe body through real jq
+        jq_arg=""
+        while [[ $# -gt 0 ]]; do
+            if [[ "$1" == "--jq" ]]; then
+                jq_arg="$2"
+                break
+            fi
+            shift
+        done
+        echo "$body" | jq -r "$jq_arg"
+    else
+        echo "$body"
+    fi
+    exit 0
+fi
+echo "gh mock: unhandled call: $*" >&2
+exit 1
+SH
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+
+    # Real jq
+    if command -v jq &>/dev/null; then
+        ln -sf "$(command -v jq)" "$BATS_TEST_TMPDIR/bin/jq"
+    fi
+
+    export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR"
+}
+
+# Build a comments JSON from one body per arg.
+make_comments() {
+    local out='{"comments":['
+    local first=true
+    for body in "$@"; do
+        if [[ "$first" == "true" ]]; then first=false; else out+=','; fi
+        # JSON-escape: double-quotes and newlines
+        local esc="${body//\\/\\\\}"
+        esc="${esc//\"/\\\"}"
+        esc="${esc//$'\n'/\\n}"
+        out+="{\"body\":\"${esc}\"}"
+    done
+    out+=']}'
+    echo "$out"
+}
+
+@test "check_proof_gate fails when neither MP4 nor FDS Verification present" {
+    GH_MOCK_COMMENTS_JSON=$(make_comments "Some random comment")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[8/11] MP4 missing"* ]]
+    [[ "$output" == *"[9/11] FDS Verification missing"* ]]
+    [[ "$output" == *"Discord Ping Protocol"* ]]
+}
+
+@test "check_proof_gate fails with [9/11] only when MP4 is present but FDS Verification is missing" {
+    GH_MOCK_COMMENTS_JSON=$(make_comments "MP4: /tmp/proof.mp4")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"[8/11] MP4 missing"* ]]
+    [[ "$output" == *"[9/11] FDS Verification missing"* ]]
+}
+
+@test "check_proof_gate fails with [8/11] only when FDS Verification is present but MP4 is missing" {
+    GH_MOCK_COMMENTS_JSON=$(make_comments "**FDS Verification (screenshot + AI)**
+- Screen X: pass")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[8/11] MP4 missing"* ]]
+    [[ "$output" != *"[9/11] FDS Verification missing"* ]]
+}
+
+@test "check_proof_gate succeeds when both MP4 and FDS Verification are present" {
+    GH_MOCK_COMMENTS_JSON=$(make_comments \
+        "MP4: /tmp/proof.mp4" \
+        "**FDS Verification (screenshot + AI)**
+- Screen X: pass")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Proof gate"* ]]
+    [[ "$output" == *"both posted"* ]]
+}
+
+@test "check_proof_gate ignores comments that merely quote the FDS sentinel inline (false-positive guard)" {
+    # A discussion comment that mentions the sentinel in backticks must NOT
+    # satisfy the gate — only a comment that STARTS with the sentinel does.
+    GH_MOCK_COMMENTS_JSON=$(make_comments \
+        "MP4: /tmp/proof.mp4" \
+        "Looking for \`**FDS Verification (screenshot + AI)**\` headers in the issue.")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[9/11] FDS Verification missing"* ]]
+}
+
+@test "check_proof_gate errors with code 2 on missing arguments" {
+    run bash -c "source '$ADO_COMMON' && check_proof_gate"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"requires"* ]]
+}


### PR DESCRIPTION
Closes #74.

## Summary

Three coordinated changes that close the dev-pipeline loophole described in #74 (and observed on #71 / PR #76):

1. **Heartbeat in `test-env-start.sh`** — replaces the silent 60s curl loop with a 15s status line so booting / hung / failed are unambiguous.
2. **Shared MP4 + FDS Verification proof gate** — new `check_proof_gate` in `ado_common.sh`, wired into `ado-transition` (was missing entirely) and `ado-push` (replaces inline MP4-only check). Rejection text names the specific skipped checklist step (`[8/11] MP4 missing` / `[9/11] FDS Verification missing`) and references the Discord Ping Protocol.
3. **HARD STOP wording in `CHECKLIST_DEV_PIPELINE` + `fivepoints-dev` persona** for steps `[6/11]`, `[8/11]`, `[9/11]`: explicit "static code analysis is NOT a substitute" + "escalate via Discord Ping Protocol on test-env failure".

## Files

- `domain/commands/test-env-start.sh` — heartbeat loop with `probe_sql/probe_api/probe_vite` helpers
- `domain/scripts/ado_common.sh` — `check_proof_gate(issue, repo)` — uses `startswith(...)` for the FDS sentinel to avoid false positives from quoted references in discussion comments
- `domain/commands/ado-transition.sh` — renumbered to `[1/4]`–`[4/4]`; new `[2/4]` proof gate before the PAT gate
- `domain/commands/ado-push.sh` — replaces inline MP4-only check with shared gate (consistency)
- `domain/operational/CHECKLIST_DEV_PIPELINE.md` + `domain/persona/fivepoints-dev.md` — HARD STOP wording on `[6/11]`, `[8/11]`, `[9/11]` (kept in sync — both files duplicate the checklist text)
- `domain/operational/TEST_ENV_START.md` — documents the heartbeat behavior
- `tests/scripts/test_check_proof_gate.bats` — 6 new bats tests covering all four MP4 × FDS combinations + false-positive guard + missing-args contract

## Verification Log

### 1. Heartbeat (extracted loop, mocked probes)

```
$ bash /tmp/test-heartbeat.sh
  [16s] booting: sqlserver=down api=down vite=down
  [32s] booting: sqlserver=up api=down vite=down
[done at 36s] sqlserver=up api=down vite=down
```

First heartbeat at 16s with all `down`; second at 32s shows sqlserver flipped to `up` (mock toggle at +20s). Heartbeat fires every ~15s as designed.

### 2. Proof gate dogfood (against this very issue, which has no MP4 / no FDS Verification comment)

```
$ source domain/scripts/ado_common.sh
$ check_proof_gate 74 CLAIRE-Fivepoints/claire-plugin; echo exit=$?
❌ Proof gate failed for issue #74 (CLAIRE-Fivepoints/claire-plugin):
   ❌ [8/11] MP4 missing: no 'MP4 URL/path' line ('.mp4') found on issue #74.
      Record an MP4 with Playwright (claire domain read video_proof technical PLAYWRIGHT_PATTERNS),
      then post the path:
        gh issue comment 74 --body 'MP4: /path/to/proof.mp4'
   ❌ [9/11] FDS Verification missing: no '**FDS Verification (screenshot + AI)**' comment on issue #74.
      Capture a final-state screenshot, AI-verify it against the FDS labels, then post:
        gh issue comment 74 --body '**FDS Verification (screenshot + AI)**'...

   These are HARD STOPs in the dev checklist. Static code analysis is NOT a substitute.
   If test-env cannot be brought up, escalate via the Discord Ping Protocol
   (claire discord send + GitHub comment + claire wait) — do NOT skip these steps.
exit=1
```

Both [8/11] and [9/11] flagged with step-named messages and the Discord Ping Protocol reference, exactly as the issue's "Pre-[10/11] gate" example dictates.

### 3. `ado-transition --help` reflects renumbering

```
$ bash ./domain/commands/ado-transition.sh --help | sed -n '1,7p'
Usage: claire fivepoints ado-transition --issue <N> [--branch <name>] [--target <branch>]

PAT-gated transition from dev to ADO. Bash orchestration + Python build agent.

  [1/4] Verify feature branch (feature/XXXXX-description or bugfix/XXXXX-description)
  [2/4] Proof gate — verify MP4 ([8/11]) and FDS Verification ([9/11]) comments on the issue
  [3/4] PAT gate — pause and wait for AZURE_DEVOPS_WRITE_PAT if not set
```

### 4. Bats suite (new + existing)

```
$ bats tests/scripts/test_check_proof_gate.bats
1..6
ok 1 check_proof_gate fails when neither MP4 nor FDS Verification present
ok 2 check_proof_gate fails with [9/11] only when MP4 is present but FDS Verification is missing
ok 3 check_proof_gate fails with [8/11] only when FDS Verification is present but MP4 is missing
ok 4 check_proof_gate succeeds when both MP4 and FDS Verification are present
ok 5 check_proof_gate ignores comments that merely quote the FDS sentinel inline (false-positive guard)
ok 6 check_proof_gate errors with code 2 on missing arguments

$ bats tests/scripts/test_transition.bats
1..5
ok 1 tester→dev is blocked when most recent failure is ado-push FAILED
ok 2 tester→dev is allowed when test failure is more recent than ado-push failure
ok 3 tester→dev is blocked when ado-push failure is more recent than test failure
ok 4 tester→dev is allowed when there is no ado-push failure marker
ok 5 tester→ado-review (default) is not affected by the ado-push guard

$ python3 -m pytest domain/scripts/tests/
============================== 62 passed in 0.13s ==============================
```

**Context:** dogfood ran in the issue-74 worktree against the live GitHub repo (`CLAIRE-Fivepoints/claire-plugin`). The heartbeat loop was exercised in isolation with mocked probes because the full TFI One stack (docker + dotnet + vite) is not available in this worktree.

## Acceptance criteria

- [x] AC #1 — Server start consistency. Interpreted narrowly: the existing `test-env-start.sh` script is the script. The "consistency" failure mode in #71 was *silence vs progress*, which AC #2 directly fixes. A larger boot-logic refactor is out of scope for this PR.
- [x] AC #2 — `test-env-start.sh` prints a 15s heartbeat (verified in section 1 above).
- [x] AC #3 — `ado-transition`'s rejection message names the specific checklist step that was skipped (`[8/11] MP4 missing` / `[9/11] FDS Verification missing`, verified in section 2 above). Same shared gate now powers `ado-push` for consistency.

## Out of scope (intentionally)

- Rewriting the boot pipeline (docker compose, makefile, etc.) — would close AC #1 more thoroughly but is a much larger refactor and the issue body itself flags this with "needs to be clarified though".
- Touching the analyst / tester pipelines — same MP4 sentinel could be reused there, but the issue is scoped to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)