### PR TITLE
docs(fivepoints-personas): mirror repo-conditional './claire' vs 'claire' rule

### DIFF
--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -77,6 +77,18 @@ Read this before starting — it has scope guard rules and detailed patterns.
 - `claire fivepoints transition --role analyst --issue N` — Hand off to developer
 - `claire domain read fivepoints knowledge ANALYST_PERSONA` — Full persona details
 
+### Worktree Path Guard — `claire` vs `./claire`
+
+When running the CLI in a worktree, which binary to call **depends on which repo's worktree you are in**:
+
+- **Editing the claire CLI itself** (worktree of `claire-labs/claire`): use `./claire`. This tests *your* changes in this worktree, not the globally-installed version on main.
+- **Editing any other repo** (fivepoints, fivepoints-plugin/claire-plugin, client repos, pacingmatters, …): use the global `claire`. The CLI binary is only tracked in `claire-labs/claire` — it does not exist in other repos' worktrees, so `./claire <cmd>` will fail with `no such file or directory`.
+- **How to tell**: `ls ./claire`. If the file exists → you're in a claire-labs/claire worktree, use `./claire`. If it doesn't → use `claire`.
+- **After editing a CLI command** (claire-labs/claire only), verify with `./claire <command> --help` — if changes don't appear, you edited the wrong copy.
+- Bash tool writes are NOT guarded — the `./claire` verification step (in claire-labs/claire worktrees) is the safest check.
+
+In a fivepoints-plugin or fivepoints worktree you are almost always in the second case — use `claire` unmodified. Do not prefix `./` to exploratory commands like `claire preview --help`; it will fail and send you down a false-bug trail.
+
 ---
 
 ## Your Checklist (MANDATORY — follow in order)

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -86,6 +86,18 @@ If you encounter something missing or unclear in the analyst's specs:
 - `claire domain search <keyword>` — Search across all domains
 - `claire context <keyword>` — Search for relevant context
 
+### Worktree Path Guard — `claire` vs `./claire`
+
+When running the CLI in a worktree, which binary to call **depends on which repo's worktree you are in**:
+
+- **Editing the claire CLI itself** (worktree of `claire-labs/claire`): use `./claire`. This tests *your* changes in this worktree, not the globally-installed version on main.
+- **Editing any other repo** (fivepoints, fivepoints-plugin/claire-plugin, client repos, pacingmatters, …): use the global `claire`. The CLI binary is only tracked in `claire-labs/claire` — it does not exist in other repos' worktrees, so `./claire <cmd>` will fail with `no such file or directory`.
+- **How to tell**: `ls ./claire`. If the file exists → you're in a claire-labs/claire worktree, use `./claire`. If it doesn't → use `claire`.
+- **After editing a CLI command** (claire-labs/claire only), verify with `./claire <command> --help` — if changes don't appear, you edited the wrong copy.
+- Bash tool writes are NOT guarded — the `./claire` verification step (in claire-labs/claire worktrees) is the safest check.
+
+In a fivepoints-plugin or fivepoints worktree you are almost always in the second case — use `claire` unmodified. Do not prefix `./` to exploratory commands like `claire preview --help`; it will fail and send you down a false-bug trail.
+
 ---
 
 ### SESSION START — Create All Tasks First (MANDATORY)

--- a/domain/persona/fivepoints-reviewer.md
+++ b/domain/persona/fivepoints-reviewer.md
@@ -75,6 +75,18 @@ When you must pause:
 - Re-run the dev's gates yourself (the dev did that in [4/11])
 - Run the test suite (the dev recorded MP4 + screenshot proof in [8/11] + [9/11])
 
+### Worktree Path Guard — `claire` vs `./claire`
+
+When running the CLI in a worktree, which binary to call **depends on which repo's worktree you are in**:
+
+- **Editing the claire CLI itself** (worktree of `claire-labs/claire`): use `./claire`. This tests *your* changes in this worktree, not the globally-installed version on main.
+- **Editing any other repo** (fivepoints, fivepoints-plugin/claire-plugin, client repos, pacingmatters, …): use the global `claire`. The CLI binary is only tracked in `claire-labs/claire` — it does not exist in other repos' worktrees, so `./claire <cmd>` will fail with `no such file or directory`.
+- **How to tell**: `ls ./claire`. If the file exists → you're in a claire-labs/claire worktree, use `./claire`. If it doesn't → use `claire`.
+- **After editing a CLI command** (claire-labs/claire only), verify with `./claire <command> --help` — if changes don't appear, you edited the wrong copy.
+- Bash tool writes are NOT guarded — the `./claire` verification step (in claire-labs/claire worktrees) is the safest check.
+
+In a fivepoints-plugin or fivepoints worktree you are almost always in the second case — use `claire` unmodified. Do not prefix `./` to exploratory commands like `claire preview --help`; it will fail and send you down a false-bug trail.
+
 ---
 
 ## 🚨 Mandatory Checks Summary

--- a/domain/persona/fivepoints-tester.md
+++ b/domain/persona/fivepoints-tester.md
@@ -76,6 +76,18 @@ The original "End-to-End Execution" rule (continue through to completion unless 
 - `claire domain read video_proof technical BACKEND_RECORDING` — Terminal/API proof recording
 - `claire domain read` — Read FDS/requirements
 
+### Worktree Path Guard — `claire` vs `./claire`
+
+When running the CLI in a worktree, which binary to call **depends on which repo's worktree you are in**:
+
+- **Editing the claire CLI itself** (worktree of `claire-labs/claire`): use `./claire`. This tests *your* changes in this worktree, not the globally-installed version on main.
+- **Editing any other repo** (fivepoints, fivepoints-plugin/claire-plugin, client repos, pacingmatters, …): use the global `claire`. The CLI binary is only tracked in `claire-labs/claire` — it does not exist in other repos' worktrees, so `./claire <cmd>` will fail with `no such file or directory`.
+- **How to tell**: `ls ./claire`. If the file exists → you're in a claire-labs/claire worktree, use `./claire`. If it doesn't → use `claire`.
+- **After editing a CLI command** (claire-labs/claire only), verify with `./claire <command> --help` — if changes don't appear, you edited the wrong copy.
+- Bash tool writes are NOT guarded — the `./claire` verification step (in claire-labs/claire worktrees) is the safest check.
+
+In a fivepoints-plugin or fivepoints worktree you are almost always in the second case — use `claire` unmodified. Do not prefix `./` to exploratory commands like `claire preview --help`; it will fail and send you down a false-bug trail.
+
 ---
 
 ### SESSION START — Create All Tasks First (MANDATORY)


### PR DESCRIPTION
## Summary

Mirrors the repo-conditional worktree-path-guard rule from `claire-labs/claire` PR #3442 into the four fivepoints-plugin personas, so agents spawned into fivepoints/plugin/client-repo worktrees stop misfiring `./claire <cmd>` and hitting `no such file or directory`.

Closes #59.

## Rule added (verbatim from the core rewrite)

```
### Worktree Path Guard — `claire` vs `./claire`

When running the CLI in a worktree, which binary to call **depends on which repo's worktree you are in**:

- **Editing the claire CLI itself** (worktree of `claire-labs/claire`): use `./claire`. …
- **Editing any other repo** (fivepoints, fivepoints-plugin/claire-plugin, client repos, pacingmatters, …): use the global `claire`. …
- **How to tell**: `ls ./claire`. If the file exists → use `./claire`; otherwise → `claire`.
- **After editing a CLI command** (claire-labs/claire only), verify with `./claire <command> --help`.
- Bash tool writes are NOT guarded — the `./claire` verification step is the safest check.
```

Plus a short fivepoints-specific tail: *"In a fivepoints-plugin or fivepoints worktree you are almost always in the second case — use `claire` unmodified. Do not prefix `./` to exploratory commands like `claire preview --help`; it will fail and send you down a false-bug trail."*

## Files changed

- `domain/persona/fivepoints-dev.md` — inserted after Key Tools, before SESSION START.
- `domain/persona/fivepoints-analyst.md` — inserted after Key Commands, before session checklist.
- `domain/persona/fivepoints-tester.md` — inserted after Key Commands, before SESSION START.
- `domain/persona/fivepoints-reviewer.md` — inserted after You DO NOT, before Mandatory Checks Summary.

## Verification Log

Command: `claire verify-templates`
Context: clean `issue-59` worktree after all four edits.

```
📋 Persona: reviewer                  → ✅ No unsubstituted placeholders
📋 Persona: fivepoints-dev            → ✅ No unsubstituted placeholders
📋 Persona: coldfusion-dev            → ✅ No unsubstituted placeholders
📋 Persona: web-dev                   → ✅ No unsubstituted placeholders
📋 Persona: fivepoints-pipeline-dev   → ✅ No unsubstituted placeholders

==================================================
✅ All template verification checks passed.
```

Grep check — block now present in all four personas:
```
$ grep -n "depends on which repo's worktree" domain/persona/*.md
domain/persona/fivepoints-analyst.md:82:...
domain/persona/fivepoints-dev.md:91:...
domain/persona/fivepoints-reviewer.md:80:...
domain/persona/fivepoints-tester.md:81:...
```

## Test plan

- [x] Rule block present in all four fivepoints personas
- [x] `claire verify-templates` green
- [x] Wording matches PR #3442's repo-conditional structure
- [ ] Gatekeeper (Steven Franklin) review

🤖 Generated with [Claude Code](https://claude.com/claude-code)