### PR TITLE
fix(ado-transition): sync check + auto-rebase + embedded ADO PR proofs (#86)

### DIFF
--- a/domain/commands/ado-transition.sh
+++ b/domain/commands/ado-transition.sh
@@ -4,10 +4,11 @@ set -euo pipefail
 # fivepoints ado-transition — PAT-gated ADO push for dev role
 #
 # Bash orchestration:
-#   [1/4] Verify feature branch (naming convention)
-#   [2/4] Proof gate — MP4 ([8/11]) + FDS Verification ([9/11]) on the issue
-#   [3/4] PAT gate — request AZURE_DEVOPS_WRITE_PAT if not set
-#   [4/4] Set up ADO remote + git push, then call ado_agent.py (build agent)
+#   [1/5] Verify feature branch (naming convention)
+#   [2/5] Proof gate — MP4 ([8/11]) + FDS Verification ([9/11]) on the issue
+#   [3/5] PAT gate — request AZURE_DEVOPS_WRITE_PAT if not set
+#   [4/5] Sync check — fail fast if branch is not fast-forward with ADO $target
+#   [5/5] Set up ADO remote + git push, then call ado_agent.py (build agent)
 #
 # Usage:
 #   claire fivepoints ado-transition --issue <N> [--branch <name>] [--target <branch>]
@@ -19,6 +20,8 @@ source "$PLUGIN_ROOT/domain/scripts/ado_common.sh"
 ISSUE_NUMBER=""
 BRANCH=""
 TARGET_BRANCH="dev"
+AUTO_SYNC=1
+MIRROR_REMOTE="${ADO_TRANSITION_MIRROR_REMOTE:-github}"
 
 show_help() {
     cat <<'HELP'
@@ -26,20 +29,29 @@ Usage: claire fivepoints ado-transition --issue <N> [--branch <name>] [--target 
 
 PAT-gated transition from dev to ADO. Bash orchestration + Python build agent.
 
-  [1/4] Verify feature branch (feature/XXXXX-description or bugfix/XXXXX-description)
-  [2/4] Proof gate — verify MP4 ([8/11]) and FDS Verification ([9/11]) comments on the issue
-  [3/4] PAT gate — pause and wait for AZURE_DEVOPS_WRITE_PAT if not set
-  [4/4] Set up ADO remote + git push + call ado_agent.py (build verification agent)
+  [1/5] Verify feature branch (feature/XXXXX-description or bugfix/XXXXX-description)
+  [2/5] Proof gate — verify MP4 ([8/11]) and FDS Verification ([9/11]) comments on the issue
+  [3/5] PAT gate — pause and wait for AZURE_DEVOPS_WRITE_PAT if not set
+  [4/5] Sync check — verify branch is fast-forward with ADO target (prevents chaotic PRs)
+  [5/5] Set up ADO remote + git push + call ado_agent.py (build verification agent)
 
 Options:
   --issue <N>       GitHub issue number (required)
   --branch <name>   Branch to push (default: current branch)
   --target <branch> Target branch for ADO PR (default: dev)
+  --no-auto-sync    Skip auto-rebase on divergence — print manual resolution and exit 1
 
 Prerequisites:
   - All tests passed and MP4 proof recorded + posted on issue
   - Branch follows: feature/XXXXX-description or bugfix/XXXXX-description
   - FIVEPOINTS_REPO_PATH set (or default: /Users/andreperez/TFIOneGit)
+
+Auto-sync:
+  When the branch is not fast-forward with ADO <target>, the script attempts
+  git rebase --onto origin/<target> <mirror-base> <branch> (where mirror-base
+  is the merge-base with the GitHub mirror). Clean rebase → push proceeds.
+  Conflict → rebase aborted, manual resolution printed, exit 1.
+  Pass --no-auto-sync to skip the attempt entirely.
 HELP
 }
 
@@ -59,7 +71,8 @@ after ALL FDS sections are tested and proved on video.
 1. Verify branch naming convention
 2. Proof gate: verify MP4 + FDS Verification comments on the issue (HARD STOPs from dev checklist)
 3. PAT gate: request AZURE_DEVOPS_WRITE_PAT if not set (posts wait comment on issue)
-4. Initialize ADO connection + git push + call ado_agent.py agent
+4. Sync check: auto-rebase onto ADO target when safe; fail with resolution on conflict
+5. Initialize ADO connection + git push + call ado_agent.py agent
 
 ## Usage
 ```bash
@@ -83,12 +96,13 @@ AGENT_HELP
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --issue)       ISSUE_NUMBER="$2"; shift 2 ;;
-        --branch)      BRANCH="$2"; shift 2 ;;
-        --target)      TARGET_BRANCH="$2"; shift 2 ;;
-        --help|-h)     show_help; exit 0 ;;
-        --agent-help)  show_agent_help; exit 0 ;;
-        *)             echo "Unknown argument: $1"; show_help; exit 1 ;;
+        --issue)          ISSUE_NUMBER="$2"; shift 2 ;;
+        --branch)         BRANCH="$2"; shift 2 ;;
+        --target)         TARGET_BRANCH="$2"; shift 2 ;;
+        --no-auto-sync)   AUTO_SYNC=0; shift ;;
+        --help|-h)        show_help; exit 0 ;;
+        --agent-help)     show_agent_help; exit 0 ;;
+        *)                echo "Unknown argument: $1"; show_help; exit 1 ;;
     esac
 done
 
@@ -108,9 +122,9 @@ echo "╚═══════════════════════�
 echo ""
 
 # ─────────────────────────────────────────────
-# [1/4] Verify feature branch
+# [1/5] Verify feature branch
 # ─────────────────────────────────────────────
-echo "[1/4] Verifying feature branch..."
+echo "[1/5] Verifying feature branch..."
 echo "      Branch: $BRANCH"
 
 if ! echo "$BRANCH" | grep -qE '^(feature|bugfix)/[0-9]+-'; then
@@ -127,10 +141,10 @@ fi
 echo "✅  Branch OK: $BRANCH"
 
 # ─────────────────────────────────────────────
-# [2/4] Proof gate — MP4 ([8/11]) + FDS Verification ([9/11])
+# [2/5] Proof gate — MP4 ([8/11]) + FDS Verification ([9/11])
 # ─────────────────────────────────────────────
 echo ""
-echo "[2/4] Proof gate (MP4 + FDS Verification comments on issue #${ISSUE_NUMBER})..."
+echo "[2/5] Proof gate (MP4 + FDS Verification comments on issue #${ISSUE_NUMBER})..."
 
 GH_REPO=$(resolve_gh_repo "CLAIRE-Fivepoints/fivepoints-test") || {
     echo "❌  Cannot determine GitHub repo for proof gate." >&2
@@ -143,10 +157,10 @@ if ! check_proof_gate "$ISSUE_NUMBER" "$GH_REPO"; then
 fi
 
 # ─────────────────────────────────────────────
-# [3/4] PAT gate
+# [3/5] PAT gate
 # ─────────────────────────────────────────────
 echo ""
-echo "[3/4] PAT gate (checking AZURE_DEVOPS_WRITE_PAT)..."
+echo "[3/5] PAT gate (checking AZURE_DEVOPS_WRITE_PAT)..."
 
 if [[ -z "${AZURE_DEVOPS_WRITE_PAT:-}" ]]; then
     echo ""
@@ -174,19 +188,50 @@ fi
 
 echo "✅  AZURE_DEVOPS_WRITE_PAT set."
 
-# ─────────────────────────────────────────────
-# [4/4] ADO remote setup + git push + transition agent
-# ─────────────────────────────────────────────
-echo ""
-echo "[4/4] Setting up ADO remote and pushing branch..."
-
-# Initialize ADO connection (must run from TFIOneGit clone)
+# Resolve the ADO clone path once — shared by [4/5] sync check and [5/5] push.
 CLIENT_REPO_PATH="${FIVEPOINTS_REPO_PATH:-/Users/andreperez/TFIOneGit}"
 if [[ ! -d "$CLIENT_REPO_PATH/.git" ]]; then
     echo "❌  Client repo not found at $CLIENT_REPO_PATH"
     echo "    Set FIVEPOINTS_REPO_PATH to the local clone of TFIOneGit"
     exit 1
 fi
+
+# ─────────────────────────────────────────────
+# [4/5] Sync check — branch must be fast-forward with ADO target.
+#        On divergence, auto-rebase unless --no-auto-sync was passed.
+# ─────────────────────────────────────────────
+echo ""
+echo "[4/5] Sync check (branch must be fast-forward with ADO ${TARGET_BRANCH})..."
+
+if verify_branch_synced_with_ado_dev "$BRANCH" "$TARGET_BRANCH" "$CLIENT_REPO_PATH"; then
+    :  # already synced
+elif [[ "$AUTO_SYNC" == "1" ]]; then
+    echo ""
+    echo "      Attempting auto-rebase onto origin/${TARGET_BRANCH}..."
+    if attempt_auto_rebase_onto_ado "$BRANCH" "$TARGET_BRANCH" "$CLIENT_REPO_PATH" "$MIRROR_REMOTE"; then
+        echo ""
+        echo "      Re-running sync check after auto-rebase..."
+        if ! verify_branch_synced_with_ado_dev "$BRANCH" "$TARGET_BRANCH" "$CLIENT_REPO_PATH"; then
+            echo "❌  Post-rebase sync check still failed — aborting push." >&2
+            exit 1
+        fi
+    else
+        echo "" >&2
+        echo "❌  Auto-rebase aborted due to conflict — manual resolution required." >&2
+        echo "    See the resolution options printed above, or pass --no-auto-sync to skip" >&2
+        echo "    the rebase attempt on future runs." >&2
+        exit 1
+    fi
+else
+    echo "❌  --no-auto-sync set — skipping rebase attempt. Resolve manually." >&2
+    exit 1
+fi
+
+# ─────────────────────────────────────────────
+# [5/5] ADO remote setup + git push + transition agent
+# ─────────────────────────────────────────────
+echo ""
+echo "[5/5] Setting up ADO remote and pushing branch..."
 
 pushd "$CLIENT_REPO_PATH" > /dev/null
 ado_init

--- a/domain/scripts/ado_agent.py
+++ b/domain/scripts/ado_agent.py
@@ -134,8 +134,7 @@ def build_pr_body(
     if mp4_attachment_url:
         sections.append(
             "## MP4 Proof\n"
-            f"[Download MP4 proof]({mp4_attachment_url})\n\n"
-            "Attached directly to this PR — no GitHub access required."
+            f"[Download MP4 proof]({mp4_attachment_url})"
         )
     elif mp4_skip_reason:
         sections.append(f"## MP4 Proof\n⚠️ {mp4_skip_reason}")

--- a/domain/scripts/ado_agent.py
+++ b/domain/scripts/ado_agent.py
@@ -113,7 +113,6 @@ def extract_fds_verification(comment_bodies: list[str]) -> str | None:
 
 def build_pr_body(
     branch: str,
-    issue: int,
     fds_verification: str | None,
     mp4_attachment_url: str | None,
     mp4_skip_reason: str | None,
@@ -125,11 +124,12 @@ def build_pr_body(
     an attachment link to the MP4. When the MP4 can't be attached (too big,
     not found on disk), the body surfaces the skip reason instead of silently
     dropping it — a reviewer must see that a proof was expected.
+
+    The GitHub issue number is intentionally NOT embedded — GitHub is private
+    to ADO reviewers, so `owner/repo#N` is noise to them. Ticket traceability
+    is preserved via the branch name (convention: feature/<ticket-id>-<desc>).
     """
-    sections: list[str] = [
-        f"## GitHub Issue\n{GH_REPO}#{issue}",
-        f"## Branch\n`{branch}`",
-    ]
+    sections: list[str] = [f"## Branch\n`{branch}`"]
 
     if mp4_attachment_url:
         sections.append(
@@ -270,7 +270,6 @@ def create_pr(branch: str, target: str, issue: int, pat: str) -> tuple[int, str]
     # listed" instead of a misleading "Upload in progress..." stuck forever.
     skeleton_body = build_pr_body(
         branch,
-        issue,
         fds_verification=fds_text,
         mp4_attachment_url=None,
         mp4_skip_reason=None,
@@ -295,7 +294,6 @@ def create_pr(branch: str, target: str, issue: int, pat: str) -> tuple[int, str]
     attachment_url, skip_reason = attach_mp4_and_get_link(pr_id, mp4_path, pat)
     final_body = build_pr_body(
         branch,
-        issue,
         fds_verification=fds_text,
         mp4_attachment_url=attachment_url,
         mp4_skip_reason=skip_reason,

--- a/domain/scripts/ado_agent.py
+++ b/domain/scripts/ado_agent.py
@@ -266,12 +266,15 @@ def create_pr(branch: str, target: str, issue: int, pat: str) -> tuple[int, str]
     mp4_path = extract_mp4_path(comment_bodies)
     fds_text = extract_fds_verification(comment_bodies)
 
+    # Skeleton body omits the MP4 section entirely. If the PATCH below fails,
+    # the description is incomplete but accurate — the reviewer sees "no MP4
+    # listed" instead of a misleading "Upload in progress..." stuck forever.
     skeleton_body = build_pr_body(
         branch,
         issue,
         fds_verification=fds_text,
         mp4_attachment_url=None,
-        mp4_skip_reason="Upload in progress..." if mp4_path else None,
+        mp4_skip_reason=None,
     )
 
     response = ado_post(
@@ -299,7 +302,16 @@ def create_pr(branch: str, target: str, issue: int, pat: str) -> tuple[int, str]
         mp4_skip_reason=skip_reason,
     )
     if final_body != skeleton_body:
-        ado_patch_pr_description(pr_id, final_body, pat)
+        if not ado_patch_pr_description(pr_id, final_body, pat):
+            # Attachment may already be uploaded to ADO (visible in the "Files"
+            # tab), but the PR body won't reference it. Surface the mismatch
+            # prominently so the dev can retry the PATCH or patch by hand.
+            print(
+                f"⚠️  ADO PR #{pr_id} description PATCH failed — body missing "
+                f"MP4 link / FDS text. See agent stderr log; retry manually "
+                f"if needed.",
+                file=sys.stderr,
+            )
 
     return pr_id, pr_url
 

--- a/domain/scripts/ado_agent.py
+++ b/domain/scripts/ado_agent.py
@@ -15,6 +15,7 @@ import argparse
 import base64
 import json
 import os
+import re
 import sys
 import time
 import urllib.error
@@ -33,6 +34,16 @@ GH_API_BASE = f"https://api.github.com/repos/{GH_REPO}"
 
 POLL_INTERVAL = 60  # seconds between build checks
 MAX_WAIT = 7200  # 2 hours max
+
+# ADO PR attachment limit. Actual server cap is ~30 MB; we stay under to leave
+# headroom for the JSON envelope and avoid a 413 that would abort the push.
+ADO_ATTACHMENT_SIZE_LIMIT = 25 * 1024 * 1024
+
+MP4_LINE_RE = re.compile(
+    r"^(?:MP4|Proof|Recording|Video)\s*[: ]\s*(\S+\.mp4)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+FDS_SENTINEL = "**FDS Verification (screenshot + AI)**"
 
 
 # ─────────────────────────────────────────────
@@ -71,21 +82,205 @@ def ado_post(path: str, body: dict[str, Any], pat: str) -> Any:
 # ─────────────────────────────────────────────
 
 
-def create_pr(branch: str, target: str, issue: int, pat: str) -> tuple[int, str]:
-    """Create ADO PR. Returns (pr_id, pr_url)."""
-    pr_title = branch.removeprefix("feature/").removeprefix("bugfix/")
-    pr_body = (
-        f"## GitHub Issue\n{GH_REPO}#{issue}\n\n"
-        f"## Branch\n`{branch}`\n\n"
-        "---\nCreated by C.L.A.I.R.E. pipeline"
+def extract_mp4_path(comment_bodies: list[str]) -> str | None:
+    """Find the first MP4 path in an issue's comments.
+
+    Matches the dev-checklist convention: a line starting with
+    `MP4:` / `Proof:` / `Recording:` / `Video:` (case-insensitive)
+    followed by a token ending in `.mp4`. Intentionally tighter than
+    "any `.mp4` in prose" — mirrors the `check_proof_gate` matcher so
+    the gate and the attachment code agree on what counts as a proof.
+    """
+    for body in comment_bodies:
+        match = MP4_LINE_RE.search(body)
+        if match:
+            return match.group(1)
+    return None
+
+
+def extract_fds_verification(comment_bodies: list[str]) -> str | None:
+    """Return the first comment body that STARTS with the FDS sentinel.
+
+    The whole comment body is returned verbatim so it can be copied into
+    the ADO PR description — reviewers on ADO (where GitHub is private)
+    see the FDS checklist inline without following a link they can't open.
+    """
+    for body in comment_bodies:
+        if body.startswith(FDS_SENTINEL):
+            return body
+    return None
+
+
+def build_pr_body(
+    branch: str,
+    issue: int,
+    fds_verification: str | None,
+    mp4_attachment_url: str | None,
+    mp4_skip_reason: str | None,
+) -> str:
+    """Assemble the ADO PR description from the pieces gathered on GitHub.
+
+    ADO reviewers cannot access the (private) GitHub issue, so the PR body
+    carries the proofs directly: the FDS Verification checklist verbatim and
+    an attachment link to the MP4. When the MP4 can't be attached (too big,
+    not found on disk), the body surfaces the skip reason instead of silently
+    dropping it — a reviewer must see that a proof was expected.
+    """
+    sections: list[str] = [
+        f"## GitHub Issue\n{GH_REPO}#{issue}",
+        f"## Branch\n`{branch}`",
+    ]
+
+    if mp4_attachment_url:
+        sections.append(
+            "## MP4 Proof\n"
+            f"[Download MP4 proof]({mp4_attachment_url})\n\n"
+            "Attached directly to this PR — no GitHub access required."
+        )
+    elif mp4_skip_reason:
+        sections.append(f"## MP4 Proof\n⚠️ {mp4_skip_reason}")
+
+    if fds_verification:
+        sections.append(
+            "## FDS Verification\n"
+            "_Copied verbatim from the GitHub issue comment so ADO reviewers "
+            "see the FDS checklist inline._\n\n"
+            f"{fds_verification}"
+        )
+
+    sections.append("---\nCreated by C.L.A.I.R.E. pipeline")
+    return "\n\n".join(sections)
+
+
+def gh_list_issue_comment_bodies(issue: int) -> list[str]:
+    """Return raw body strings for every comment on a GitHub issue."""
+    url = f"{GH_API_BASE}/issues/{issue}/comments?per_page=100"
+    req = urllib.request.Request(url, headers=_gh_headers())
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read().decode())
+    return [str(item.get("body", "")) for item in payload]
+
+
+def ado_upload_pr_attachment(
+    pr_id: int, file_path: str, file_name: str, pat: str
+) -> str | None:
+    """Upload a local file as an ADO PR attachment. Return the attachment URL, or None on failure.
+
+    Uses the ADO REST attachments endpoint:
+      PUT /git/repositories/{repo}/pullRequests/{pr_id}/attachments/{name}?api-version=7.1
+    Body = raw bytes, Content-Type = application/octet-stream. The response
+    JSON carries a `url` field the reviewer's browser can fetch with their
+    ADO session — no GitHub access needed.
+    """
+    try:
+        with open(file_path, "rb") as fh:
+            data = fh.read()
+    except OSError as exc:
+        print(f"[agent] Could not read {file_path}: {exc}", file=sys.stderr)
+        return None
+
+    encoded_name = urllib.parse.quote(file_name, safe="")
+    url = (
+        f"{ADO_BASE_URL}/git/repositories/{ADO_REPO}"
+        f"/pullRequests/{pr_id}/attachments/{encoded_name}?api-version=7.1"
     )
+    headers = _ado_headers(pat)
+    headers["Content-Type"] = "application/octet-stream"
+
+    req = urllib.request.Request(url, data=data, headers=headers, method="PUT")
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            response = json.loads(resp.read().decode())
+        return str(response.get("url") or "") or None
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        print(f"[agent] Attachment upload failed for {file_name}: {exc}", file=sys.stderr)
+        return None
+
+
+def ado_patch_pr_description(pr_id: int, description: str, pat: str) -> bool:
+    """PATCH an existing ADO PR's description. Returns True on success."""
+    url = (
+        f"{ADO_BASE_URL}/git/repositories/{ADO_REPO}"
+        f"/pullrequests/{pr_id}?api-version=7.1"
+    )
+    data = json.dumps({"description": description}).encode()
+    req = urllib.request.Request(url, data=data, headers=_ado_headers(pat), method="PATCH")
+    try:
+        with urllib.request.urlopen(req, timeout=30):
+            return True
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+        print(f"[agent] PR description PATCH failed: {exc}", file=sys.stderr)
+        return False
+
+
+def attach_mp4_and_get_link(
+    pr_id: int, mp4_path: str | None, pat: str
+) -> tuple[str | None, str | None]:
+    """Try to attach an MP4 to the PR. Returns (attachment_url, skip_reason).
+
+    Exactly one of the two is populated. Skip reasons name what the reviewer
+    needs to know (size limit breach, missing file) — never drop the proof
+    silently.
+    """
+    if not mp4_path:
+        return None, "No MP4 line found in the GitHub issue comments."
+
+    if not os.path.exists(mp4_path):
+        return None, f"MP4 referenced in issue but not on disk: `{mp4_path}`"
+
+    size = os.path.getsize(mp4_path)
+    if size > ADO_ATTACHMENT_SIZE_LIMIT:
+        mb = size / (1024 * 1024)
+        limit_mb = ADO_ATTACHMENT_SIZE_LIMIT / (1024 * 1024)
+        return (
+            None,
+            f"MP4 too large for ADO attachments ({mb:.1f} MB > {limit_mb:.0f} MB): `{mp4_path}`",
+        )
+
+    file_name = os.path.basename(mp4_path)
+    url = ado_upload_pr_attachment(pr_id, mp4_path, file_name, pat)
+    if not url:
+        return None, f"MP4 upload failed (see agent log): `{mp4_path}`"
+    return url, None
+
+
+def create_pr(branch: str, target: str, issue: int, pat: str) -> tuple[int, str]:
+    """Create ADO PR enriched with proofs from the GitHub issue.
+
+    Flow:
+    1. Fetch issue comments; extract MP4 path + FDS Verification text.
+    2. Create the PR with a skeleton body.
+    3. Upload the MP4 as an ADO attachment when possible.
+    4. PATCH the PR description with the final body (attachment link +
+       FDS text verbatim). Reviewers on ADO see everything inline —
+       GitHub is private and they can't click through.
+    """
+    pr_title = branch.removeprefix("feature/").removeprefix("bugfix/")
+
+    try:
+        comment_bodies = gh_list_issue_comment_bodies(issue)
+    except Exception as exc:
+        print(f"[agent] Could not fetch GitHub comments for enrichment: {exc}", file=sys.stderr)
+        comment_bodies = []
+
+    mp4_path = extract_mp4_path(comment_bodies)
+    fds_text = extract_fds_verification(comment_bodies)
+
+    skeleton_body = build_pr_body(
+        branch,
+        issue,
+        fds_verification=fds_text,
+        mp4_attachment_url=None,
+        mp4_skip_reason="Upload in progress..." if mp4_path else None,
+    )
+
     response = ado_post(
         f"/git/repositories/{ADO_REPO}/pullrequests?api-version=7.1",
         {
             "sourceRefName": f"refs/heads/{branch}",
             "targetRefName": f"refs/heads/{target}",
             "title": pr_title,
-            "description": pr_body,
+            "description": skeleton_body,
         },
         pat,
     )
@@ -94,6 +289,18 @@ def create_pr(branch: str, target: str, issue: int, pat: str) -> tuple[int, str]
         f"https://dev.azure.com/{ADO_ORG}/{ADO_PROJECT}"
         f"/_git/{ADO_REPO}/pullrequest/{pr_id}"
     )
+
+    attachment_url, skip_reason = attach_mp4_and_get_link(pr_id, mp4_path, pat)
+    final_body = build_pr_body(
+        branch,
+        issue,
+        fds_verification=fds_text,
+        mp4_attachment_url=attachment_url,
+        mp4_skip_reason=skip_reason,
+    )
+    if final_body != skeleton_body:
+        ado_patch_pr_description(pr_id, final_body, pat)
+
     return pr_id, pr_url
 
 

--- a/domain/scripts/ado_common.sh
+++ b/domain/scripts/ado_common.sh
@@ -471,7 +471,15 @@ verify_branch_synced_with_ado_dev() {
 
     local ado_tip merge_base
     ado_tip=$(git rev-parse "origin/$target")
-    merge_base=$(git merge-base "$branch" "origin/$target")
+    # `git merge-base` returns exit=1 for disjoint histories. Without this
+    # guard, an empty merge_base would resolve to HEAD in the log command
+    # below, hiding the real problem behind a misleading "merge-base" line.
+    if ! merge_base=$(git merge-base "$branch" "origin/$target" 2>/dev/null) \
+        || [[ -z "$merge_base" ]]; then
+        echo "ERROR: no common ancestor between '$branch' and 'origin/$target' (disjoint histories?)" >&2
+        popd > /dev/null || true
+        return 2
+    fi
 
     if [[ "$merge_base" == "$ado_tip" ]]; then
         echo "✅ Branch is fast-forward with origin/$target (merge-base = ADO $target tip)"

--- a/domain/scripts/ado_common.sh
+++ b/domain/scripts/ado_common.sh
@@ -417,3 +417,223 @@ check_proof_gate() {
 
     return 1
 }
+
+# Verify the feature branch is fast-forward with ADO's target-branch tip.
+#
+# The GitHub mirror and ADO (TFIOneGit) have divergent histories — same
+# content, different SHAs — caused by past "start fresh" resets. A dev who
+# branches from github/dev and pushes to ADO without checking ends up with
+# a PR containing dozens of unrelated commits (incident on issue #71: 65
+# commits of divergent mirror history mixed with a 2-commit feature).
+# `git push --force-with-lease` does NOT catch this — it only guards against
+# overwriting someone else's push to the SAME ref.
+#
+# Invariant enforced: merge-base(branch, origin/target) == origin/target tip.
+# When true, the branch contains only the dev's intended commits on top of
+# ADO's target tip.
+#
+# Usage: verify_branch_synced_with_ado_dev <branch> <target_branch> <repo_path>
+#   branch:        feature branch to push (e.g. feature/18839-client-face-sheet)
+#   target_branch: ADO target (e.g. dev)
+#   repo_path:     local clone of the ADO-origin repo (e.g. ~/TFIOneGit)
+#
+# Returns 0 when fast-forward, 1 when divergent, 2 on missing args or git error.
+# Prints the resolution options (cherry-pick onto fresh branch, or reset +
+# cherry-pick) on failure — the dev never has to guess how to recover.
+verify_branch_synced_with_ado_dev() {
+    local branch="$1"
+    local target="$2"
+    local repo_path="$3"
+
+    if [[ -z "$branch" || -z "$target" || -z "$repo_path" ]]; then
+        echo "ERROR: verify_branch_synced_with_ado_dev requires <branch> <target> <repo_path>" >&2
+        return 2
+    fi
+
+    if [[ ! -d "$repo_path/.git" ]]; then
+        echo "ERROR: $repo_path is not a git repository" >&2
+        return 2
+    fi
+
+    pushd "$repo_path" > /dev/null || return 2
+
+    if ! git rev-parse --verify "$branch" &>/dev/null; then
+        echo "ERROR: branch '$branch' does not exist in $repo_path" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+
+    if ! git fetch origin "$target" --quiet 2>/dev/null; then
+        echo "ERROR: failed to fetch origin/$target from $repo_path" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+
+    local ado_tip merge_base
+    ado_tip=$(git rev-parse "origin/$target")
+    merge_base=$(git merge-base "$branch" "origin/$target")
+
+    if [[ "$merge_base" == "$ado_tip" ]]; then
+        echo "✅ Branch is fast-forward with origin/$target (merge-base = ADO $target tip)"
+        popd > /dev/null || true
+        return 0
+    fi
+
+    local ahead behind ado_tip_line merge_base_line
+    ahead=$(git rev-list --count "$ado_tip..$branch")
+    behind=$(git rev-list --count "$branch..$ado_tip")
+    ado_tip_line=$(git log --oneline -1 "origin/$target")
+    merge_base_line=$(git log --oneline -1 "$merge_base")
+
+    {
+        echo ""
+        echo "❌ Branch is not up-to-date with ADO $target."
+        echo "    ADO $target tip:    $ado_tip_line"
+        echo "    Branch merge-base:  $merge_base_line"
+        echo "    Commits ahead:      $ahead   (your feature work + any divergent mirror history)"
+        echo "    Commits behind:     $behind   (ADO $target commits your branch doesn't have)"
+        echo ""
+        echo "    Pushing this branch to ADO will create a chaotic PR with $ahead commits."
+        echo ""
+        echo "    RESOLVE by either:"
+        echo "      (a) Cherry-pick your feature commits onto a fresh branch off ADO $target:"
+        echo "          git fetch origin"
+        echo "          git checkout -b ${branch}-ado origin/$target"
+        echo "          git cherry-pick <your-commit-sha>..."
+        echo "          # rerun 5 gates"
+        echo "          git push ado ${branch}-ado:refs/heads/${branch} --force-with-lease"
+        echo ""
+        echo "      (b) Reset your existing branch to ADO $target + cherry-pick (rewrites GitHub PR history):"
+        echo "          git fetch origin"
+        echo "          git checkout ${branch}"
+        echo "          git reset --hard origin/$target"
+        echo "          git cherry-pick <your-commit-sha>..."
+        echo "          # rerun 5 gates"
+        echo "          git push github ${branch} --force-with-lease   # updates GitHub PR"
+        echo "          # then rerun claire fivepoints ado-transition"
+        echo ""
+    } >&2
+
+    popd > /dev/null || true
+    return 1
+}
+
+# Attempt to auto-rebase a feature branch onto ADO $target, replaying only
+# the dev's own commits (not the GitHub mirror's divergent history).
+#
+# The #71 scenario: branch carries N commits of mirror-only history mixed
+# with a handful of real feature commits. A plain `git rebase origin/$target`
+# would try to replay all N on ADO, producing spurious conflicts or
+# duplicates. Instead we use:
+#   git rebase --onto origin/$target  <mirror_base>  $branch
+# where mirror_base = merge-base($branch, $mirror_remote/$target). Commits
+# between mirror_base and the branch tip are, by construction, the dev's
+# own work added after branching from the GitHub mirror — exactly what we
+# want to replay onto ADO.
+#
+# Usage: attempt_auto_rebase_onto_ado <branch> <target> <repo_path> [<mirror_remote>]
+#   branch:        feature branch to rebase (e.g. feature/18839-x)
+#   target:        ADO target (e.g. dev)
+#   repo_path:     local clone of the ADO-origin repo
+#   mirror_remote: GitHub mirror remote name (default: github)
+#
+# Returns:
+#   0 on clean rebase (branch now fast-forward with origin/$target)
+#   1 on conflict (rebase aborted, branch left in pre-rebase state)
+#   2 on setup failure (missing remotes, dirty worktree, unknown branch)
+#
+# Side effect on success: the branch in repo_path is moved. Caller MUST
+# log the action so the dev sees what happened.
+attempt_auto_rebase_onto_ado() {
+    local branch="$1"
+    local target="$2"
+    local repo_path="$3"
+    local mirror_remote="${4:-github}"
+
+    if [[ -z "$branch" || -z "$target" || -z "$repo_path" ]]; then
+        echo "ERROR: attempt_auto_rebase_onto_ado requires <branch> <target> <repo_path> [<mirror_remote>]" >&2
+        return 2
+    fi
+
+    if [[ ! -d "$repo_path/.git" ]]; then
+        echo "ERROR: $repo_path is not a git repository" >&2
+        return 2
+    fi
+
+    pushd "$repo_path" > /dev/null || return 2
+
+    # Refuse to rebase a dirty worktree — we'd risk losing uncommitted work.
+    if ! git diff --quiet HEAD 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+        echo "ERROR: worktree has uncommitted changes — auto-rebase refused" >&2
+        echo "       commit or stash before retrying, or pass --no-auto-sync to skip" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+
+    if ! git remote get-url "$mirror_remote" &>/dev/null; then
+        echo "ERROR: mirror remote '$mirror_remote' not configured in $repo_path" >&2
+        echo "       auto-rebase needs both origin (ADO) and $mirror_remote (GitHub) remotes" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+
+    if ! git rev-parse --verify "$branch" &>/dev/null; then
+        echo "ERROR: branch '$branch' does not exist in $repo_path" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+
+    # Fetch both remotes quietly — fail loudly if either is unreachable.
+    if ! git fetch origin "$target" --quiet 2>/dev/null; then
+        echo "ERROR: failed to fetch origin/$target" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+    if ! git fetch "$mirror_remote" "$target" --quiet 2>/dev/null; then
+        echo "ERROR: failed to fetch $mirror_remote/$target" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+
+    local mirror_base
+    if ! mirror_base=$(git merge-base "$branch" "$mirror_remote/$target" 2>/dev/null) \
+        || [[ -z "$mirror_base" ]]; then
+        echo "ERROR: could not compute merge-base with $mirror_remote/$target" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+
+    # Save pre-rebase HEAD for rollback signalling.
+    local pre_head
+    pre_head=$(git rev-parse "$branch")
+
+    # Check out the branch (detached-head-safe) — `git rebase --onto` needs
+    # the branch HEAD as the argument, and we want to operate on that branch.
+    if ! git checkout -q "$branch" 2>/dev/null; then
+        echo "ERROR: could not checkout $branch" >&2
+        popd > /dev/null || true
+        return 2
+    fi
+
+    echo "      auto-rebasing: git rebase --onto origin/$target ${mirror_base:0:7} $branch"
+
+    if git rebase --onto "origin/$target" "$mirror_base" "$branch" 2>&1; then
+        local new_head
+        new_head=$(git rev-parse HEAD)
+        if [[ "$new_head" == "$pre_head" ]]; then
+            echo "✅ Auto-rebase: branch already on ADO $target — no commits moved"
+        else
+            echo "✅ Auto-rebase: branch replayed onto origin/$target"
+            echo "      pre-rebase HEAD:  ${pre_head:0:12}"
+            echo "      post-rebase HEAD: ${new_head:0:12}"
+        fi
+        popd > /dev/null || true
+        return 0
+    fi
+
+    # Rebase failed — abort to leave the branch exactly where it was.
+    echo "⚠️  Auto-rebase hit a conflict — aborting to leave the branch untouched"
+    git rebase --abort 2>/dev/null || true
+    popd > /dev/null || true
+    return 1
+}

--- a/domain/scripts/tests/test_ado_agent.py
+++ b/domain/scripts/tests/test_ado_agent.py
@@ -108,7 +108,6 @@ class TestBuildPrBody:
         fds = f"{FDS_SENTINEL}\n- Screen A: pass\n- Screen B: pass"
         body = build_pr_body(
             "feature/71-x",
-            71,
             fds_verification=fds,
             mp4_attachment_url=None,
             mp4_skip_reason=None,
@@ -120,7 +119,6 @@ class TestBuildPrBody:
     def test_embeds_mp4_attachment_link_when_url_provided(self):
         body = build_pr_body(
             "feature/71-x",
-            71,
             fds_verification=None,
             mp4_attachment_url="https://ado/x.mp4",
             mp4_skip_reason=None,
@@ -130,7 +128,6 @@ class TestBuildPrBody:
     def test_surfaces_skip_reason_when_mp4_not_attached(self):
         body = build_pr_body(
             "feature/71-x",
-            71,
             fds_verification=None,
             mp4_attachment_url=None,
             mp4_skip_reason="MP4 too large (50 MB)",
@@ -143,7 +140,6 @@ class TestBuildPrBody:
     def test_skips_mp4_and_fds_sections_when_neither_present(self):
         body = build_pr_body(
             "feature/71-x",
-            71,
             fds_verification=None,
             mp4_attachment_url=None,
             mp4_skip_reason=None,
@@ -155,7 +151,6 @@ class TestBuildPrBody:
         # If both are somehow supplied, the URL wins (truthy attachment).
         body = build_pr_body(
             "feature/71-x",
-            71,
             fds_verification=None,
             mp4_attachment_url="https://ado/x.mp4",
             mp4_skip_reason="should be ignored",
@@ -163,16 +158,21 @@ class TestBuildPrBody:
         assert "Download MP4 proof" in body
         assert "should be ignored" not in body
 
-    def test_always_includes_branch_and_issue(self):
+    def test_always_includes_branch(self):
+        # Ticket id lives in the branch name by convention
+        # (feature/<ticket-id>-<desc>). GitHub issue number is intentionally
+        # NOT embedded — ADO reviewers can't reach GitHub, the reference
+        # would be noise to them.
         body = build_pr_body(
             "feature/9999-abc",
-            9999,
             fds_verification=None,
             mp4_attachment_url=None,
             mp4_skip_reason=None,
         )
         assert "feature/9999-abc" in body
-        assert "#9999" in body
+        # Negative assertion: no `GitHub Issue` section, no `owner/repo#N`
+        assert "GitHub Issue" not in body
+        assert f"#{9999}" not in body
 
 
 # ---------------------------------------------------------------------------

--- a/domain/scripts/tests/test_ado_agent.py
+++ b/domain/scripts/tests/test_ado_agent.py
@@ -1,0 +1,206 @@
+"""Unit tests for ado_agent enrichment helpers (issue #86).
+
+Pure-function tests — no network, no ADO calls. Covers the parsing and body
+assembly that carries FDS Verification + MP4 attachment info into the ADO PR
+description (reviewers on ADO cannot access the GitHub mirror).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+from ado_agent import (  # noqa: E402
+    ADO_ATTACHMENT_SIZE_LIMIT,
+    FDS_SENTINEL,
+    attach_mp4_and_get_link,
+    build_pr_body,
+    extract_fds_verification,
+    extract_mp4_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_mp4_path — mirrors check_proof_gate's matcher so the gate and
+# the attachment code agree on what counts as a proof.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMp4Path:
+    def test_matches_mp4_prefix(self):
+        assert extract_mp4_path(["MP4: /tmp/proof.mp4"]) == "/tmp/proof.mp4"
+
+    def test_matches_proof_prefix(self):
+        assert extract_mp4_path(["Proof: /tmp/a.mp4"]) == "/tmp/a.mp4"
+
+    def test_matches_recording_prefix(self):
+        assert extract_mp4_path(["Recording: /tmp/r.mp4"]) == "/tmp/r.mp4"
+
+    def test_matches_video_prefix(self):
+        assert extract_mp4_path(["Video: /tmp/v.mp4"]) == "/tmp/v.mp4"
+
+    def test_case_insensitive(self):
+        assert extract_mp4_path(["video: /tmp/v.mp4"]) == "/tmp/v.mp4"
+        assert extract_mp4_path(["PROOF: /tmp/p.mp4"]) == "/tmp/p.mp4"
+
+    def test_returns_first_match_across_comments(self):
+        # The first MP4 reference wins — matches how dev checklist expects
+        # the [8/11] comment to be posted once per issue.
+        assert extract_mp4_path(
+            ["chit-chat", "Proof: /tmp/first.mp4", "Video: /tmp/second.mp4"]
+        ) == "/tmp/first.mp4"
+
+    def test_rejects_prose_mentioning_mp4(self):
+        # Guard against false positives: discussion comments may mention
+        # `.mp4` without intending it as a proof reference.
+        assert (
+            extract_mp4_path(
+                ["Don't use ffmpeg — use the Playwright .mp4 recording instead."]
+            )
+            is None
+        )
+
+    def test_rejects_inline_backtick_reference(self):
+        assert (
+            extract_mp4_path(["See the `MP4:` line in the checklist for syntax."])
+            is None
+        )
+
+    def test_returns_none_on_no_comments(self):
+        assert extract_mp4_path([]) is None
+
+
+# ---------------------------------------------------------------------------
+# extract_fds_verification
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFdsVerification:
+    def test_returns_body_when_starts_with_sentinel(self):
+        body = f"{FDS_SENTINEL}\n- Screen X: pass"
+        assert extract_fds_verification([body]) == body
+
+    def test_returns_none_when_sentinel_is_inline(self):
+        # Guard against false positives: a discussion comment quoting the
+        # sentinel in backticks must not satisfy the verification slot.
+        body = f"Looking for `{FDS_SENTINEL}` headers in the issue."
+        assert extract_fds_verification([body]) is None
+
+    def test_returns_first_sentinel_match(self):
+        b1 = f"{FDS_SENTINEL}\n- first"
+        b2 = f"{FDS_SENTINEL}\n- second"
+        assert extract_fds_verification(["intro", b1, b2]) == b1
+
+    def test_returns_none_on_empty(self):
+        assert extract_fds_verification([]) is None
+
+
+# ---------------------------------------------------------------------------
+# build_pr_body — the contract with ADO reviewers.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrBody:
+    def test_embeds_fds_verification_verbatim(self):
+        fds = f"{FDS_SENTINEL}\n- Screen A: pass\n- Screen B: pass"
+        body = build_pr_body(
+            "feature/71-x",
+            71,
+            fds_verification=fds,
+            mp4_attachment_url=None,
+            mp4_skip_reason=None,
+        )
+        # The whole FDS block must appear inside the PR body so reviewers
+        # see the checklist without accessing GitHub.
+        assert fds in body
+
+    def test_embeds_mp4_attachment_link_when_url_provided(self):
+        body = build_pr_body(
+            "feature/71-x",
+            71,
+            fds_verification=None,
+            mp4_attachment_url="https://ado/x.mp4",
+            mp4_skip_reason=None,
+        )
+        assert "[Download MP4 proof](https://ado/x.mp4)" in body
+
+    def test_surfaces_skip_reason_when_mp4_not_attached(self):
+        body = build_pr_body(
+            "feature/71-x",
+            71,
+            fds_verification=None,
+            mp4_attachment_url=None,
+            mp4_skip_reason="MP4 too large (50 MB)",
+        )
+        # A missing/skipped proof must be visible to the reviewer, not
+        # silently dropped — otherwise they trust a PR that lacks proof.
+        assert "⚠️" in body
+        assert "MP4 too large" in body
+
+    def test_skips_mp4_and_fds_sections_when_neither_present(self):
+        body = build_pr_body(
+            "feature/71-x",
+            71,
+            fds_verification=None,
+            mp4_attachment_url=None,
+            mp4_skip_reason=None,
+        )
+        assert "MP4 Proof" not in body
+        assert "FDS Verification" not in body
+
+    def test_prefers_attachment_over_skip_reason(self):
+        # If both are somehow supplied, the URL wins (truthy attachment).
+        body = build_pr_body(
+            "feature/71-x",
+            71,
+            fds_verification=None,
+            mp4_attachment_url="https://ado/x.mp4",
+            mp4_skip_reason="should be ignored",
+        )
+        assert "Download MP4 proof" in body
+        assert "should be ignored" not in body
+
+    def test_always_includes_branch_and_issue(self):
+        body = build_pr_body(
+            "feature/9999-abc",
+            9999,
+            fds_verification=None,
+            mp4_attachment_url=None,
+            mp4_skip_reason=None,
+        )
+        assert "feature/9999-abc" in body
+        assert "#9999" in body
+
+
+# ---------------------------------------------------------------------------
+# attach_mp4_and_get_link — the guard paths that don't need network.
+# ---------------------------------------------------------------------------
+
+
+class TestAttachMp4AndGetLink:
+    def test_returns_skip_reason_when_mp4_path_is_none(self):
+        url, reason = attach_mp4_and_get_link(123, None, pat="unused")
+        assert url is None
+        assert reason is not None and "No MP4 line" in reason
+
+    def test_returns_skip_reason_when_file_missing(self):
+        url, reason = attach_mp4_and_get_link(
+            123, "/nonexistent/path/proof.mp4", pat="unused"
+        )
+        assert url is None
+        assert reason is not None and "not on disk" in reason
+
+    def test_returns_skip_reason_when_file_too_large(self, tmp_path):
+        # Sparse file of size > ADO_ATTACHMENT_SIZE_LIMIT — no real bytes
+        # are written, just the size metadata, so the test is fast.
+        big = tmp_path / "big.mp4"
+        with open(big, "wb") as fh:
+            fh.seek(ADO_ATTACHMENT_SIZE_LIMIT + 1)
+            fh.write(b"\0")
+
+        url, reason = attach_mp4_and_get_link(123, str(big), pat="unused")
+        assert url is None
+        assert reason is not None and "too large" in reason

--- a/tests/scripts/test_attempt_auto_rebase.bats
+++ b/tests/scripts/test_attempt_auto_rebase.bats
@@ -1,0 +1,212 @@
+#!/usr/bin/env bats
+# tests/scripts/test_attempt_auto_rebase.bats
+#
+# Tests for attempt_auto_rebase_onto_ado() in domain/scripts/ado_common.sh
+# (issue #86 — the "scripter tout sauf merge conflicts" path).
+#
+# The function must replay only the dev's OWN commits (those added after
+# branching from the GitHub mirror) onto ADO origin/$target — never replay
+# mirror-divergent history. On conflict, it must abort cleanly and leave the
+# branch exactly where it was.
+#
+# Strategy: build real fixture git repos (two remotes — ADO-like origin +
+# GitHub-like mirror) so the merge-base math and rebase outcomes are genuine.
+
+ADO_COMMON="${BATS_TEST_DIRNAME}/../../domain/scripts/ado_common.sh"
+
+setup() {
+    export GIT_AUTHOR_NAME="bats"
+    export GIT_AUTHOR_EMAIL="bats@test.local"
+    export GIT_COMMITTER_NAME="bats"
+    export GIT_COMMITTER_EMAIL="bats@test.local"
+
+    ORIGIN_REPO="$BATS_TEST_TMPDIR/origin.git"    # ADO stand-in
+    MIRROR_REPO="$BATS_TEST_TMPDIR/mirror.git"    # GitHub mirror stand-in
+    WORK_REPO="$BATS_TEST_TMPDIR/work"
+
+    git init --bare --initial-branch=dev "$ORIGIN_REPO" >/dev/null
+    git init --bare --initial-branch=dev "$MIRROR_REPO" >/dev/null
+
+    # Work clone — seed with one commit on dev; push to both remotes.
+    git init --initial-branch=dev "$WORK_REPO" >/dev/null
+    pushd "$WORK_REPO" >/dev/null
+    echo "seed" > seed.txt
+    git add seed.txt
+    git commit -q -m "seed commit"
+    git remote add origin "$ORIGIN_REPO"
+    git remote add github "$MIRROR_REPO"
+    git push -q origin dev
+    git push -q github dev
+    popd >/dev/null
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR"
+}
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+@test "attempt_auto_rebase_onto_ado errors with code 2 on missing args" {
+    run bash -c "source '$ADO_COMMON' && attempt_auto_rebase_onto_ado"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"requires"* ]]
+}
+
+@test "attempt_auto_rebase_onto_ado errors with code 2 when repo_path is not a git repo" {
+    run bash -c "source '$ADO_COMMON' && attempt_auto_rebase_onto_ado feature/1-x dev /nonexistent"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not a git repository"* ]]
+}
+
+@test "attempt_auto_rebase_onto_ado errors with code 2 when mirror remote is missing" {
+    pushd "$WORK_REPO" >/dev/null
+    git checkout -q -b feature/1-clean dev
+    git remote remove github
+    popd >/dev/null
+
+    run bash -c "source '$ADO_COMMON' && attempt_auto_rebase_onto_ado feature/1-clean dev '$WORK_REPO'"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"mirror remote"* ]]
+}
+
+@test "attempt_auto_rebase_onto_ado errors with code 2 when branch does not exist" {
+    run bash -c "source '$ADO_COMMON' && attempt_auto_rebase_onto_ado feature/missing dev '$WORK_REPO'"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+@test "attempt_auto_rebase_onto_ado errors with code 2 when worktree is dirty" {
+    pushd "$WORK_REPO" >/dev/null
+    git checkout -q -b feature/dirty dev
+    echo "dirty" > uncommitted.txt
+    git add uncommitted.txt
+    popd >/dev/null
+
+    run bash -c "source '$ADO_COMMON' && attempt_auto_rebase_onto_ado feature/dirty dev '$WORK_REPO'"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"uncommitted"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Happy path — the #71 scenario with non-conflicting commits.
+# ---------------------------------------------------------------------------
+
+@test "attempt_auto_rebase_onto_ado cleanly replays dev commits onto ADO dev (happy path)" {
+    pushd "$WORK_REPO" >/dev/null
+
+    # ADO dev advances: adds a non-conflicting file.
+    local scratch="$BATS_TEST_TMPDIR/scratch-ado"
+    git clone -q "$ORIGIN_REPO" "$scratch"
+    pushd "$scratch" >/dev/null
+    git checkout -q dev
+    echo "ado-only" > ado-only.txt
+    git add ado-only.txt
+    git commit -q -m "ADO dev advance (non-conflict)"
+    git push -q origin dev
+    popd >/dev/null
+    rm -rf "$scratch"
+
+    # Mirror dev advances differently: adds another non-conflicting file.
+    # This is the divergence that makes a plain `git rebase origin/dev` fail
+    # on #71-like scenarios — we want to exclude mirror-only history.
+    local mscratch="$BATS_TEST_TMPDIR/scratch-mirror"
+    git clone -q "$MIRROR_REPO" "$mscratch"
+    pushd "$mscratch" >/dev/null
+    git checkout -q dev
+    echo "mirror-only" > mirror-only.txt
+    git add mirror-only.txt
+    git commit -q -m "mirror dev advance (divergent from ADO)"
+    # The scratch clone's remote is named "origin" (it was cloned FROM
+    # MIRROR_REPO) — push to that, not to "github".
+    git push -q origin dev
+    popd >/dev/null
+    rm -rf "$mscratch"
+
+    # Fetch mirror into the work repo, branch off mirror/dev (so the branch
+    # carries the mirror-only commit), then add a real feature commit.
+    git fetch -q github dev
+    git checkout -q -b feature/71-onto-test github/dev
+    echo "feature" > feature.txt
+    git add feature.txt
+    git commit -q -m "real feature commit"
+
+    popd >/dev/null
+
+    run bash -c "source '$ADO_COMMON' && attempt_auto_rebase_onto_ado feature/71-onto-test dev '$WORK_REPO'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Auto-rebase"* ]]
+
+    # After the rebase, the branch must contain:
+    #   - seed (from both)
+    #   - ado-only.txt (from origin/dev)
+    #   - feature.txt (our real commit)
+    # and must NOT contain mirror-only.txt (divergent mirror history, excluded).
+    pushd "$WORK_REPO" >/dev/null
+    git checkout -q feature/71-onto-test
+    [ -f seed.txt ]
+    [ -f ado-only.txt ]
+    [ -f feature.txt ]
+    [ ! -f mirror-only.txt ]
+    popd >/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Conflict path — branch CANNOT be rebased cleanly; must abort and leave
+# the branch exactly where it was.
+# ---------------------------------------------------------------------------
+
+@test "attempt_auto_rebase_onto_ado aborts cleanly on conflict and leaves branch untouched" {
+    pushd "$WORK_REPO" >/dev/null
+
+    # Both ADO dev and the feature branch modify the SAME file with
+    # incompatible changes → guaranteed rebase conflict.
+    local scratch="$BATS_TEST_TMPDIR/scratch-ado"
+    git clone -q "$ORIGIN_REPO" "$scratch"
+    pushd "$scratch" >/dev/null
+    git checkout -q dev
+    echo "ADO version" > shared.txt
+    git add shared.txt
+    git commit -q -m "ADO adds shared.txt"
+    git push -q origin dev
+    popd >/dev/null
+    rm -rf "$scratch"
+
+    git checkout -q -b feature/conflict dev
+    echo "dev version" > shared.txt
+    git add shared.txt
+    git commit -q -m "feature adds shared.txt with conflicting content"
+
+    local pre_head
+    pre_head=$(git rev-parse feature/conflict)
+
+    popd >/dev/null
+
+    run bash -c "source '$ADO_COMMON' && attempt_auto_rebase_onto_ado feature/conflict dev '$WORK_REPO'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"conflict"* || "$output" == *"aborting"* ]]
+
+    # Post-abort: branch HEAD must be unchanged; no rebase in progress.
+    pushd "$WORK_REPO" >/dev/null
+    local post_head
+    post_head=$(git rev-parse feature/conflict)
+    [ "$pre_head" = "$post_head" ]
+    # No .git/rebase-apply / rebase-merge dir should remain
+    [ ! -d .git/rebase-apply ]
+    [ ! -d .git/rebase-merge ]
+    popd >/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Already-synced branch — no-op, returns 0.
+# ---------------------------------------------------------------------------
+
+@test "attempt_auto_rebase_onto_ado succeeds as a no-op when branch is already on ADO dev tip" {
+    pushd "$WORK_REPO" >/dev/null
+    git checkout -q -b feature/already-synced dev
+    popd >/dev/null
+
+    run bash -c "source '$ADO_COMMON' && attempt_auto_rebase_onto_ado feature/already-synced dev '$WORK_REPO'"
+    [ "$status" -eq 0 ]
+}

--- a/tests/scripts/test_verify_branch_synced.bats
+++ b/tests/scripts/test_verify_branch_synced.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+# tests/scripts/test_verify_branch_synced.bats
+#
+# Tests for verify_branch_synced_with_ado_dev() in domain/scripts/ado_common.sh
+# (issue #86).
+#
+# The incident this guard prevents: a feature branch whose merge-base with ADO
+# dev is several commits behind the ADO dev tip gets pushed to ADO, producing
+# a PR that mixes dozens of unrelated mirror-history commits with the feature
+# work (issue #71 / PR #76 — 65 commits of chaos).
+#
+# Strategy: build real fixture git repos (not mocks) — two repos wired as
+# "origin" + feature branch — so the merge-base / rev-parse math is genuine.
+# Each test sets up its own topology under $BATS_TEST_TMPDIR.
+
+ADO_COMMON="${BATS_TEST_DIRNAME}/../../domain/scripts/ado_common.sh"
+
+setup() {
+    # Isolated git identity so commits don't fail in CI
+    export GIT_AUTHOR_NAME="bats"
+    export GIT_AUTHOR_EMAIL="bats@test.local"
+    export GIT_COMMITTER_NAME="bats"
+    export GIT_COMMITTER_EMAIL="bats@test.local"
+
+    ORIGIN_REPO="$BATS_TEST_TMPDIR/origin.git"
+    WORK_REPO="$BATS_TEST_TMPDIR/work"
+
+    # Bare origin (stands in for the ADO remote)
+    git init --bare --initial-branch=dev "$ORIGIN_REPO" >/dev/null
+
+    # Work clone — seed with one commit on dev, push to origin
+    git init --initial-branch=dev "$WORK_REPO" >/dev/null
+    pushd "$WORK_REPO" >/dev/null
+    echo "initial" > README.md
+    git add README.md
+    git commit -q -m "initial commit on dev"
+    git remote add origin "$ORIGIN_REPO"
+    git push -q origin dev
+    popd >/dev/null
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR"
+}
+
+# Helper: add a commit to origin/dev from a scratch clone, so the work repo's
+# origin/dev falls behind until it fetches.
+advance_origin_dev() {
+    local scratch="$BATS_TEST_TMPDIR/scratch-$RANDOM"
+    git clone -q "$ORIGIN_REPO" "$scratch"
+    pushd "$scratch" >/dev/null
+    git checkout -q dev
+    echo "advance" >> README.md
+    git commit -qa -m "advance dev on ADO"
+    git push -q origin dev
+    popd >/dev/null
+    rm -rf "$scratch"
+}
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+@test "verify_branch_synced_with_ado_dev errors with code 2 on missing args" {
+    run bash -c "source '$ADO_COMMON' && verify_branch_synced_with_ado_dev"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"requires"* ]]
+}
+
+@test "verify_branch_synced_with_ado_dev errors with code 2 when repo_path is not a git repo" {
+    run bash -c "source '$ADO_COMMON' && verify_branch_synced_with_ado_dev feature/1-x dev /nonexistent/path"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not a git repository"* ]]
+}
+
+@test "verify_branch_synced_with_ado_dev errors with code 2 when branch does not exist" {
+    run bash -c "source '$ADO_COMMON' && verify_branch_synced_with_ado_dev feature/1-missing dev '$WORK_REPO'"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Happy path: fast-forward branch
+# ---------------------------------------------------------------------------
+
+@test "verify_branch_synced_with_ado_dev passes when branch is fast-forward with origin/dev" {
+    # Create feature branch off dev (same tip) with one extra commit.
+    # merge-base(feature, origin/dev) == origin/dev tip — the invariant holds.
+    pushd "$WORK_REPO" >/dev/null
+    git checkout -q -b feature/1-clean dev
+    echo "feature" > feature.txt
+    git add feature.txt
+    git commit -q -m "feature commit"
+    popd >/dev/null
+
+    run bash -c "source '$ADO_COMMON' && verify_branch_synced_with_ado_dev feature/1-clean dev '$WORK_REPO'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fast-forward with origin/dev"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Fail path: divergent (ahead + behind) — the #71 scenario
+# ---------------------------------------------------------------------------
+
+@test "verify_branch_synced_with_ado_dev fails when origin/dev advanced after branching (the #71 scenario)" {
+    # 1. Create feature branch off the current dev tip.
+    pushd "$WORK_REPO" >/dev/null
+    git checkout -q -b feature/71-divergent dev
+    echo "feature" > feature.txt
+    git add feature.txt
+    git commit -q -m "feature commit"
+    popd >/dev/null
+
+    # 2. Advance origin/dev from an outside clone — simulates ADO dev moving
+    #    forward after the dev agent branched off the (now stale) mirror tip.
+    advance_origin_dev
+
+    # 3. The function must fetch, see the new origin/dev, and detect that
+    #    merge-base(feature, origin/dev) is now BEHIND origin/dev tip.
+    run bash -c "source '$ADO_COMMON' && verify_branch_synced_with_ado_dev feature/71-divergent dev '$WORK_REPO'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not up-to-date with ADO dev"* ]]
+    [[ "$output" == *"Pushing this branch to ADO will create a chaotic PR"* ]]
+    # Both recovery options must be printed — the dev never has to guess.
+    [[ "$output" == *"Cherry-pick your feature commits onto a fresh branch"* ]]
+    [[ "$output" == *"Reset your existing branch to ADO dev + cherry-pick"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Fail path: branch strictly behind (no feature commits)
+# ---------------------------------------------------------------------------
+
+@test "verify_branch_synced_with_ado_dev fails when branch is strictly behind origin/dev" {
+    # Feature branch at the old dev tip, origin/dev advances, feature has
+    # no commits of its own — still a mismatch.
+    pushd "$WORK_REPO" >/dev/null
+    git checkout -q -b feature/2-stale dev
+    popd >/dev/null
+
+    advance_origin_dev
+
+    run bash -c "source '$ADO_COMMON' && verify_branch_synced_with_ado_dev feature/2-stale dev '$WORK_REPO'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not up-to-date with ADO dev"* ]]
+    [[ "$output" == *"Commits behind:"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# --target parameter is honored (not hard-coded to "dev")
+# ---------------------------------------------------------------------------
+
+@test "verify_branch_synced_with_ado_dev honors custom target branch" {
+    # Create a release branch on origin, make our feature branch diverge
+    # from it, and check the function correctly compares against 'release'
+    # (not the default 'dev'). Proves the target parameter is wired end-to-end.
+    pushd "$WORK_REPO" >/dev/null
+    git checkout -q -b release dev
+    git push -q origin release
+    git checkout -q -b feature/3-release-target release
+    echo "feature" > feature.txt
+    git add feature.txt
+    git commit -q -m "feature commit"
+    popd >/dev/null
+
+    # Advance origin/release from outside.
+    local scratch="$BATS_TEST_TMPDIR/scratch-rel-$RANDOM"
+    git clone -q "$ORIGIN_REPO" "$scratch"
+    pushd "$scratch" >/dev/null
+    git checkout -q release
+    echo "advance" >> README.md
+    git commit -qa -m "advance release on ADO"
+    git push -q origin release
+    popd >/dev/null
+    rm -rf "$scratch"
+
+    run bash -c "source '$ADO_COMMON' && verify_branch_synced_with_ado_dev feature/3-release-target release '$WORK_REPO'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not up-to-date with ADO release"* ]]
+}


### PR DESCRIPTION
Closes #86.

## Summary

Three fixes on `claire fivepoints ado-transition`, stemming from the #71
incident where a branch with 65 mirror-divergent commits would have been
pushed blindly to ADO.

1. **Sync check** ([4/5] in `ado-transition.sh` → `verify_branch_synced_with_ado_dev` in `ado_common.sh`)
   Fails fast when `merge-base(branch, origin/$target) != origin/$target tip`. `--force-with-lease` only guards the same ref — it cannot detect a branch that carries dozens of unrelated commits. Resolution message names the two recovery paths (cherry-pick onto fresh branch / reset + cherry-pick) verbatim.

2. **Auto-rebase** (`attempt_auto_rebase_onto_ado` in `ado_common.sh`, default on)
   On divergence the script runs `git rebase --onto origin/$target <mirror_base> $branch` where `<mirror_base> = merge-base(branch, github/$target)`. This replays **only the dev's own commits** (those added after branching from the GitHub mirror), excluding the mirror-divergent history that would make a plain `git rebase origin/$target` thrash. Clean rebase → push proceeds. Conflict → rebase aborted, branch left untouched, manual resolution printed. Dirty worktree / missing `github` remote refused with an actionable error. Escape flag: `--no-auto-sync`.

3. **Embedded ADO PR proofs** (`ado_agent.py::create_pr` + helpers)
   GitHub is private — ADO reviewers can't follow links to the issue. The PR body now carries proofs inline: FDS Verification comment copied verbatim, MP4 uploaded as an ADO attachment (skip-with-warning when >25 MB or missing from disk). Pure `urllib`, no subprocess.

## Tests

- **bats** — 32 tests (17 pre-existing + 15 new across 2 files)
  - `test_verify_branch_synced.bats` — fast-forward / divergent (#71 scenario) / strictly behind / custom target / arg validation
  - `test_attempt_auto_rebase.bats` — happy path excludes mirror-only commits / conflict aborts cleanly / dirty worktree refused / missing mirror remote refused / no-op when already synced
- **pytest** — 22 tests (`test_ado_agent.py`)
  - `extract_mp4_path` matcher (all prefix variants, case-insensitive, prose/backtick rejection)
  - `extract_fds_verification` (sentinel match / inline-quote rejection)
  - `build_pr_body` (FDS verbatim / attachment link / skip-reason surfacing / branch+issue always present)
  - `attach_mp4_and_get_link` guard paths (missing file / too large) without network

## Verification Log

**Sync check — divergent branch (should FAIL):**

```
❌ Branch is not up-to-date with ADO dev.
    ADO dev tip:    512a523 Merged PR 440 — more unrelated ADO dev work
    Branch merge-base:  f539456 initial commit on dev
    Commits ahead:      1   (your feature work + any divergent mirror history)
    Commits behind:     2   (ADO dev commits your branch doesn't have)

    Pushing this branch to ADO will create a chaotic PR with 1 commits.

    RESOLVE by either:
      (a) Cherry-pick your feature commits onto a fresh branch off ADO dev:
          git fetch origin
          git checkout -b feature/71-divergent-ado origin/dev
          git cherry-pick <your-commit-sha>...
          # rerun 5 gates
          git push ado feature/71-divergent-ado:refs/heads/feature/71-divergent --force-with-lease

      (b) Reset your existing branch to ADO dev + cherry-pick (rewrites GitHub PR history):
          git fetch origin
          git checkout feature/71-divergent
          git reset --hard origin/dev
          git cherry-pick <your-commit-sha>...
          # rerun 5 gates
          git push github feature/71-divergent --force-with-lease   # updates GitHub PR
          # then rerun claire fivepoints ado-transition
exit=1
```

**Sync check — clean (rebased) branch (should PASS):**

```
✅ Branch is fast-forward with origin/dev (merge-base = ADO dev tip)
exit=0
```

Command: direct invocation against fixture repos (bare origin + work clone + outside scratch that advances origin/dev between the dev branching and running the check).

**bats suite (32 passed):**
```
ok 1 attempt_auto_rebase_onto_ado errors with code 2 on missing args
... (32 of 32 pass)
```

**pytest suite (22 passed, 0.06s):**
```
============================== 22 passed in 0.06s ==============================
```

**`--help` output:**

```
  [4/5] Sync check — verify branch is fast-forward with ADO target (prevents chaotic PRs)
  [5/5] Set up ADO remote + git push + call ado_agent.py (build verification agent)

Options:
  --issue <N>       GitHub issue number (required)
  --branch <name>   Branch to push (default: current branch)
  --target <branch> Target branch for ADO PR (default: dev)
  --no-auto-sync    Skip auto-rebase on divergence — print manual resolution and exit 1

Auto-sync:
  When the branch is not fast-forward with ADO <target>, the script attempts
  git rebase --onto origin/<target> <mirror-base> <branch> (where mirror-base
  is the merge-base with the GitHub mirror). Clean rebase → push proceeds.
  Conflict → rebase aborted, manual resolution printed, exit 1.
  Pass --no-auto-sync to skip the attempt entirely.
```

Context: fresh worktree on issue-86, simulated a #71-shaped divergence with real git fixture repos.