### PR TITLE
docs(fivepoints): clarify 3-location feature branch visibility (#92)

### DIFF
--- a/domain/operational/ADO_GITHUB_SYNC.md
+++ b/domain/operational/ADO_GITHUB_SYNC.md
@@ -3,8 +3,8 @@ domain: fivepoints
 category: operational
 name: ADO_GITHUB_SYNC
 title: "FivePoints — ADO ↔ GitHub Sync (TFIOneGit mirror)"
-keywords: [five-points, fivepoints, ado, github, sync, ado-github-sync, tfionegit, mirror, dev-branch, remote, origin, review-repo, analyst]
-updated: 2026-04-14
+keywords: [five-points, fivepoints, ado, github, sync, ado-github-sync, tfionegit, mirror, dev-branch, feature-branch, branch-visibility, 3-location, remote, origin, review-repo, analyst, dev]
+updated: 2026-04-20
 pr: "#24"
 ---
 
@@ -89,8 +89,65 @@ The analyst session should never ask "should I push dev to GitHub?" — the answ
 
 ---
 
+## Feature Branch Visibility (3 Locations)
+
+`dev` is not the only branch that lives in multiple places. **Feature
+branches** (`feature/<ticket-id>-<slug>`) also move through three distinct
+locations during the pipeline, and each one lights up at a different step.
+Checking only one location and concluding "branch doesn't exist" is the
+failure mode this section prevents.
+
+| Location | What it is | When the branch lands here | How to check |
+|---|---|---|---|
+| `~/TFIOneGit/` local | The agent's working clone. Source of truth for the active session. | Immediately after `git checkout -b feature/<ticket-id>-<slug>` during analyst pre-flight. | `git -C ~/TFIOneGit branch --list "feature/<ticket-id>-*"` |
+| `github` remote on TFIOneGit (review repo — `$CLAIRE_WAIT_REPO`) | GitHub mirror. Pipeline issues + PRs coordinate here; this is where Steven Reviewer runs. | When the session runs `git push github feature/<ticket-id>-*` (analyst branch creation, or dev step [4/11]). | `gh api "repos/$CLAIRE_WAIT_REPO/branches/feature/<ticket-id>-<slug>" --jq .name 2>/dev/null` |
+| `origin` remote on TFIOneGit (ADO — source of truth) | Azure DevOps TFIOneGit. Production pipeline target. | ONLY after `claire fivepoints ado-transition --issue <N>` at dev step [10/11]. | `git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/<ticket-id>-*"` |
+
+**Absence on `origin` (ADO) is NORMAL until dev step [10/11].** Do not
+conclude "branch doesn't exist" from `origin` alone.
+
+### Pre-flight snippet — run at the top of every `[1/11]`-equivalent step
+
+```bash
+# Expect the ticket ID from the GitHub issue title (e.g. "Task #18842 (PBI #18840)" → 18842)
+ticket_id="<ticket-id>"                    # example: 18842
+slug="<slug-from-issue>"                   # example: service-provider-face-sheet
+branch="feature/${ticket_id}-${slug}"
+
+local=$(git -C ~/TFIOneGit branch --list "feature/${ticket_id}-*" | awk '{print $NF}' | head -1)
+github=$(gh api "repos/$CLAIRE_WAIT_REPO/branches/${branch}" --jq .name 2>/dev/null || echo "")
+ado=$(git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/${ticket_id}-*" | awk '{print $2}' | head -1)
+
+echo "local=${local:-absent}"
+echo "github=${github:-absent}"
+echo "ado=${ado:-absent}"
+```
+
+### Interpretation
+
+| local | github | ado | Meaning | Action |
+|---|---|---|---|---|
+| present | present | present | Branch already merged to ADO (or previously transitioned). | Investigate — this ticket may already be done. Do not recreate. |
+| present | present | absent | **Normal pre-transition state.** Interrupted or in-progress pipeline. | **Reuse it.** Check out the existing branch. Do not recreate. |
+| present | absent  | absent | Analyst started locally but never pushed to `github`. | `git push github "$branch"` — then reuse. |
+| absent  | present | absent | Previous session on a different host. | `git fetch github "$branch" && git checkout "$branch"` — then reuse. |
+| absent  | absent  | absent | **Truly new** — no prior session exists for this ticket. | Create the branch per the analyst checklist. |
+| absent  | absent  | present | ADO has a branch but local + github have been wiped. | Re-mirror: `git fetch origin "$branch" && git push github "$branch"` — then reuse. |
+
+The rule of thumb:
+
+> A branch ABSENT from `origin` (ADO) but PRESENT on `github` + `~/TFIOneGit`
+> means a prior session was interrupted before `[10/11] ado-transition`.
+> **Reuse it.** Do not recreate.
+>
+> A branch absent from all three locations → truly new → create per the
+> analyst checklist.
+
+---
+
 ## Related Docs
 
-- `claire domain read fivepoints operational CHECKLIST_ANALYST` — analyst pipeline (uses this sync)
+- `claire domain read fivepoints operational CHECKLIST_ANALYST` — analyst pipeline (uses this sync; cites the 3-location matrix at pre-flight)
+- `claire domain read fivepoints operational CHECKLIST_DEV_PIPELINE` — dev pipeline (cites the 3-location matrix at `[1/11]`)
 - `claire domain read fivepoints operational PIPELINE_WORKFLOW` — full client pipeline
 - `claire domain read fivepoints operational ADO_PAT_GUIDE` — PAT scopes for `git push origin`

--- a/domain/operational/ADO_GITHUB_SYNC.md
+++ b/domain/operational/ADO_GITHUB_SYNC.md
@@ -133,6 +133,13 @@ echo "ado=${ado:-absent}"
 | absent  | present | absent | Previous session on a different host. | `git fetch github "$branch" && git checkout "$branch"` — then reuse. |
 | absent  | absent  | absent | **Truly new** — no prior session exists for this ticket. | Create the branch per the analyst checklist. |
 | absent  | absent  | present | ADO has a branch but local + github have been wiped. | Re-mirror: `git fetch origin "$branch" && git push github "$branch"` — then reuse. |
+| present | absent  | present | Post-transition but github mirror was wiped. | Re-mirror to github: `git push github "$branch"` — then reuse. |
+| absent  | present | present | Post-transition but local working clone is missing. | Re-clone locally: `git fetch github "$branch" && git checkout "$branch"` — then reuse. |
+
+The last two rows cover every remaining `local/github/ado` combination. They
+are uncommon (typically a post-merge state where one of the mirrors has been
+wiped) and both resolve to the same pattern: re-mirror the missing location
+from whichever one still holds the branch, then reuse.
 
 The rule of thumb:
 

--- a/domain/operational/CHECKLIST_ANALYST.md
+++ b/domain/operational/CHECKLIST_ANALYST.md
@@ -3,7 +3,7 @@ name: CHECKLIST_ANALYST
 description: "Five Points — Pipeline role:analyst session checklist"
 type: operational
 keywords: [fivepoints, analyst, pipeline, checklist, role]
-updated: 2026-04-19
+updated: 2026-04-20
 ---
 
 ## Your Checklist (MANDATORY — follow in order)
@@ -238,10 +238,23 @@ EOF
          have already created a branch (and possibly an associated PR) for this task.
          Reusing that work preserves context and avoids duplicate branches.
 
-      existing_branch=$(gh api "repos/$CLAIRE_WAIT_REPO/branches" \
+      🚨 HARD RULE — check all 3 locations before deciding. Absence on GitHub
+         alone is NOT proof the branch doesn't exist. Reference:
+         claire domain read fivepoints operational ADO_GITHUB_SYNC
+         (section: Feature Branch Visibility (3 Locations)).
+
+      local=$(git -C ~/TFIOneGit branch --list "feature/{ticket-id}-*" | awk '{print $NF}' | head -1)
+      github=$(gh api "repos/$CLAIRE_WAIT_REPO/branches" \
         --paginate \
         --jq ".[] | select(.name | startswith(\"feature/{ticket-id}-\")) | .name" \
         | head -1)
+      ado=$(git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/{ticket-id}-*" | awk '{print $2}' | head -1)
+      echo "local=${local:-absent} github=${github:-absent} ado=${ado:-absent}"
+
+      # existing_branch is the authoritative value for the branch step below.
+      # Prefer github, fall back to local, then ado.
+      existing_branch="${github:-${local:-$(echo "$ado" | sed 's|refs/heads/||')}}"
+
       existing_pr=$(gh pr list --repo "$CLAIRE_WAIT_REPO" \
         --search "head:feature/{ticket-id}-" --state all \
         --json number,state,headRefName -q '.[0]')

--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -3,7 +3,7 @@ name: CHECKLIST_DEV_PIPELINE
 description: "Five Points — Pipeline role:dev session checklist"
 type: operational
 keywords: [fivepoints, dev, developer, pipeline, checklist, role]
-updated: 2026-04-16
+updated: 2026-04-20
 ---
 
 ### SESSION START — Create All Tasks First (MANDATORY)
@@ -40,11 +40,34 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (issue stays open 
       claire domain read fivepoints operational PIPELINE_WORKFLOW
       claire domain read fivepoints operational CODE_REVIEW_WORKFLOW
       claire domain read fivepoints operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational ADO_GITHUB_SYNC
       claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       claire domain read claire knowledge DEBUG_METHODOLOGY
       Read the GitHub issue — locate the **FDS Section** comment (the issue
       author or a prior session should have posted one with the exact source
       file path; if missing, you'll fetch the FDS yourself in [1.5/11]).
+
+      🚨 HARD RULE — Branch existence is a 3-location check. Feature branches
+         live in ~/TFIOneGit/ local + github mirror + ado origin; each
+         location lights up at a different pipeline step (ado = only after
+         [10/11]). See the Branch Visibility Matrix in fivepoints-dev persona
+         and ADO_GITHUB_SYNC (section: Feature Branch Visibility (3 Locations)).
+
+         ticket_id="<ticket-id>"                    # from the GitHub issue title
+         slug="<slug-from-issue>"
+         branch="feature/${ticket_id}-${slug}"
+         local=$(git -C ~/TFIOneGit branch --list "feature/${ticket_id}-*" | awk '{print $NF}' | head -1)
+         github=$(gh api "repos/$CLAIRE_WAIT_REPO/branches/${branch}" --jq .name 2>/dev/null || echo "")
+         ado=$(git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/${ticket_id}-*" | awk '{print $2}' | head -1)
+         echo "local=${local:-absent} github=${github:-absent} ado=${ado:-absent}"
+
+         - Present on github + local, absent on ado → interrupted prior
+           session before [10/11] → reuse the branch. Do not recreate.
+         - Present only on github → git fetch github "$branch" && git
+           checkout "$branch" → reuse.
+         - Present only on local → git push github "$branch" → reuse.
+         - Absent everywhere → truly new → create per analyst checklist.
+
       git fetch github
       git checkout feature/{ticket-id}-{description}
 

--- a/domain/persona/fivepoints-analyst.md
+++ b/domain/persona/fivepoints-analyst.md
@@ -3,7 +3,7 @@ name: fivepoints-analyst
 description: "Five Points analyst agent persona — pipeline role: role:analyst"
 type: persona
 keywords: [persona, fivepoints, analyst, pipeline, role]
-updated: 2026-04-19
+updated: 2026-04-20
 ---
 
 ## Persona: Five Points Analyst (Pipeline Role)
@@ -35,6 +35,27 @@ Rules:
    is your audit trail — the dev will verify their implementation against it.
 5. If the FDS is missing, unreadable, or contradicts the ADO description →
    post ONE focused question, `claire wait`. Never speculate.
+
+### Branch Visibility Matrix (HARD RULE — before creating a branch)
+
+You are the role that creates the feature branch. A previous analyst session
+may have already created the branch on `~/TFIOneGit/` and/or pushed it to
+`github`, even if `origin` (ADO) still has nothing. Before `git checkout -b`
+check all three locations:
+
+| Location | What it is | When the branch lands here | How to check |
+|---|---|---|---|
+| `~/TFIOneGit/` local | Your working clone of TFIOneGit. Source of truth for the active session. | Immediately after `git checkout -b feature/<ticket-id>-<slug>` below. | `git -C ~/TFIOneGit branch --list "feature/<ticket-id>-*"` |
+| `github` remote on TFIOneGit (= `$CLAIRE_WAIT_REPO`) | GitHub mirror. Pipeline issues + PRs coordinate here; Steven Reviewer runs here. | When you `git push -u github feature/<ticket-id>-*` during branch creation below. | `gh api "repos/$CLAIRE_WAIT_REPO/branches/feature/<ticket-id>-<slug>" --jq .name 2>/dev/null` |
+| `origin` remote on TFIOneGit (= ADO, source of truth) | Azure DevOps TFIOneGit. Production pipeline target. | ONLY after the dev's `[10/11] ado-transition`. | `git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/<ticket-id>-*"` |
+
+**Absence on `origin` (ADO) is NORMAL during analyst and dev work.** It is
+the expected state until the dev role's `[10/11] ado-transition` runs.
+Do not conclude "branch doesn't exist" from `origin` alone.
+
+Canonical reference (decision table + pre-flight snippet):
+`claire domain read fivepoints operational ADO_GITHUB_SYNC`
+(section: **Feature Branch Visibility (3 Locations)**).
 
 ### When You Need to Block — Discord Ping Protocol (GLOBAL)
 
@@ -322,10 +343,24 @@ EOF
          have already created a branch (and possibly an associated PR) for this task.
          Reusing that work preserves context and avoids duplicate branches.
 
-      existing_branch=$(gh api "repos/$CLAIRE_WAIT_REPO/branches" \
+      🚨 HARD RULE — check all 3 locations (see Branch Visibility Matrix in persona
+         and ADO_GITHUB_SYNC → Feature Branch Visibility (3 Locations)). A branch
+         absent from GitHub is NOT proof it doesn't exist — it may be on
+         ~/TFIOneGit/ local only (previous session never pushed), or on ADO
+         only (post-merge, post-wipe):
+
+      local=$(git -C ~/TFIOneGit branch --list "feature/{ticket-id}-*" | awk '{print $NF}' | head -1)
+      github=$(gh api "repos/$CLAIRE_WAIT_REPO/branches" \
         --paginate \
         --jq ".[] | select(.name | startswith(\"feature/{ticket-id}-\")) | .name" \
         | head -1)
+      ado=$(git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/{ticket-id}-*" | awk '{print $2}' | head -1)
+      echo "local=${local:-absent} github=${github:-absent} ado=${ado:-absent}"
+
+      # existing_branch is the authoritative value for the branch step below.
+      # Prefer github (pipeline's coordination surface), fall back to local, then ado.
+      existing_branch="${github:-${local:-$(echo "$ado" | sed 's|refs/heads/||')}}"
+
       existing_pr=$(gh pr list --repo "$CLAIRE_WAIT_REPO" \
         --search "head:feature/{ticket-id}-" --state all \
         --json number,state,headRefName -q '.[0]')

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -47,6 +47,9 @@ ticket_id="<ticket-id>"                    # from the GitHub issue title
 slug="<slug-from-issue>"
 branch="feature/${ticket_id}-${slug}"
 
+# local + ado use wildcard "feature/${ticket_id}-*" so a prior session's slug
+# drift doesn't hide the branch; github uses the exact "${branch}" composed
+# above because the GitHub branches API needs the full name (no glob support).
 local=$(git -C ~/TFIOneGit branch --list "feature/${ticket_id}-*" | awk '{print $NF}' | head -1)
 github=$(gh api "repos/$CLAIRE_WAIT_REPO/branches/${branch}" --jq .name 2>/dev/null || echo "")
 ado=$(git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/${ticket_id}-*" | awk '{print $2}' | head -1)

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -3,7 +3,7 @@ name: fivepoints-dev
 description: "Five Points developer agent persona — single source of truth (pipeline mode is the default; non-pipeline mode is no longer used in this plugin)"
 type: persona
 keywords: [persona, fivepoints, dev, developer, pipeline, role]
-updated: 2026-04-19
+updated: 2026-04-20
 ---
 
 ## Persona: Five Points Developer
@@ -27,6 +27,44 @@ document attached to the parent PBI is the source of truth. Before you implement
 
 If you skip this step, you are the last line of defense, and you have failed.
 This is enforced by `[1.5/12]` in `CHECKLIST_DEV_PIPELINE`.
+
+### Branch Visibility Matrix (HARD RULE — before concluding "branch doesn't exist")
+
+Feature branches (`feature/<ticket-id>-<slug>`) live in **three** locations
+during the pipeline, each lit up at a different step:
+
+| Location | What it is | When the branch lands here | How to check |
+|---|---|---|---|
+| `~/TFIOneGit/` local | Your working clone of TFIOneGit. Source of truth for the active session. | Immediately after `git checkout -b feature/<ticket-id>-<slug>` during analyst pre-flight. | `git -C ~/TFIOneGit branch --list "feature/<ticket-id>-*"` |
+| `github` remote on TFIOneGit (= `$CLAIRE_WAIT_REPO`) | GitHub mirror. Pipeline issues + PRs coordinate here; Steven Reviewer runs here. | When the session runs `git push github feature/<ticket-id>-*` (analyst branch creation, or dev step `[4/11]`). | `gh api "repos/$CLAIRE_WAIT_REPO/branches/feature/<ticket-id>-<slug>" --jq .name 2>/dev/null` |
+| `origin` remote on TFIOneGit (= ADO, source of truth) | Azure DevOps TFIOneGit. Production pipeline target. | ONLY after `claire fivepoints ado-transition --issue <N>` at `[10/11]`. | `git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/<ticket-id>-*"` |
+
+**Absence on `origin` (ADO) is NORMAL until `[10/11]` completes.** Before
+concluding "branch doesn't exist", check all three locations:
+
+```bash
+ticket_id="<ticket-id>"                    # from the GitHub issue title
+slug="<slug-from-issue>"
+branch="feature/${ticket_id}-${slug}"
+
+local=$(git -C ~/TFIOneGit branch --list "feature/${ticket_id}-*" | awk '{print $NF}' | head -1)
+github=$(gh api "repos/$CLAIRE_WAIT_REPO/branches/${branch}" --jq .name 2>/dev/null || echo "")
+ado=$(git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/${ticket_id}-*" | awk '{print $2}' | head -1)
+echo "local=${local:-absent} github=${github:-absent} ado=${ado:-absent}"
+```
+
+Decision rules:
+
+- Present on `github` + `~/TFIOneGit`, absent on `ado` → **interrupted prior
+  session before [10/11] ado-transition. Reuse it. Do not recreate.**
+- Present only on `github` → previous session on a different host →
+  `git fetch github "$branch" && git checkout "$branch"`, then reuse.
+- Present only on `~/TFIOneGit` → analyst never pushed the mirror →
+  `git push github "$branch"`, then reuse.
+- Absent from all three → truly new → create per analyst checklist.
+
+Canonical reference: `claire domain read fivepoints operational ADO_GITHUB_SYNC`
+(section: **Feature Branch Visibility (3 Locations)**).
 
 ### When You Need to Block — Discord Ping Protocol (GLOBAL)
 
@@ -134,11 +172,30 @@ TaskCreate(title="[11/11] Stop test environment + claire stop (issue stays open 
       claire domain read fivepoints operational PIPELINE_WORKFLOW
       claire domain read fivepoints operational CODE_REVIEW_WORKFLOW
       claire domain read fivepoints operational SWAGGER_VERIFICATION
+      claire domain read fivepoints operational ADO_GITHUB_SYNC
       claire domain read fivepoints technical FACE_SHEET_SECTION_PATTERNS
       claire domain read claire knowledge DEBUG_METHODOLOGY
       Read the GitHub issue — locate the **FDS Section** comment (the issue
       author or a prior session should have posted one with the exact source
       file path; if missing, you'll fetch the FDS yourself in [1.5/11]).
+
+      🚨 HARD RULE — Branch existence is a 3-location check. Before concluding
+         "branch doesn't exist", you MUST check local + github + ado. See the
+         Branch Visibility Matrix at the top of this persona and
+         ADO_GITHUB_SYNC (section: Feature Branch Visibility (3 Locations)):
+
+         ticket_id="<ticket-id>"
+         slug="<slug-from-issue>"
+         branch="feature/${ticket_id}-${slug}"
+         local=$(git -C ~/TFIOneGit branch --list "feature/${ticket_id}-*" | awk '{print $NF}' | head -1)
+         github=$(gh api "repos/$CLAIRE_WAIT_REPO/branches/${branch}" --jq .name 2>/dev/null || echo "")
+         ado=$(git -C ~/TFIOneGit ls-remote origin "refs/heads/feature/${ticket_id}-*" | awk '{print $2}' | head -1)
+         echo "local=${local:-absent} github=${github:-absent} ado=${ado:-absent}"
+
+         Absent on ADO but present on github + local = interrupted prior
+         session before [10/11]. **Reuse it.** Do not recreate.
+         Absent everywhere = truly new. Create per analyst checklist.
+
       git fetch github
       git checkout feature/{ticket-id}-{description}
 


### PR DESCRIPTION
## Summary

Fixes #92 — dev and analyst agents were concluding "branch doesn't exist" after checking only `origin` (ADO), then recreating interrupted pipelines. This happens because feature branches actually live in **three** locations during the pipeline, and ADO is the last one to receive the branch (only at dev step `[10/11] ado-transition`).

## Changes

- **`domain/operational/ADO_GITHUB_SYNC.md`** — new **"Feature Branch Visibility (3 Locations)"** section with the matrix, a pre-flight snippet, and a 6-row decision table covering every local/github/ado combination. This is the canonical reference; dev and analyst docs point at it.
- **`domain/persona/fivepoints-dev.md`** — added **"Branch Visibility Matrix"** block near the top + HARD RULE inside `[1/11]` branch-checkout step.
- **`domain/operational/CHECKLIST_DEV_PIPELINE.md`** — same HARD RULE wired into `[1/11]`.
- **`domain/persona/fivepoints-analyst.md`** — matrix block + rewrote the pre-flight "detect existing branch" step to check all three locations (local/github/ado) instead of only `gh api .../branches`.
- **`domain/operational/CHECKLIST_ANALYST.md`** — same 3-location pre-flight pattern.

Uses `\$CLAIRE_WAIT_REPO` (not a hardcoded org/name) in all new snippets, matching the convention already in place in CHECKLIST_ANALYST so both prod and test pipelines resolve correctly.

## Verification Log

Command: `claire verify-templates`
Context: worktree `issue-92-docs-fivepoints-dev-clarify-wh`, no prior config

\`\`\`
📋 Persona: fivepoints-dev
  ✅ No unsubstituted placeholders
  ✅ Section present: '## Current Task'
  ✅ Section present: '## Quick Reference'
  ✅ Section present: 'Checklist'
  ✅ Persona-specific content present ('fivepoints')
...
==================================================
✅ All template verification checks passed.
\`\`\`

Command: `claire context "TFIOneGit local github ado"`
Output (truncated — confirms ADO_GITHUB_SYNC now surfaces for the 3-location keyword set):

\`\`\`
### Domains
- **fivepoints/operational/ADO_GITHUB_SYNC**: FivePoints — ADO ↔ GitHub Sync
  Keywords: five-points, fivepoints, ado, github, sync
  → \`claire domain read fivepoints operational ADO_GITHUB_SYNC\`
\`\`\`

## Validation

- [x] Matrix + decision table documented in ADO_GITHUB_SYNC
- [x] Dev persona + checklist wire the HARD RULE into `[1/11]`
- [x] Analyst persona + checklist replace the single-lookup pre-flight with a 3-location check
- [x] `claire verify-templates` passes (no unsubstituted placeholders)
- [x] `claire context` surfaces the new keyword set

Closes #92