### PR TITLE
docs(fivepoints-dev): clarify plugin-local PRs skip the TFI One pipeline

### DIFF
--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -6,6 +6,30 @@ keywords: [fivepoints, dev, developer, pipeline, checklist, role]
 updated: 2026-04-20
 ---
 
+### Scope — TFI One app only
+
+This checklist drives **TFI One application work** in `~/TFIOneGit` — a
+feature in the API / web / migrations that ends with an ADO push. It does
+**NOT** apply to PRs that only touch the claire-plugin repo itself (bash
+in `domain/commands/`, Python in `domain/scripts/`, persona/checklist
+markdown, etc.).
+
+If the worktree path contains
+`.claire/plugins/fivepoints/.claire/worktrees/…`, skip this 11-step
+pipeline. Neither `./claire test` (no `./claire` wrapper exists in the
+plugin repo) nor global `claire test` (wrong suite — runs core
+claire-tests) is the right gate. Run the plugin's own tests directly:
+
+```bash
+bats tests/scripts/
+python3 -m pytest domain/scripts/tests/
+```
+
+Then push → open PR against `main` on `CLAIRE-Fivepoints/claire-plugin`
+and let Steven Reviewer (GitHub Actions) handle review. The FDS / Swagger
+/ Playwright / ADO-transition steps below are skipped entirely for
+plugin-local PRs.
+
 ### SESSION START — Create All Tasks First (MANDATORY)
 
 Before doing ANY work, create all 11 checklist tasks so each step is auditable:

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -11,6 +11,31 @@ updated: 2026-04-20
 > **Your session checklist is embedded below** (canonical content from
 > `operational/CHECKLIST_DEV_PIPELINE`). Follow it in order.
 
+### Scope — TFI One app vs plugin-local PRs
+
+This persona (and its 11-step checklist) targets **TFI One application
+work** in `~/TFIOneGit` — API / web / migrations / FDS-driven features,
+culminating in an ADO push. It does **NOT** apply to PRs that only touch
+the claire-plugin repo itself (bash in `domain/commands/`, Python in
+`domain/scripts/`, persona/checklist markdown, etc.).
+
+How to tell which side you're on: if the worktree path contains
+`.claire/plugins/fivepoints/.claire/worktrees/…`, you're on a
+**plugin-local** PR — the 11-step checklist does not apply, and neither
+the `./claire` wrapper nor global `claire test` is the right gate (there
+is no `./claire` wrapper in the plugin repo, and global `claire test`
+drives the core claire-tests suite, which will surface unrelated
+failures). Run the plugin's own tests directly:
+
+```bash
+bats tests/scripts/
+python3 -m pytest domain/scripts/tests/
+```
+
+Then push → open PR against `main` on `CLAIRE-Fivepoints/claire-plugin`
+and let Steven Reviewer (GitHub Actions) handle review. The FDS / Swagger
+/ Playwright / ADO-transition steps are skipped entirely.
+
 ## 🚨 RULE ZERO — Work end-to-end. Never stop silently.
 
 **The default is end-to-end execution.** Complete the full checklist in one


### PR DESCRIPTION
## Summary

Closes #90.

The fivepoints-dev persona and its 11-step checklist are 100% framed
around TFI One application work (FDS → Swagger → Playwright → ADO push,
in `~/TFIOneGit`). Nothing in them tells a developer what to do for a
**plugin-local PR** — one that only touches the `claire-plugin` repo
itself (`domain/commands/*.sh`, `domain/scripts/*.py`, persona/checklist
markdown, etc.).

That gap is what the retrospective from PR #87 / issue #86 hit. The
specific line it cited (step [5/11] saying "run `./claire test`") has
since been restructured away — but the underlying doc gap is broader
and still present.

### Change

Add a `### Scope` note at the top of both:
- `domain/persona/fivepoints-dev.md`
- `domain/operational/CHECKLIST_DEV_PIPELINE.md`

The note:
- States the persona/checklist targets TFI One app work
- Tells the reader how to recognize a plugin-local worktree (path
  contains `.claire/plugins/fivepoints/.claire/worktrees/…`)
- Names the two actual plugin-local test commands:
  - `bats tests/scripts/`
  - `python3 -m pytest domain/scripts/tests/`
- Confirms FDS / Swagger / Playwright / ADO-transition are skipped for
  plugin-local PRs

No structural change to the 11-step pipeline itself.

## Verification Log

Ran the plugin-local tests the new note points at, from this worktree:

```
$ bats tests/scripts/
…
ok 32 verify_branch_synced_with_ado_dev honors custom target branch

$ python3 -m pytest domain/scripts/tests/
============================== 84 passed in 0.16s ==============================
```

Both suites pass (bats 32/32, pytest 84/84). Docs-only diff — no runtime
behavior changes — so this is confirming the documented commands work
as described rather than gating a code change.

Context: fresh worktree
`.claire/worktrees/issue-90-docs-fivepoints-dev-clarify-cl`, branch
`issue-90`, no uncommitted changes.