### PR TITLE
feat(proof-gate): accept .webm (Playwright default) and .mov

### DIFF
--- a/domain/scripts/ado_common.sh
+++ b/domain/scripts/ado_common.sh
@@ -362,9 +362,14 @@ resolve_gh_repo() {
 #
 # Matchers:
 #   MP4: line starting with `MP4:` / `Proof:` / `Recording:` / `Video:`
-#        (case-insensitive, multiline) followed by content ending in `.mp4`.
-#        Tighter than `contains(".mp4")` to avoid false positives from
-#        discussion comments that mention `.mp4` in prose (PR #78 review point 2).
+#        (case-insensitive, multiline) followed by content ending in
+#        `.mp4`, `.webm`, or `.mov`. `.webm` is Playwright's default
+#        `record_video_dir` output, and `.mov` is the default screen
+#        recording format on macOS — accepting them lets the dev post
+#        the raw recording without a ffmpeg transcode step (issue #122).
+#        Still tighter than `contains(".mp4")` to avoid false positives
+#        from discussion comments that mention an extension in prose
+#        (PR #78 review point 2).
 #   FDS: comment whose body STARTS with `**FDS Verification (screenshot + AI)**`
 #        (per the dev checklist's documented heredoc format).
 #
@@ -381,7 +386,7 @@ check_proof_gate() {
     local result_json
     result_json=$(gh issue view "$issue_number" --repo "$gh_repo" --json comments \
         --jq '{
-            mp4: any(.comments[].body; test("(?im)^(MP4|Proof|Recording|Video)[: ].*\\.mp4")),
+            mp4: any(.comments[].body; test("(?im)^(MP4|Proof|Recording|Video)[: ].*\\.(mp4|webm|mov)")),
             fds: any(.comments[].body; startswith("**FDS Verification (screenshot + AI)**"))
         }' \
         2>/dev/null || echo '{"mp4":false,"fds":false}')
@@ -399,10 +404,11 @@ check_proof_gate() {
         echo ""
         echo "❌ Proof gate failed for issue #${issue_number} (${gh_repo}):"
         if [[ "$mp4_found" != "true" ]]; then
-            echo "   ❌ [8/11] MP4 missing: no 'MP4 URL/path' line found on issue #${issue_number}."
-            echo "      Record an MP4 with Playwright (claire domain read video_proof technical PLAYWRIGHT_PATTERNS),"
-            echo "      then post the path with one of the recognised prefixes (MP4:/Proof:/Recording:/Video:):"
-            echo "        gh issue comment ${issue_number} --body 'MP4: /path/to/proof.mp4'"
+            echo "   ❌ [8/11] MP4 missing: no recording URL/path line found on issue #${issue_number}."
+            echo "      Record with Playwright (claire domain read video_proof technical PLAYWRIGHT_PATTERNS),"
+            echo "      then post the path with one of the recognised prefixes (MP4:/Proof:/Recording:/Video:)"
+            echo "      and a .mp4, .webm, or .mov extension:"
+            echo "        gh issue comment ${issue_number} --body 'MP4: /path/to/proof.webm'"
         fi
         if [[ "$fds_found" != "true" ]]; then
             echo "   ❌ [9/11] FDS Verification missing: no '**FDS Verification (screenshot + AI)**' comment on issue #${issue_number}."

--- a/domain/technical/E2E_TESTING.md
+++ b/domain/technical/E2E_TESTING.md
@@ -102,20 +102,21 @@ All output goes to `--output-dir` (default: `./education_e2e_videos`).
 
 ### Video Proof Format Requirements
 
-**⚠️ `.webm` files are NOT accepted as proof for GitHub issues or ADO PRs.**
+The proof gate (`check_proof_gate` in `domain/scripts/ado_common.sh`) accepts `.mp4`, `.webm`, and `.mov` directly — Playwright's `record_video_dir` default (`.webm`) and macOS screen recording default (`.mov`) no longer need a ffmpeg transcode to pass the gate (issue #122).
 
-Before attaching a video proof to a GitHub issue or Azure DevOps PR:
+When attaching a video proof to a GitHub issue or Azure DevOps PR:
 
-1. **Convert to MP4** — GitHub and ADO only render MP4 inline; `.webm` is not supported:
+1. **Use a recognised prefix + one of the accepted extensions.** The comment must contain a line starting with `MP4:` / `Proof:` / `Recording:` / `Video:` (case-insensitive) followed by a path ending in `.mp4`, `.webm`, or `.mov`:
+   ```
+   Proof: /Users/andreperez/proof-archive/fivepoints/siblings/proof_20260310.webm
+   ```
+
+2. **Use the full absolute path.** Never use just a filename like `proof_recording.webm` — the reviewer won't be able to locate it.
+
+3. **Transcode to `.mp4` only if you need inline playback** on a client that doesn't render `.webm`. The gate itself does not require it:
    ```bash
    ffmpeg -i proof_recording.webm -c:v libx264 -c:a aac proof_recording.mp4
    ```
-
-2. **Use the full absolute path** — When referencing the file in a comment, always use the full path so it can be found unambiguously:
-   ```
-   Proof: /Users/andreperez/proof-archive/fivepoints/siblings/proof_20260310.mp4
-   ```
-   Never use just a filename like `proof_recording.mp4`.
 
 ## Architecture
 

--- a/tests/scripts/test_check_proof_gate.bats
+++ b/tests/scripts/test_check_proof_gate.bats
@@ -156,6 +156,55 @@ make_comments() {
     done
 }
 
+@test "check_proof_gate accepts .webm recordings (Playwright record_video_dir default, issue #122)" {
+    GH_MOCK_COMMENTS_JSON=$(make_comments \
+        "MP4: /tmp/proof.webm" \
+        "**FDS Verification (screenshot + AI)**
+- Screen X: pass")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"both posted"* ]]
+}
+
+@test "check_proof_gate accepts .mov recordings (macOS screen recording default, issue #122)" {
+    GH_MOCK_COMMENTS_JSON=$(make_comments \
+        "Recording: /tmp/proof.mov" \
+        "**FDS Verification (screenshot + AI)**
+- Screen X: pass")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"both posted"* ]]
+}
+
+@test "check_proof_gate ignores comments that merely mention .webm in prose (prose guard extends to new extensions)" {
+    GH_MOCK_COMMENTS_JSON=$(make_comments \
+        "**FDS Verification (screenshot + AI)**
+- Screen X: pass" \
+        "FYI Playwright writes .webm by default — you can attach it directly now.")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[8/11] MP4 missing"* ]]
+}
+
+@test "check_proof_gate rejection hint names .webm / .mov as accepted extensions" {
+    # Ensures the failure text doesn't contradict the widened regex — a dev
+    # reading "no recording URL/path line found" should see .webm/.mov listed.
+    GH_MOCK_COMMENTS_JSON=$(make_comments "unrelated comment")
+    export GH_MOCK_COMMENTS_JSON
+
+    run bash -c "source '$ADO_COMMON' && check_proof_gate 42 fake/repo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *".mp4"* ]]
+    [[ "$output" == *".webm"* ]]
+    [[ "$output" == *".mov"* ]]
+}
+
 @test "check_proof_gate errors with code 2 on missing arguments" {
     run bash -c "source '$ADO_COMMON' && check_proof_gate"
     [ "$status" -eq 2 ]


### PR DESCRIPTION
## Summary
- Broaden the `check_proof_gate` regex in `domain/scripts/ado_common.sh` from `.mp4` to `.(mp4|webm|mov)` so Playwright's default `.webm` output and macOS `.mov` screen recordings pass the gate without a ffmpeg transcode step (issue #122, preferred fix candidate 1).
- Align the header comment and the `[8/11] MP4 missing` rejection hint so the error text names the accepted extensions and no longer says `.mp4` exclusively.
- Refresh `domain/technical/E2E_TESTING.md`'s "Video Proof Format Requirements" — the old note said `.webm` is "NOT accepted as proof", which contradicts the new gate.

## Notes
- The false-positive guard from PR #78 is preserved: the match still anchors on a recognised prefix (`MP4:`/`Proof:`/`Recording:`/`Video:`), so prose that only mentions an extension does not satisfy the gate. A new test extends the prose guard to `.webm`.
- `.webm` acceptance by the gate ≠ inline playback everywhere. E2E_TESTING.md keeps the ffmpeg hint for the case where a client doesn't render `.webm` inline, but it is no longer framed as mandatory.
- Out of scope: fix candidates 2 (emit `.mp4` directly from Playwright) and 3 (`convert-proof` helper). The issue names #1 as preferred and one-line; the others were alternatives.

## Test plan
- [x] `bats tests/scripts/` — 36/36 pass (4 new cases: `.webm` accept, `.mov` accept, `.webm` prose-guard, rejection-hint names all three extensions).
- [x] `python3 -m pytest domain/scripts/tests/` — 84/84 pass.

Closes #122