### PR TITLE
docs: clarify issue routing for fivepoints-dev retrospectives

### DIFF
--- a/domain/operational/CHECKLIST_DEV_PIPELINE.md
+++ b/domain/operational/CHECKLIST_DEV_PIPELINE.md
@@ -526,16 +526,23 @@ EOF
       ℹ️ The GitHub issue stays open (see [10/11]) — you stop the session,
          the owner closes the issue separately.
 
-      Retrospective — pick the correct target repo when filing improvement issues:
-      When `claire wait` returns the retrospective prompt, walk the 4-question decision flow:
-      `claire domain read claire knowledge ISSUE_REPO_ROUTING`
-      Always pass `--github-repo <owner/name>` explicitly to `claire issue create`.
-      The pre-flight warning fires if the flag disagrees with the cwd-detected repo —
-      heed it; cwd auto-detection has silently mis-routed plugin issues into core before.
+      Retrospective — issue routing rule (MANDATORY):
+      **For fivepoints-dev sessions: ALL retrospective issues → `CLAIRE-Fivepoints/claire-plugin` by default.**
+      The motif: TFI One dev sessions run from `~/TFIOneGit/`, which auto-detects `CLAIRE-Fivepoints/fivepoints` as the origin repo.
+      Without an explicit `--github-repo` flag, cwd auto-detection wins — silent mis-routing to the app repo.
+      Rule: Only PBI-linked direct client work lands in `fivepoints`. Everything else (workflow fixes, dev tooling, pipeline bugs, doc gaps) → `claire-plugin`.
+      
+      When `claire wait` returns the retrospective prompt:
+      Always pass `--github-repo CLAIRE-Fivepoints/claire-plugin` explicitly to `claire issue create`.
+      (The pre-flight warning fires if the flag disagrees with cwd-detected repo — heed it.)
+      
+      Optional: Walk the full 4-question decision flow in `claire domain read claire knowledge ISSUE_REPO_ROUTING`
+      
       Quick guide for dev-side retrospectives:
         • Dev checklists, gates, FDS handling, ADO transition, fivepoints commands
           → `CLAIRE-Fivepoints/claire-plugin`
-        • TFI One application code (endpoints, migrations, web UI) → `CLAIRE-Fivepoints/fivepoints`
+        • TFI One application code (endpoints, migrations, web UI) — ONLY if PBI-linked
+          → `CLAIRE-Fivepoints/fivepoints`
         • Claire core (bash/python architecture, generic personas, hooks) → `claire-labs/claire`
 
       Tear down + stop:

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -52,6 +52,7 @@ Before any other tool call, I must execute this in order. No task-related tool c
 - [ ] Never commit test code (e2e specs, fixtures, Playwright configs) to the feature branch — `fivepoints-reviewer` rejects PRs containing test pollution (issue #42); keep tests in `~/.claire/scratch/tests/<issue-N>/`
 - [ ] Never bypass pre-commit hooks (`--no-verify`) or force-push without explicit operator directive
 - [ ] Never touch `main` / `master` directly
+- [ ] **Issue routing:** Never file retrospective issues in `CLAIRE-Fivepoints/fivepoints` — only PBI-linked direct client work lands there. Retrospectives, workflow fixes, dev tooling, pipeline bugs, doc gaps **always** → `CLAIRE-Fivepoints/claire-plugin` (see [11/11] in CHECKLIST_DEV_PIPELINE for rationale)
 
 ## Behavior rules
 


### PR DESCRIPTION
## Summary

Strengthen documentation to prevent mis-routing of retrospective issues and improvement findings to the app repo. Only PBI-linked direct client work belongs in `CLAIRE-Fivepoints/fivepoints`; workflow fixes, tooling, and dev ergonomics belong in `CLAIRE-Fivepoints/claire-plugin`.

## Changes

- **CHECKLIST_DEV_PIPELINE.md [11/11]**: Add explicit routing rule upfront with motif (why cwd auto-detection causes drift). Default retrospectives to claire-plugin.
- **fivepoints-dev.md**: Add issue routing rule to authorization boundary so it's loaded every session.

## Test Plan

- ✅ bats tests (32/32 pass)
- ✅ pytest tests (84/84 pass)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)