### PR TITLE
feat(fivepoints): add verify-templates command — DRY guard for dev pipeline checklist (closes #80)

### DIFF
--- a/domain/commands/verify-templates.sh
+++ b/domain/commands/verify-templates.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# fivepoints verify-templates
+# Verifies no checklist duplication between fivepoints-dev persona and
+# operational/CHECKLIST_DEV_PIPELINE — single-source-of-truth guard.
+#
+# Issue #80 (CLAIRE-Fivepoints/claire-plugin): the persona file used to
+# embed the full [1/11]..[11/11] checklist body inline. This script asserts
+# that duplication is absent: the persona must reference the checklist but
+# never contain its step markers.
+#
+# Exit codes:
+#   0 — no duplication; CHECKLIST_DEV_PIPELINE is the single source of truth
+#   1 — duplication detected or required file missing
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    cat <<'EOF'
+Usage: claire fivepoints verify-templates [OPTIONS]
+
+Verify no checklist duplication between the fivepoints-dev persona and
+domain/operational/CHECKLIST_DEV_PIPELINE.
+
+Checks:
+  1. domain/persona/fivepoints-dev.md does NOT contain [N/11] step markers
+  2. domain/operational/CHECKLIST_DEV_PIPELINE.md contains all 11 steps
+     (confirms it is the single source of truth)
+
+Options:
+  --verbose, -v   Show per-check detail
+  --agent-help    Show LLM-optimized help
+  -h, --help      Show this help
+
+Exit codes:
+  0  No duplication found
+  1  Duplication detected or a required file is missing
+EOF
+    exit 0
+fi
+
+if [[ "${1:-}" == "--agent-help" ]]; then
+    cat <<'EOF'
+fivepoints verify-templates — single-source-of-truth guard for the dev pipeline checklist.
+
+WHEN TO RUN
+  Run after any edit to domain/persona/fivepoints-dev.md or
+  domain/operational/CHECKLIST_DEV_PIPELINE.md to confirm the persona does
+  not embed checklist steps.  Also run in CI / bats tests.
+
+OUTPUT
+  Success (exit 0):
+    ✓ verify-templates: no duplication — CHECKLIST_DEV_PIPELINE is the single source of truth
+
+  Failure (exit 1):
+    ✗ [N/11] found in fivepoints-dev.md  (one line per duplicate step)
+    ✗ verify-templates: FAILED (N duplicate steps, M missing steps)
+
+FLAGS
+  --verbose  Emit per-check pass/fail lines; useful for debugging.
+  --help     Human-readable help.
+EOF
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Parse options
+# ---------------------------------------------------------------------------
+
+VERBOSE=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --verbose|-v) VERBOSE=true ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+# ---------------------------------------------------------------------------
+# Locate domain root
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOMAIN_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PERSONA_FILE="${DOMAIN_DIR}/persona/fivepoints-dev.md"
+CHECKLIST_FILE="${DOMAIN_DIR}/operational/CHECKLIST_DEV_PIPELINE.md"
+
+FAIL=0
+DUPLICATE_STEPS=0
+MISSING_STEPS=0
+
+# ---------------------------------------------------------------------------
+# Check 1: required files exist
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "$PERSONA_FILE" ]]; then
+    echo "✗ MISSING: ${PERSONA_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -f "$CHECKLIST_FILE" ]]; then
+    echo "✗ MISSING: ${CHECKLIST_FILE}" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: persona must NOT contain embedded checklist step definitions
+#
+# An *embedded step* is a line starting with a markdown checkbox followed by
+# the step marker: "- [ ] [N/11]" or "- [x] [N/11]".
+# Inline cross-references such as "see [10/11]" or "never skip `[8/11]`" are
+# not embedded steps and are intentionally permitted in the persona.
+# ---------------------------------------------------------------------------
+
+for step in 1 2 3 4 5 6 7 8 9 10 11; do
+    if grep -qE "^- \[[ x]\] \[${step}/11\]" "$PERSONA_FILE"; then
+        if [[ "$VERBOSE" == "true" ]]; then
+            echo "✗ [${step}/11] embedded as a step definition in $(basename "$PERSONA_FILE")"
+        fi
+        DUPLICATE_STEPS=$((DUPLICATE_STEPS + 1))
+        FAIL=1
+    fi
+done
+
+if [[ "$VERBOSE" == "true" && $DUPLICATE_STEPS -eq 0 ]]; then
+    echo "✓ No checklist steps embedded in $(basename "$PERSONA_FILE")"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: CHECKLIST_DEV_PIPELINE must contain all 11 steps (single source)
+# ---------------------------------------------------------------------------
+
+for step in 1 2 3 4 5 6 7 8 9 10 11; do
+    if ! grep -qE "^- \[[ x]\] \[${step}/11\]" "$CHECKLIST_FILE"; then
+        if [[ "$VERBOSE" == "true" ]]; then
+            echo "✗ [${step}/11] missing from $(basename "$CHECKLIST_FILE")"
+        fi
+        MISSING_STEPS=$((MISSING_STEPS + 1))
+        FAIL=1
+    fi
+done
+
+if [[ "$VERBOSE" == "true" && $MISSING_STEPS -eq 0 ]]; then
+    echo "✓ All 11 steps present in $(basename "$CHECKLIST_FILE") (single source of truth)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+if [[ $FAIL -eq 0 ]]; then
+    echo "✓ verify-templates: no duplication — CHECKLIST_DEV_PIPELINE is the single source of truth"
+else
+    echo "✗ verify-templates: FAILED (${DUPLICATE_STEPS} duplicate step(s) in persona, ${MISSING_STEPS} missing step(s) in checklist)" >&2
+    exit 1
+fi

--- a/domain/knowledge/VERIFY_TEMPLATES.md
+++ b/domain/knowledge/VERIFY_TEMPLATES.md
@@ -1,0 +1,78 @@
+---
+name: VERIFY_TEMPLATES
+title: "fivepoints verify-templates — single-source-of-truth guard for the dev pipeline checklist"
+description: "Checks that fivepoints-dev.md has no embedded checklist step definitions and CHECKLIST_DEV_PIPELINE.md is the single source of truth"
+domain: fivepoints
+category: knowledge
+keywords: [verify-templates, checklist, duplication, dry, single-source, fivepoints-dev, CHECKLIST_DEV_PIPELINE, persona, guard]
+updated: 2026-05-20
+---
+
+# fivepoints verify-templates
+
+Single-source-of-truth guard for the dev pipeline checklist. Asserts that
+`domain/persona/fivepoints-dev.md` contains **no embedded step definitions**
+(`- [ ] [N/11]` or `- [x] [N/11]` line-starters) and that
+`domain/operational/CHECKLIST_DEV_PIPELINE.md` is the canonical file with
+all 11 steps.
+
+---
+
+## Usage
+
+```bash
+claire fivepoints verify-templates          # summary line only
+claire fivepoints verify-templates --verbose # per-check detail
+claire fivepoints verify-templates --help
+claire fivepoints verify-templates --agent-help
+```
+
+---
+
+## What it checks
+
+| Check | Pass condition |
+|-------|----------------|
+| 1 | `domain/persona/fivepoints-dev.md` exists |
+| 2 | `domain/operational/CHECKLIST_DEV_PIPELINE.md` exists |
+| 3 | Persona has **no** lines matching `^- \[[ x]\] \[N/11\]` (N = 1–11) |
+| 4 | Checklist has **all** lines matching `^- \[[ x]\] \[N/11\]` (N = 1–11) |
+
+Inline cross-references in the persona — e.g. `"never skip [8/11]"` or
+`` "see `[10/11]`" `` — are **not** flagged. Only actual step-definition lines
+(markdown checkbox + step marker at line start) trigger a failure.
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No duplication; checklist is the single source of truth |
+| 1 | Duplication detected, step missing from checklist, or a required file is absent |
+
+---
+
+## Context
+
+Issue #80 (CLAIRE-Fivepoints/claire-plugin): the lean-v3 persona rewrite
+(`6c03ec3`) removed the full `[1/11]`–`[11/11]` block that was hand-copied
+from `CHECKLIST_DEV_PIPELINE.md` into `fivepoints-dev.md`. This command
+formalises that invariant so future edits to either file are immediately
+caught if the duplication is re-introduced.
+
+---
+
+## Implementation
+
+| File | Purpose |
+|------|---------|
+| `domain/commands/verify-templates.sh` | Command implementation |
+| `tests/scripts/test_verify_templates.bats` | 9 bats tests |
+
+---
+
+## See also
+
+- `claire domain read fivepoints operational CHECKLIST_DEV_PIPELINE` — the single source of truth
+- `claire domain read fivepoints persona fivepoints-dev` — the persona that must not embed the checklist

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -139,6 +139,10 @@ commands:
     script: "domain/commands/rebase-no-force.sh"
     description: "Rebase branch onto ADO target and push without ForcePush permission (snapshot+merge strategy)"
 
+  - name: "fivepoints verify-templates"
+    script: "domain/commands/verify-templates.sh"
+    description: "Verify no checklist duplication between fivepoints-dev persona and CHECKLIST_DEV_PIPELINE (single-source-of-truth guard)"
+
 github_orgs:
   - CLAIRE-Fivepoints
 

--- a/tests/scripts/test_verify_templates.bats
+++ b/tests/scripts/test_verify_templates.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# tests/scripts/test_verify_templates.bats
+#
+# Tests for domain/commands/verify-templates.sh (issue #80).
+# Verifies the single-source-of-truth guard: the fivepoints-dev persona must
+# not embed [N/11] checklist step markers from CHECKLIST_DEV_PIPELINE.
+
+VERIFY_TEMPLATES="${BATS_TEST_DIRNAME}/../../domain/commands/verify-templates.sh"
+PERSONA_FILE="${BATS_TEST_DIRNAME}/../../domain/persona/fivepoints-dev.md"
+CHECKLIST_FILE="${BATS_TEST_DIRNAME}/../../domain/operational/CHECKLIST_DEV_PIPELINE.md"
+
+# ---------------------------------------------------------------------------
+# Live file assertions — the real repo state must satisfy the invariant
+# ---------------------------------------------------------------------------
+
+@test "fivepoints-dev.md contains no embedded checklist step definitions" {
+    # A step *definition* is a line starting with a markdown checkbox: "- [ ] [N/11]".
+    # Inline cross-references like "see [10/11]" are allowed and not counted.
+    for step in 1 2 3 4 5 6 7 8 9 10 11; do
+        run grep -cE "^- \[[ x]\] \[${step}/11\]" "$PERSONA_FILE"
+        [ "$output" -eq 0 ]
+    done
+}
+
+@test "CHECKLIST_DEV_PIPELINE.md contains all 11 steps (single source of truth)" {
+    for step in 1 2 3 4 5 6 7 8 9 10 11; do
+        run grep -cF "[${step}/11]" "$CHECKLIST_FILE"
+        [ "$output" -ge 1 ]
+    done
+}
+
+@test "verify-templates passes on the real files" {
+    run bash "$VERIFY_TEMPLATES"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no duplication"* ]]
+}
+
+@test "verify-templates --verbose passes on the real files" {
+    run bash "$VERIFY_TEMPLATES" --verbose
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No checklist steps embedded"* ]]
+    [[ "$output" == *"All 11 steps present"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Isolation tests — synthetic persona/checklist dirs in tmpdir
+# ---------------------------------------------------------------------------
+
+setup() {
+    FAKE_DOMAIN="$BATS_TEST_TMPDIR/domain"
+    mkdir -p "$FAKE_DOMAIN/persona" "$FAKE_DOMAIN/operational"
+
+    FAKE_PERSONA="$FAKE_DOMAIN/persona/fivepoints-dev.md"
+    FAKE_CHECKLIST="$FAKE_DOMAIN/operational/CHECKLIST_DEV_PIPELINE.md"
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR"
+}
+
+_write_clean_persona() {
+    cat > "$FAKE_PERSONA" <<'EOF'
+# FIVEPOINTS-DEV
+
+Identity only. No checklist steps here.
+Checklist is in operational/CHECKLIST_DEV_PIPELINE.
+EOF
+}
+
+_write_checklist_with_all_steps() {
+    {
+        for step in 1 2 3 4 5 6 7 8 9 10 11; do
+            echo "- [ ] [${step}/11] Step ${step}"
+        done
+    } > "$FAKE_CHECKLIST"
+}
+
+@test "verify-templates passes when persona has no step markers" {
+    _write_clean_persona
+    _write_checklist_with_all_steps
+
+    # Point script at fake domain by symlinking script to run from FAKE_DOMAIN
+    # The script resolves DOMAIN_DIR as two levels up from its own location;
+    # write a wrapper that sets up that path structure.
+    FAKE_COMMANDS="$FAKE_DOMAIN/commands"
+    mkdir -p "$FAKE_COMMANDS"
+    cp "$VERIFY_TEMPLATES" "$FAKE_COMMANDS/verify-templates.sh"
+
+    run bash "$FAKE_COMMANDS/verify-templates.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no duplication"* ]]
+}
+
+@test "verify-templates fails when persona embeds a checklist step" {
+    # Persona with [3/11] as an embedded step definition — simulates pre-lean-v3 state.
+    # (Inline cross-references like "see [3/11]" would NOT trigger the check.)
+    cat > "$FAKE_PERSONA" <<'EOF'
+# FIVEPOINTS-DEV
+
+- [ ] [3/11] Implement the requirements
+EOF
+    _write_checklist_with_all_steps
+
+    FAKE_COMMANDS="$FAKE_DOMAIN/commands"
+    mkdir -p "$FAKE_COMMANDS"
+    cp "$VERIFY_TEMPLATES" "$FAKE_COMMANDS/verify-templates.sh"
+
+    run bash "$FAKE_COMMANDS/verify-templates.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "FAILED" ]]
+}
+
+@test "verify-templates fails when persona embeds multiple checklist steps" {
+    cat > "$FAKE_PERSONA" <<'EOF'
+# FIVEPOINTS-DEV
+
+- [ ] [6/11] Start test environment
+- [ ] [8/11] Run E2E tests
+- [ ] [9/11] Screenshot + visual verification
+EOF
+    _write_checklist_with_all_steps
+
+    FAKE_COMMANDS="$FAKE_DOMAIN/commands"
+    mkdir -p "$FAKE_COMMANDS"
+    cp "$VERIFY_TEMPLATES" "$FAKE_COMMANDS/verify-templates.sh"
+
+    run bash "$FAKE_COMMANDS/verify-templates.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "3 duplicate step(s)" ]]
+}
+
+@test "verify-templates fails when checklist file is missing a step" {
+    _write_clean_persona
+    # Only 10 steps — missing [7/11]
+    {
+        for step in 1 2 3 4 5 6 8 9 10 11; do
+            echo "- [ ] [${step}/11] Step ${step}"
+        done
+    } > "$FAKE_CHECKLIST"
+
+    FAKE_COMMANDS="$FAKE_DOMAIN/commands"
+    mkdir -p "$FAKE_COMMANDS"
+    cp "$VERIFY_TEMPLATES" "$FAKE_COMMANDS/verify-templates.sh"
+
+    run bash "$FAKE_COMMANDS/verify-templates.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "FAILED" ]]
+}
+
+@test "verify-templates exits 1 when persona file is missing" {
+    _write_checklist_with_all_steps
+    # No persona file — skip _write_clean_persona
+
+    FAKE_COMMANDS="$FAKE_DOMAIN/commands"
+    mkdir -p "$FAKE_COMMANDS"
+    cp "$VERIFY_TEMPLATES" "$FAKE_COMMANDS/verify-templates.sh"
+
+    run bash "$FAKE_COMMANDS/verify-templates.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "MISSING" ]]
+}

--- a/tests/scripts/test_verify_templates.bats
+++ b/tests/scripts/test_verify_templates.bats
@@ -23,8 +23,10 @@ CHECKLIST_FILE="${BATS_TEST_DIRNAME}/../../domain/operational/CHECKLIST_DEV_PIPE
 }
 
 @test "CHECKLIST_DEV_PIPELINE.md contains all 11 steps (single source of truth)" {
+    # Use the same line-start pattern as the script so inline cross-references
+    # ("see [7/11]") do not produce false positives.
     for step in 1 2 3 4 5 6 7 8 9 10 11; do
-        run grep -cF "[${step}/11]" "$CHECKLIST_FILE"
+        run grep -cE "^- \[[ x]\] \[${step}/11\]" "$CHECKLIST_FILE"
         [ "$output" -ge 1 ]
     done
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/CLAIRE-Fivepoints/claire-plugin/issues/80

The lean-v3 persona rewrite (`6c03ec3`) already eliminated the duplication: `fivepoints-dev.md` no longer embeds the `[1/11]`–`[11/11]` checklist body. This PR formalises that invariant with a verify command, domain doc, and bats tests.

### Changes

- **`domain/commands/verify-templates.sh`** — new command that asserts:
  1. `domain/persona/fivepoints-dev.md` has **no embedded step definitions** (`- [ ] [N/11]` or `- [x] [N/11]` line-starters). Inline cross-references like `"see [10/11]"` or `` "never skip `[8/11]`" `` are explicitly allowed.
  2. `domain/operational/CHECKLIST_DEV_PIPELINE.md` contains all 11 steps — confirming it is the single source of truth.

- **`domain/knowledge/VERIFY_TEMPLATES.md`** — domain doc with full frontmatter so `claire context "verify-templates"` is discoverable after install.

- **`plugin.yaml`** — registers `fivepoints verify-templates`.

- **`tests/scripts/test_verify_templates.bats`** — 9 tests: 4 against the real repo files (live invariant) and 5 isolated synthetic cases. Live test 2 uses the same `^- \[[ x]\] \[N/11\]` line-start pattern as the script (aligned per reviewer suggestion).

### Acceptance criteria

- [x] Editing `[N/11]` step text in one file is enough to keep both rendered outputs consistent — satisfied by lean-v3 (`CHECKLIST_DEV_PIPELINE.md` is the only source).
- [x] `claire fivepoints verify-templates` confirms both persona and checklist sections render without drift.
- [x] Bats test asserts no duplication remains (test 1: `fivepoints-dev.md contains no embedded checklist step definitions`).

## Dogfood

```
$ bash domain/commands/verify-templates.sh --verbose
✓ No checklist steps embedded in fivepoints-dev.md
✓ All 11 steps present in CHECKLIST_DEV_PIPELINE.md (single source of truth)
✓ verify-templates: no duplication — CHECKLIST_DEV_PIPELINE is the single source of truth

$ bats tests/scripts/test_verify_templates.bats
1..9
ok 1 fivepoints-dev.md contains no embedded checklist step definitions
ok 2 CHECKLIST_DEV_PIPELINE.md contains all 11 steps (single source of truth)
ok 3 verify-templates passes on the real files
ok 4 verify-templates --verbose passes on the real files
ok 5 verify-templates passes when persona has no step markers
ok 6 verify-templates fails when persona embeds a checklist step
ok 7 verify-templates fails when persona embeds multiple checklist steps
ok 8 verify-templates fails when checklist file is missing a step
ok 9 verify-templates exits 1 when persona file is missing

$ bats tests/scripts/
1..107
... (all 107 pass)
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)