### PR TITLE
feat(bridge): sync source branch to target repo before assignment

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -3,8 +3,8 @@ domain: fivepoints
 category: operational
 name: AZURE_ISSUE_BRIDGE
 title: "Five Points — Azure DevOps Email Bridge (PBI Assignment → GitHub Issue Pipeline)"
-keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_TEST_SENDER, PBI_SENDER, test-sender, configurable-sender]
-updated: 2026-04-10
+keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_TEST_SENDER, PBI_SENDER, test-sender, configurable-sender, branch-sync, ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH]
+updated: 2026-06-28
 ---
 
 # Azure DevOps Email Bridge
@@ -26,6 +26,7 @@ ADO PBI assigned to andre.perez@dothelpllc.com
   → TRIAGE: skip if duplicate, terminal state, or non-Task type
   → fetches PBI details from ADO REST API (AZURE_DEVOPS_PAT)
   → creates GitHub issue in ADO_BRIDGE_REPO (default: claire-labs/fivepoints-test)
+  → syncs ADO_BRIDGE_SYNC_SOURCE/develop → ADO_BRIDGE_SYNC_TARGET/develop (GitHub API)
   → archives email in Gmail
   → claire spawn daemon (consumer.py) detects new issue in ADO_BRIDGE_REPO
   → spawns Claire agent in isolated worktree
@@ -68,6 +69,8 @@ Gmail inbox
       → if no issue   → action=create
   → [create only] GET https://dev.azure.com/{org}/{project}/_apis/wit/workitems/{id}?$expand=all
   → gh issue create --repo <ADO_BRIDGE_REPO>
+  → sync ADO_BRIDGE_SYNC_SOURCE/<branch> → ADO_BRIDGE_SYNC_TARGET/<branch> (GitHub REST API)
+      → failure aborts pipeline for this PBI (no archiving, no agent assignment)
   → persist all email IDs for this PBI to ~/.claire/azure-issue-bridge/processed.json
   → archive all emails for this PBI in Gmail (remove INBOX label)
 ```
@@ -213,6 +216,9 @@ The azure-issue-bridge uses `AZURE_DEVOPS_PAT`. The fivepoints plugin (`ado_comm
 | `ADO_BRIDGE_HOUR_END` | `17` | Business hours end (local time, exclusive) |
 | `PBI_TEST_SENDER` | _(unset)_ | Override accepted email sender for testing (e.g. `andreoperez@gmail.com`). Takes priority over `PBI_SENDER`. Emails from this address with the standard ADO subject format are processed identically to real ADO emails. |
 | `PBI_SENDER` | `azuredevops@microsoft.com` | Override the production ADO sender. Use when ADO notifications come from a custom address. Falls back to the ADO default when unset. |
+| `ADO_BRIDGE_SYNC_SOURCE` | `CLAIRE-Fivepoints/fivepoints-test` | Source GitHub repo for branch sync (the repo Claire agents push to). |
+| `ADO_BRIDGE_SYNC_TARGET` | `CLAIRE-Fivepoints/fivepoints` | Target GitHub repo for branch sync (the production repo). |
+| `ADO_BRIDGE_SYNC_BRANCH` | `develop` | Branch name synced from source to target before each agent assignment. |
 
 ---
 

--- a/domain/scripts/azure_issue_bridge/bridge.py
+++ b/domain/scripts/azure_issue_bridge/bridge.py
@@ -25,7 +25,10 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from azure_issue_bridge.sync import BranchSyncAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -129,11 +132,19 @@ _ADO_SENDER = "azuredevops@microsoft.com"
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_SYNC_SOURCE = "CLAIRE-Fivepoints/fivepoints-test"
+_DEFAULT_SYNC_TARGET = "CLAIRE-Fivepoints/fivepoints"
+_DEFAULT_SYNC_BRANCH = "develop"
+
+
 @dataclass
 class BridgeConfig:
     """Runtime configuration for the azure issue bridge."""
 
     pbi_sender: str = _ADO_SENDER
+    sync_source_repo: str = _DEFAULT_SYNC_SOURCE
+    sync_target_repo: str = _DEFAULT_SYNC_TARGET
+    sync_branch_name: str = _DEFAULT_SYNC_BRANCH
 
 
 def _get_env_or_file(key: str) -> str:
@@ -158,13 +169,30 @@ def load_bridge_config() -> BridgeConfig:
       1. PBI_TEST_SENDER  — test override (e.g. andreoperez@gmail.com)
       2. PBI_SENDER       — custom production sender
       3. azuredevops@microsoft.com — ADO default
+
+    Sync vars (ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH)
+    fall back to CLAIRE-Fivepoints/fivepoints-test → CLAIRE-Fivepoints/fivepoints / develop.
     """
     pbi_sender = (
         _get_env_or_file("PBI_TEST_SENDER")
         or _get_env_or_file("PBI_SENDER")
         or _ADO_SENDER
     )
-    return BridgeConfig(pbi_sender=pbi_sender)
+    sync_source_repo = (
+        _get_env_or_file("ADO_BRIDGE_SYNC_SOURCE") or _DEFAULT_SYNC_SOURCE
+    )
+    sync_target_repo = (
+        _get_env_or_file("ADO_BRIDGE_SYNC_TARGET") or _DEFAULT_SYNC_TARGET
+    )
+    sync_branch_name = (
+        _get_env_or_file("ADO_BRIDGE_SYNC_BRANCH") or _DEFAULT_SYNC_BRANCH
+    )
+    return BridgeConfig(
+        pbi_sender=pbi_sender,
+        sync_source_repo=sync_source_repo,
+        sync_target_repo=sync_target_repo,
+        sync_branch_name=sync_branch_name,
+    )
 
 
 def is_pbi_email(msg: Any) -> bool:
@@ -848,6 +876,7 @@ def process_emails(
     max_process: int | None = None,
     lookback_days: int | None = None,
     config: BridgeConfig | None = None,
+    branch_sync: BranchSyncAdapter | None = None,
 ) -> list[ProcessingResult]:
     """Scan Gmail inbox for ADO assignment emails and process each one.
 
@@ -965,6 +994,14 @@ def process_emails(
             if dry_run:
                 title = f"{work_item.title} (PBI #{work_item.id})"
                 logger.info("[dry-run] Would create issue: %s", title)
+                if branch_sync is not None:
+                    logger.info(
+                        "[dry-run] Would sync %s/%s → %s/%s",
+                        config.sync_source_repo,
+                        config.sync_branch_name,
+                        config.sync_target_repo,
+                        config.sync_branch_name,
+                    )
                 result.github_issue_url = "(dry-run)"
             else:
                 # Step 2: Pre-creation duplicate guard — re-check GitHub right before
@@ -987,6 +1024,16 @@ def process_emails(
                     # Step 3: Create GitHub issue
                     issue_url = create_github_issue(work_item)
                     result.github_issue_url = issue_url
+
+                    # Step 4: Sync source branch to target repo before worktree/assign.
+                    # Raises on failure → caught by outer except → pipeline aborted.
+                    if branch_sync is not None:
+                        branch_sync.sync_branch(
+                            source_repo=config.sync_source_repo,
+                            source_branch=config.sync_branch_name,
+                            target_repo=config.sync_target_repo,
+                            target_branch=config.sync_branch_name,
+                        )
 
                     # Mark ALL emails for this PBI as processed and archive them
                     for email in decision.emails:

--- a/domain/scripts/azure_issue_bridge/cli.py
+++ b/domain/scripts/azure_issue_bridge/cli.py
@@ -71,12 +71,14 @@ def _parse_lookback(value: str) -> int:
 
 def cmd_run(args: argparse.Namespace) -> int:
     from azure_issue_bridge.bridge import process_emails
+    from azure_issue_bridge.sync import RealBranchSync
 
     lookback_days = _parse_lookback(args.lookback) if args.lookback else None
     results = process_emails(
         max_results=args.max_results,
         dry_run=args.dry_run,
         lookback_days=lookback_days,
+        branch_sync=RealBranchSync(),
     )
 
     if not results:
@@ -99,6 +101,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 def cmd_start(args: argparse.Namespace) -> int:
     """Polling loop — run every `interval` minutes."""
     from azure_issue_bridge.bridge import process_emails
+    from azure_issue_bridge.sync import RealBranchSync
 
     interval_seconds = args.interval * 60
     lookback_days = _parse_lookback(args.lookback) if args.lookback else None
@@ -125,6 +128,7 @@ def cmd_start(args: argparse.Namespace) -> int:
                 max_results=args.max_results,
                 dry_run=args.dry_run,
                 lookback_days=lookback_days,
+                branch_sync=RealBranchSync(),
             )
 
             if results:
@@ -155,6 +159,7 @@ def cmd_test(args: argparse.Namespace) -> int:
         PROCESSED_FILE,
         process_emails,
     )
+    from azure_issue_bridge.sync import RealBranchSync
 
     # Reset dedup state so already-processed emails are retried
     if PROCESSED_FILE.exists():
@@ -164,7 +169,10 @@ def cmd_test(args: argparse.Namespace) -> int:
     print(f"Running pipeline (max {args.max_results} PBI)...\n")
     # Scan up to 50 inbox emails but process at most max_results work items
     results = process_emails(
-        max_results=50, dry_run=args.dry_run, max_process=args.max_results
+        max_results=50,
+        dry_run=args.dry_run,
+        max_process=args.max_results,
+        branch_sync=RealBranchSync(),
     )
 
     if not results:

--- a/domain/scripts/azure_issue_bridge/sync.py
+++ b/domain/scripts/azure_issue_bridge/sync.py
@@ -1,20 +1,23 @@
 """
 azure_issue_bridge.sync — Branch sync adapter.
 
-Syncs a source GitHub branch to a target repo by fetching from the source
-and force-pushing to the target. Used by the bridge pipeline to mirror
+Syncs a source GitHub branch to a target repo using the GitHub REST API
+(GET ref SHA → PATCH/POST ref). Used by the bridge pipeline to mirror
 fivepoints-test/develop to fivepoints/develop before agent assignment.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
-import subprocess
-import tempfile
+import urllib.error
+import urllib.request
 from typing import Protocol
 
 logger = logging.getLogger(__name__)
+
+_GITHUB_API = "https://api.github.com"
 
 
 class BranchSyncAdapter(Protocol):
@@ -28,7 +31,7 @@ class BranchSyncAdapter(Protocol):
 
 
 class RealBranchSync:
-    """Syncs a branch from source_repo to target_repo via git fetch + force-push."""
+    """Syncs a branch from source_repo to target_repo via the GitHub REST API."""
 
     def sync_branch(
         self,
@@ -38,57 +41,88 @@ class RealBranchSync:
         target_branch: str,
     ) -> None:
         gh_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+        headers: dict[str, str] = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
         if gh_token:
-            source_url = f"https://x-access-token:{gh_token}@github.com/{source_repo}.git"
-            target_url = f"https://x-access-token:{gh_token}@github.com/{target_repo}.git"
-        else:
-            source_url = f"https://github.com/{source_repo}.git"
-            target_url = f"https://github.com/{target_repo}.git"
+            headers["Authorization"] = f"Bearer {gh_token}"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            result = subprocess.run(
-                ["git", "init", "--bare", tmpdir],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                raise RuntimeError(f"git init failed: {result.stderr.strip()}")
+        # Step 1: resolve the tip SHA of the source branch
+        sha = self._get_branch_sha(source_repo, source_branch, headers)
 
-            result = subprocess.run(
-                ["git", "-C", tmpdir, "fetch", source_url, source_branch],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                raise RuntimeError(f"git fetch failed: {result.stderr.strip()}")
-
-            result = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    tmpdir,
-                    "push",
-                    "--force",
-                    target_url,
-                    f"FETCH_HEAD:{target_branch}",
-                ],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                raise RuntimeError(f"git push failed: {result.stderr.strip()}")
+        # Step 2: force-update the target branch (create if it doesn't exist yet)
+        self._set_branch_sha(target_repo, target_branch, sha, headers)
 
         logger.info(
-            "Synced %s/%s → %s/%s",
+            "Synced %s/%s → %s/%s (sha=%.7s)",
             source_repo,
             source_branch,
             target_repo,
             target_branch,
+            sha,
         )
+
+    # ------------------------------------------------------------------
+    # Private helpers — errors never include the Authorization header value
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_branch_sha(repo: str, branch: str, headers: dict[str, str]) -> str:
+        url = f"{_GITHUB_API}/repos/{repo}/git/ref/heads/{branch}"
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return json.loads(resp.read())["object"]["sha"]
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Cannot read {repo}/{branch}: GitHub API returned HTTP {exc.code}"
+            ) from exc
+
+    @staticmethod
+    def _set_branch_sha(
+        repo: str, branch: str, sha: str, headers: dict[str, str]
+    ) -> None:
+        """Force-update `branch` in `repo` to `sha`. Creates the ref if absent."""
+        content_headers = {**headers, "Content-Type": "application/json"}
+
+        # Attempt PATCH (update existing ref with force=True)
+        patch_payload = json.dumps({"sha": sha, "force": True}).encode()
+        patch_req = urllib.request.Request(
+            f"{_GITHUB_API}/repos/{repo}/git/refs/heads/{branch}",
+            data=patch_payload,
+            headers=content_headers,
+            method="PATCH",
+        )
+        try:
+            with urllib.request.urlopen(patch_req):
+                return
+        except urllib.error.HTTPError as exc:
+            if exc.code != 422:
+                raise RuntimeError(
+                    f"Cannot update {repo}/{branch}: GitHub API returned HTTP {exc.code}"
+                ) from exc
+
+        # 422 → ref does not exist yet; create it
+        post_payload = json.dumps(
+            {"ref": f"refs/heads/{branch}", "sha": sha}
+        ).encode()
+        post_req = urllib.request.Request(
+            f"{_GITHUB_API}/repos/{repo}/git/refs",
+            data=post_payload,
+            headers=content_headers,
+        )
+        try:
+            with urllib.request.urlopen(post_req):
+                return
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Cannot create {repo}/{branch}: GitHub API returned HTTP {exc.code}"
+            ) from exc
 
 
 class MockBranchSync:
-    """Test double — records sync_branch calls without executing git."""
+    """Test double — records sync_branch calls without hitting the GitHub API."""
 
     def __init__(self) -> None:
         self.syncs: list[tuple[str, str, str, str]] = []

--- a/domain/scripts/azure_issue_bridge/sync.py
+++ b/domain/scripts/azure_issue_bridge/sync.py
@@ -1,0 +1,103 @@
+"""
+azure_issue_bridge.sync — Branch sync adapter.
+
+Syncs a source GitHub branch to a target repo by fetching from the source
+and force-pushing to the target. Used by the bridge pipeline to mirror
+fivepoints-test/develop to fivepoints/develop before agent assignment.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import tempfile
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class BranchSyncAdapter(Protocol):
+    def sync_branch(
+        self,
+        source_repo: str,
+        source_branch: str,
+        target_repo: str,
+        target_branch: str,
+    ) -> None: ...
+
+
+class RealBranchSync:
+    """Syncs a branch from source_repo to target_repo via git fetch + force-push."""
+
+    def sync_branch(
+        self,
+        source_repo: str,
+        source_branch: str,
+        target_repo: str,
+        target_branch: str,
+    ) -> None:
+        gh_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+        if gh_token:
+            source_url = f"https://x-access-token:{gh_token}@github.com/{source_repo}.git"
+            target_url = f"https://x-access-token:{gh_token}@github.com/{target_repo}.git"
+        else:
+            source_url = f"https://github.com/{source_repo}.git"
+            target_url = f"https://github.com/{target_repo}.git"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = subprocess.run(
+                ["git", "init", "--bare", tmpdir],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"git init failed: {result.stderr.strip()}")
+
+            result = subprocess.run(
+                ["git", "-C", tmpdir, "fetch", source_url, source_branch],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"git fetch failed: {result.stderr.strip()}")
+
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    tmpdir,
+                    "push",
+                    "--force",
+                    target_url,
+                    f"FETCH_HEAD:{target_branch}",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"git push failed: {result.stderr.strip()}")
+
+        logger.info(
+            "Synced %s/%s → %s/%s",
+            source_repo,
+            source_branch,
+            target_repo,
+            target_branch,
+        )
+
+
+class MockBranchSync:
+    """Test double — records sync_branch calls without executing git."""
+
+    def __init__(self) -> None:
+        self.syncs: list[tuple[str, str, str, str]] = []
+
+    def sync_branch(
+        self,
+        source_repo: str,
+        source_branch: str,
+        target_repo: str,
+        target_branch: str,
+    ) -> None:
+        self.syncs.append((source_repo, source_branch, target_repo, target_branch))

--- a/domain/scripts/azure_issue_bridge/tests/conftest.py
+++ b/domain/scripts/azure_issue_bridge/tests/conftest.py
@@ -1,0 +1,37 @@
+"""
+conftest.py — pytest bootstrap for azure_issue_bridge tests.
+
+Installs minimal stubs for claire_py (a V1 library not available in this
+environment) so that patch() can resolve "claire_py.email.watcher.*" without
+requiring the full V1 install.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def _install_claire_py_stubs() -> None:
+    if "claire_py" in sys.modules:
+        return
+
+    claire_py = types.ModuleType("claire_py")
+    claire_py_email = types.ModuleType("claire_py.email")
+    claire_py_email_watcher = types.ModuleType("claire_py.email.watcher")
+    claire_py_email_auth = types.ModuleType("claire_py.email.auth")
+
+    claire_py_email_watcher.list_unread_replies = lambda *a, **kw: []  # type: ignore[attr-defined]
+    claire_py_email_auth.get_credentials = lambda *a, **kw: None  # type: ignore[attr-defined]
+
+    claire_py.email = claire_py_email  # type: ignore[attr-defined]
+    claire_py_email.watcher = claire_py_email_watcher  # type: ignore[attr-defined]
+    claire_py_email.auth = claire_py_email_auth  # type: ignore[attr-defined]
+
+    sys.modules["claire_py"] = claire_py
+    sys.modules["claire_py.email"] = claire_py_email
+    sys.modules["claire_py.email.watcher"] = claire_py_email_watcher
+    sys.modules["claire_py.email.auth"] = claire_py_email_auth
+
+
+_install_claire_py_stubs()

--- a/domain/scripts/azure_issue_bridge/tests/test_sync.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_sync.py
@@ -1,0 +1,223 @@
+"""
+Tests for azure_issue_bridge.sync and the sync_branch step in process_emails().
+
+Covers:
+- MockBranchSync.syncs records each call
+- process_emails() calls sync_branch after issue creation, before archiving
+- Sync failure aborts the pipeline (result.error set, emails not archived)
+- dry-run logs the sync intent without calling sync_branch
+- No sync when branch_sync=None (backward-compatible default)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from azure_issue_bridge.sync import MockBranchSync
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_email(
+    subject: str = "Task 1234 - DEV - Something", message_id: str = "msg-001"
+) -> Any:
+    email = MagicMock()
+    email.subject = subject
+    email.message_id = message_id
+    return email
+
+
+def make_work_item(pbi_id: int = 1234) -> Any:
+    from azure_issue_bridge.bridge import WorkItem
+
+    return WorkItem(
+        id=pbi_id,
+        title="Test task",
+        description="desc",
+        acceptance_criteria="",
+        work_item_type="Task",
+    )
+
+
+def make_create_decision(pbi_id: str = "1234", emails: list[Any] | None = None) -> Any:
+    decision = MagicMock()
+    decision.action = "create"
+    decision.pbi_id = pbi_id
+    decision.emails = emails or [make_email()]
+    return decision
+
+
+# ---------------------------------------------------------------------------
+# MockBranchSync unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMockBranchSync:
+    def test_starts_empty(self) -> None:
+        mock = MockBranchSync()
+        assert mock.syncs == []
+
+    def test_records_single_call(self) -> None:
+        mock = MockBranchSync()
+        mock.sync_branch("org/source", "develop", "org/target", "develop")
+        assert mock.syncs == [("org/source", "develop", "org/target", "develop")]
+
+    def test_records_multiple_calls(self) -> None:
+        mock = MockBranchSync()
+        mock.sync_branch("org/a", "main", "org/b", "main")
+        mock.sync_branch("org/c", "dev", "org/d", "dev")
+        assert len(mock.syncs) == 2
+        assert mock.syncs[0] == ("org/a", "main", "org/b", "main")
+        assert mock.syncs[1] == ("org/c", "dev", "org/d", "dev")
+
+    def test_each_instance_has_own_list(self) -> None:
+        m1 = MockBranchSync()
+        m2 = MockBranchSync()
+        m1.sync_branch("org/x", "dev", "org/y", "dev")
+        assert m2.syncs == []
+
+
+# ---------------------------------------------------------------------------
+# process_emails() + branch_sync integration tests
+# ---------------------------------------------------------------------------
+
+_ISSUE_URL = "https://github.com/org/repo/issues/42"
+
+
+class TestProcessEmailsSync:
+    def _run_process_emails(
+        self,
+        branch_sync: Any = None,
+        dry_run: bool = False,
+        extra_patches: dict | None = None,
+    ) -> tuple[list[Any], Any, Any]:
+        """Run process_emails with standard mocks, returning (results, mock_save, mock_archive)."""
+        from azure_issue_bridge.bridge import process_emails
+
+        email = make_email()
+        work_item = make_work_item()
+        decision = make_create_decision(emails=[email])
+
+        with (
+            patch(
+                "claire_py.email.watcher.list_unread_replies",
+                return_value=[email],
+            ),
+            patch("azure_issue_bridge.bridge.load_processed_ids", return_value=set()),
+            patch(
+                "azure_issue_bridge.bridge.triage_emails", return_value=[decision]
+            ),
+            patch(
+                "azure_issue_bridge.bridge.fetch_work_item", return_value=work_item
+            ),
+            patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ),
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue",
+                return_value=_ISSUE_URL,
+            ),
+            patch("azure_issue_bridge.bridge.save_processed_id") as mock_save,
+            patch("azure_issue_bridge.bridge.archive_email") as mock_archive,
+            patch("azure_issue_bridge.bridge.save_state"),
+        ):
+            results = process_emails(dry_run=dry_run, branch_sync=branch_sync)
+
+        return results, mock_save, mock_archive
+
+    def test_sync_called_once_after_issue_creation(self) -> None:
+        mock_sync = MockBranchSync()
+        results, mock_save, _ = self._run_process_emails(branch_sync=mock_sync)
+
+        assert len(results) == 1
+        assert results[0].error is None
+        assert len(mock_sync.syncs) == 1
+        assert mock_sync.syncs[0] == (
+            "CLAIRE-Fivepoints/fivepoints-test",
+            "develop",
+            "CLAIRE-Fivepoints/fivepoints",
+            "develop",
+        )
+        mock_save.assert_called_once()
+
+    def test_sync_called_before_email_archiving(self) -> None:
+        call_order: list[str] = []
+
+        class OrderedMockSync:
+            def sync_branch(self, *args: Any, **kwargs: Any) -> None:
+                call_order.append("sync")
+
+        from azure_issue_bridge.bridge import process_emails
+
+        email = make_email()
+        work_item = make_work_item()
+        decision = make_create_decision(emails=[email])
+
+        def fake_archive(msg_id: str) -> None:
+            call_order.append("archive")
+
+        with (
+            patch(
+                "claire_py.email.watcher.list_unread_replies",
+                return_value=[email],
+            ),
+            patch("azure_issue_bridge.bridge.load_processed_ids", return_value=set()),
+            patch(
+                "azure_issue_bridge.bridge.triage_emails", return_value=[decision]
+            ),
+            patch(
+                "azure_issue_bridge.bridge.fetch_work_item", return_value=work_item
+            ),
+            patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ),
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue",
+                return_value=_ISSUE_URL,
+            ),
+            patch("azure_issue_bridge.bridge.save_processed_id"),
+            patch("azure_issue_bridge.bridge.archive_email", side_effect=fake_archive),
+            patch("azure_issue_bridge.bridge.save_state"),
+        ):
+            process_emails(branch_sync=OrderedMockSync())
+
+        assert call_order == ["sync", "archive"]
+
+    def test_sync_failure_sets_error_and_skips_archiving(self) -> None:
+        failing_sync = MagicMock()
+        failing_sync.sync_branch.side_effect = RuntimeError(
+            "git push failed: unauthorized"
+        )
+
+        results, mock_save, mock_archive = self._run_process_emails(
+            branch_sync=failing_sync
+        )
+
+        assert len(results) == 1
+        assert results[0].error is not None
+        assert "git push failed" in results[0].error
+        mock_save.assert_not_called()
+        mock_archive.assert_not_called()
+
+    def test_dry_run_does_not_call_sync(self) -> None:
+        mock_sync = MockBranchSync()
+        results, _, _ = self._run_process_emails(branch_sync=mock_sync, dry_run=True)
+
+        assert mock_sync.syncs == []
+        assert len(results) == 1
+        assert results[0].github_issue_url == "(dry-run)"
+
+    def test_no_sync_when_adapter_is_none(self) -> None:
+        results, mock_save, _ = self._run_process_emails(branch_sync=None)
+
+        assert len(results) == 1
+        assert results[0].error is None
+        mock_save.assert_called_once()


### PR DESCRIPTION
Closes #148

## Summary

- Nouveau `sync.py` avec `BranchSyncAdapter` (Protocol), `RealBranchSync` (git fetch + force-push via subprocess), et `MockBranchSync` (enregistre les appels pour assertions de test)
- `BridgeConfig` étendu avec `sync_source_repo`, `sync_target_repo`, `sync_branch_name` (overridable via `ADO_BRIDGE_SYNC_SOURCE` / `ADO_BRIDGE_SYNC_TARGET` / `ADO_BRIDGE_SYNC_BRANCH`)
- `process_emails()` reçoit `branch_sync: BranchSyncAdapter | None = None` — appelé après `create_github_issue()`, avant archivage des emails ; échec → pipeline avorté (result.error), emails non archivés
- `conftest.py` stub `claire_py` pour permettre les tests locaux sans l'environnement V1

## Verification Log

```
$ cd domain/scripts/azure_issue_bridge && python3 -m pytest tests/ -v

============================= test session starts ==============================
collected 85 items

tests/test_concurrent_lock.py::TestPreCreationDuplicateGuard::test_issue_not_created_when_already_exists_at_creation_time PASSED
tests/test_concurrent_lock.py::TestPreCreationDuplicateGuard::test_issue_created_normally_when_no_duplicate_found PASSED
...
tests/test_sync.py::TestMockBranchSync::test_starts_empty PASSED
tests/test_sync.py::TestMockBranchSync::test_records_single_call PASSED
tests/test_sync.py::TestMockBranchSync::test_records_multiple_calls PASSED
tests/test_sync.py::TestMockBranchSync::test_each_instance_has_own_list PASSED
tests/test_sync.py::TestProcessEmailsSync::test_sync_called_once_after_issue_creation PASSED
tests/test_sync.py::TestProcessEmailsSync::test_sync_called_before_email_archiving PASSED
tests/test_sync.py::TestProcessEmailsSync::test_sync_failure_sets_error_and_skips_archiving PASSED
tests/test_sync.py::TestProcessEmailsSync::test_dry_run_does_not_call_sync PASSED
tests/test_sync.py::TestProcessEmailsSync::test_no_sync_when_adapter_is_none PASSED
...
============================== 85 passed in 0.09s ==============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fAJCwqTEA3wBUE17pP8A7