### PR TITLE
feat(bridge): create worktree and named branch before assigning issue (#149)

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -3,7 +3,7 @@ domain: fivepoints
 category: operational
 name: AZURE_ISSUE_BRIDGE
 title: "Five Points — Azure DevOps Email Bridge (PBI Assignment → GitHub Issue Pipeline)"
-keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_TEST_SENDER, PBI_SENDER, test-sender, configurable-sender, branch-sync, ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH]
+keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_TEST_SENDER, PBI_SENDER, test-sender, configurable-sender, branch-sync, ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH, ADO_BRIDGE_AGENT, ADO_BRIDGE_CLIENT, worktree, role-label]
 updated: 2026-06-28
 ---
 
@@ -25,12 +25,15 @@ ADO PBI assigned to andre.perez@dothelpllc.com
   → parses PBI ID from subject: "Product Backlog Item {ID} - {area} - {title}"
   → TRIAGE: skip if duplicate, terminal state, or non-Task type
   → fetches PBI details from ADO REST API (AZURE_DEVOPS_PAT)
-  → creates GitHub issue in ADO_BRIDGE_REPO (default: claire-labs/fivepoints-test)
-  → syncs ADO_BRIDGE_SYNC_SOURCE/develop → ADO_BRIDGE_SYNC_TARGET/develop (GitHub API)
+  → creates GitHub issue in ADO_BRIDGE_SYNC_TARGET repo
+  → adds role label: role:{ADO_BRIDGE_CLIENT}-dev
+  → syncs ADO_BRIDGE_SYNC_SOURCE/develop → ADO_BRIDGE_SYNC_TARGET/develop (GitHub REST API)
+  → creates git worktree at <local>/.claire/worktrees/issue-{N} on branch pbi-{N}  ← BEFORE assignment
+  → assigns issue to ADO_BRIDGE_AGENT                                                ← ALWAYS LAST
   → archives email in Gmail
-  → claire spawn daemon (consumer.py) detects new issue in ADO_BRIDGE_REPO
-  → spawns Claire agent in isolated worktree
-  → agent receives CLAIRE_WAIT_REPO=<ADO_BRIDGE_REPO> for wait/PR targeting
+  → claire spawn daemon (consumer.py) detects assignment, finds worktree already prepared
+  → launches Claire agent in the pre-created worktree (no re-creation)
+  → agent receives CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET> for wait/PR targeting
 ```
 
 ---
@@ -68,9 +71,14 @@ Gmail inbox
       → if issue exists → action=skip (mark emails processed + archive)
       → if no issue   → action=create
   → [create only] GET https://dev.azure.com/{org}/{project}/_apis/wit/workitems/{id}?$expand=all
-  → gh issue create --repo <ADO_BRIDGE_REPO>
+  → gh issue create --repo <ADO_BRIDGE_SYNC_TARGET>
+  → gh issue edit --add-label role:{ADO_BRIDGE_CLIENT}-dev
   → sync ADO_BRIDGE_SYNC_SOURCE/<branch> → ADO_BRIDGE_SYNC_TARGET/<branch> (GitHub REST API)
       → failure aborts pipeline for this PBI (no archiving, no agent assignment)
+  → git worktree add -b pbi-{N} <local>/.claire/worktrees/issue-{N} origin/develop
+      → worktree created BEFORE issue assignment
+      → failure aborts pipeline (no archiving, no agent assignment)
+  → gh issue edit --add-assignee <ADO_BRIDGE_AGENT>  ← ALWAYS LAST
   → persist all email IDs for this PBI to ~/.claire/azure-issue-bridge/processed.json
   → archive all emails for this PBI in Gmail (remove INBOX label)
 ```
@@ -96,23 +104,26 @@ Gmail inbox
 
 ## Spawn Daemon Pickup
 
-After the bridge creates a GitHub issue, the **claire spawn daemon** (`consumer.py`) takes over:
+After the bridge creates the GitHub issue, adds the role label, creates the worktree, and assigns the issue, the **claire spawn daemon** (`consumer.py`) takes over:
 
-1. The spawn daemon monitors `ADO_BRIDGE_REPO` for newly opened issues
-2. When an issue matching the spawn criteria is detected, it creates an isolated git worktree
-3. A Claire agent is launched inside the worktree with the issue as its task
-4. The agent receives `CLAIRE_WAIT_REPO=<ADO_BRIDGE_REPO>` in its environment so `claire wait` targets the correct repo for PR creation and review polling
+1. The spawn daemon monitors `ADO_BRIDGE_SYNC_TARGET` for newly assigned issues
+2. When it detects the assignment to `ADO_BRIDGE_AGENT`, it looks for an existing worktree at `.claire/worktrees/issue-{N}` — the bridge has already created it
+3. A Claire agent is launched **inside the pre-created worktree** (no re-creation); `claire start --issue N` is idempotent when the worktree already exists
+4. The agent receives `CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET>` in its environment so `claire wait` targets the correct repo for PR creation and review polling
 
-**`ADO_BRIDGE_REPO` vs `CLAIRE_WAIT_REPO`:**
-- `ADO_BRIDGE_REPO` — configures where the bridge creates GitHub issues (set at bridge/operator level)
+**Why the bridge creates the worktree before assigning:**
+The spawn daemon used to create the worktree on detection. Moving worktree creation into the bridge (before assignment) means the agent starts on a branch that already exists, avoiding a race between branch creation and the first `git push`.
+
+**`ADO_BRIDGE_SYNC_TARGET` vs `CLAIRE_WAIT_REPO`:**
+- `ADO_BRIDGE_SYNC_TARGET` — configures where the bridge creates GitHub issues and the worktree (set at bridge/operator level)
 - `CLAIRE_WAIT_REPO` — passed by the spawn daemon into the spawned agent's environment so the agent knows which repo to watch for wait events
 - Both refer to the same repo; they are different variable names at different stages of the pipeline
 
-To repoint the pipeline to a different repo, set `ADO_BRIDGE_REPO`:
+To repoint the pipeline to a different repo, set `ADO_BRIDGE_SYNC_TARGET`:
 
 ```bash
-export ADO_BRIDGE_REPO=claire-labs/fivepoints   # production
-export ADO_BRIDGE_REPO=claire-labs/fivepoints-test  # staging (default)
+export ADO_BRIDGE_SYNC_TARGET=CLAIRE-Fivepoints/fivepoints   # production
+export ADO_BRIDGE_SYNC_TARGET=CLAIRE-Fivepoints/fivepoints-test  # staging (default)
 ```
 
 ---
@@ -216,9 +227,11 @@ The azure-issue-bridge uses `AZURE_DEVOPS_PAT`. The fivepoints plugin (`ado_comm
 | `ADO_BRIDGE_HOUR_END` | `17` | Business hours end (local time, exclusive) |
 | `PBI_TEST_SENDER` | _(unset)_ | Override accepted email sender for testing (e.g. `andreoperez@gmail.com`). Takes priority over `PBI_SENDER`. Emails from this address with the standard ADO subject format are processed identically to real ADO emails. |
 | `PBI_SENDER` | `azuredevops@microsoft.com` | Override the production ADO sender. Use when ADO notifications come from a custom address. Falls back to the ADO default when unset. |
+| `ADO_BRIDGE_AGENT` | `claire-test-ai` | GitHub username assigned to each new issue. **Set this explicitly in production** — the default targets the test account. |
+| `ADO_BRIDGE_CLIENT` | `fivepoints` | Client slug used to build the role label: `role:{ADO_BRIDGE_CLIENT}-dev`. Determines which agent persona is activated by the spawn daemon. |
 | `ADO_BRIDGE_SYNC_SOURCE` | `CLAIRE-Fivepoints/fivepoints-test` | Source GitHub repo for branch sync (the repo Claire agents push to). |
-| `ADO_BRIDGE_SYNC_TARGET` | `CLAIRE-Fivepoints/fivepoints` | Target GitHub repo for branch sync (the production repo). |
-| `ADO_BRIDGE_SYNC_BRANCH` | `develop` | Branch name synced from source to target before each agent assignment. |
+| `ADO_BRIDGE_SYNC_TARGET` | `CLAIRE-Fivepoints/fivepoints` | Target GitHub repo where issues are created, where the worktree branch is pushed, and where the issue is assigned. |
+| `ADO_BRIDGE_SYNC_BRANCH` | `develop` | Branch name synced from source to target and used as base for the new `pbi-{N}` branch. |
 
 ---
 
@@ -238,8 +251,10 @@ The azure-issue-bridge uses `AZURE_DEVOPS_PAT`. The fivepoints plugin (`ado_comm
 | File | Role |
 |------|------|
 | `domain/scripts/azure_issue_bridge/bridge.py` | Core pipeline logic |
+| `domain/scripts/azure_issue_bridge/sync.py` | Branch sync adapter — `RealBranchSync` (GitHub REST API) and `MockBranchSync` (test double) |
+| `domain/scripts/azure_issue_bridge/worktree.py` | Worktree adapter — `WorktreePrepareAdapter` Protocol, `RealWorktreePrepare` (git worktree add), `MockWorktreePrepare` (test double) |
 | `domain/scripts/azure_issue_bridge/cli.py` | CLI entry point (`python3 -m azure_issue_bridge.cli`) |
-| `domain/scripts/azure_issue_bridge/tests/` | Unit tests (triage, fetch metadata, concurrent lock) |
+| `domain/scripts/azure_issue_bridge/tests/` | Unit tests (triage, sync, worktree, concurrent lock) |
 | `domain/commands/azure-issue-bridge.sh` | Bash router — sets PYTHONPATH and dispatches to the python CLI |
 
 The bash router prepends `domain/scripts` to `PYTHONPATH` so the package is importable as `azure_issue_bridge`. The module still imports `claire_py.email.auth` and `claire_py.email.watcher` from claire core (which remain there).

--- a/domain/scripts/azure_issue_bridge/bridge.py
+++ b/domain/scripts/azure_issue_bridge/bridge.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from azure_issue_bridge.sync import BranchSyncAdapter
     from azure_issue_bridge.worktree import WorktreePrepareAdapter
 
 logger = logging.getLogger(__name__)
@@ -542,21 +543,6 @@ def assign_github_issue(repo: str, issue_number: int, agent: str) -> None:
     logger.info("Assigned issue #%s in %s to %s", issue_number, repo, agent)
 
 
-def sync_github_branch(
-    source_repo: str,
-    source_branch: str,
-    target_repo: str,
-    target_branch: str,
-) -> None:
-    """Sync source_branch from source_repo to target_repo via the GitHub REST API.
-
-    Raises RuntimeError on failure (propagated from RealBranchSync).
-    """
-    from azure_issue_bridge.sync import RealBranchSync
-
-    RealBranchSync().sync_branch(source_repo, source_branch, target_repo, target_branch)
-
-
 # ---------------------------------------------------------------------------
 # Full pipeline
 # ---------------------------------------------------------------------------
@@ -986,7 +972,8 @@ def process_emails(
     max_process: int | None = None,
     lookback_days: int | None = None,
     config: BridgeConfig | None = None,
-    worktree_prepare: WorktreePrepareAdapter | None = None,
+    branch_sync: "BranchSyncAdapter | None" = None,
+    worktree_prepare: "WorktreePrepareAdapter | None" = None,
 ) -> list[ProcessingResult]:
     """Scan Gmail inbox for ADO assignment emails and process each one.
 
@@ -999,16 +986,21 @@ def process_emails(
         dry_run: If True, log what would be created without touching GitHub or archiving.
         max_process: If set, limit the number of new work items created.
         lookback_days: If set, only scan emails from the last N days (Gmail newer_than filter).
+        branch_sync: Adapter for syncing the develop branch.  When None, uses
+            RealBranchSync().  Pass a MockBranchSync in tests.
         worktree_prepare: Adapter for creating git worktrees.  When None, uses
             RealWorktreePrepare().  Pass a MockWorktreePrepare in tests.
 
     Returns a list of ProcessingResult for each unique ADO work item found.
     """
+    from azure_issue_bridge.sync import RealBranchSync
     from azure_issue_bridge.worktree import RealWorktreePrepare
     from claire_py.email.watcher import list_unread_replies
 
     if config is None:
         config = load_bridge_config()
+    if branch_sync is None:
+        branch_sync = RealBranchSync()
     if worktree_prepare is None:
         worktree_prepare = RealWorktreePrepare()
 
@@ -1109,6 +1101,22 @@ def process_emails(
             if dry_run:
                 title = f"{work_item.title} (PBI #{work_item.id})"
                 logger.info("[dry-run] Would create issue: %s", title)
+                logger.info(
+                    "[dry-run] Would add label: role:%s-dev", config.client
+                )
+                logger.info(
+                    "[dry-run] Would sync branch %s: %s → %s",
+                    config.sync_branch,
+                    config.source_repo,
+                    config.target_repo,
+                )
+                logger.info(
+                    "[dry-run] Would create worktree for issue (branch: pbi-%s)",
+                    pbi_id,
+                )
+                logger.info(
+                    "[dry-run] Would assign issue to %s", config.agent
+                )
                 result.github_issue_url = "(dry-run)"
             else:
                 # Step 2: Pre-creation duplicate guard — re-check GitHub right before
@@ -1140,7 +1148,7 @@ def process_emails(
                     )
 
                     # Step 5: Sync develop branch source → target repo
-                    sync_github_branch(
+                    branch_sync.sync_branch(
                         config.source_repo,
                         config.sync_branch,
                         config.target_repo,

--- a/domain/scripts/azure_issue_bridge/bridge.py
+++ b/domain/scripts/azure_issue_bridge/bridge.py
@@ -514,7 +514,6 @@ def add_issue_label(repo: str, issue_number: int, label: str) -> None:
     logger.info("Added label %r to issue #%s in %s", label, issue_number, repo)
 
 
-
 def assign_github_issue(repo: str, issue_number: int, agent: str) -> None:
     """Assign a GitHub issue to an agent via gh CLI.
 

--- a/domain/scripts/azure_issue_bridge/bridge.py
+++ b/domain/scripts/azure_issue_bridge/bridge.py
@@ -514,79 +514,6 @@ def add_issue_label(repo: str, issue_number: int, label: str) -> None:
     logger.info("Added label %r to issue #%s in %s", label, issue_number, repo)
 
 
-def sync_github_branch(
-    source_repo: str,
-    source_branch: str,
-    target_repo: str,
-    target_branch: str,
-) -> None:
-    """Force-sync target_repo/target_branch to the current HEAD of source_repo/source_branch.
-
-    Uses the GitHub REST API via gh CLI to:
-      1. Fetch the SHA of source_repo/source_branch
-      2. Force-update target_repo/target_branch to that SHA
-
-    Raises RuntimeError on any failure — the caller should abort the pipeline.
-    """
-    # Step 1: resolve source branch SHA
-    sha_result = subprocess.run(
-        [
-            "gh",
-            "api",
-            f"repos/{source_repo}/git/ref/heads/{source_branch}",
-            "--jq",
-            ".object.sha",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if sha_result.returncode != 0 or not sha_result.stdout.strip():
-        raise RuntimeError(
-            f"Failed to resolve SHA for {source_repo}/{source_branch}: "
-            f"{sha_result.stderr.strip()}"
-        )
-    sha = sha_result.stdout.strip()
-    logger.info(
-        "Syncing %s/%s → %s/%s (SHA %s)",
-        source_repo,
-        source_branch,
-        target_repo,
-        target_branch,
-        sha[:8],
-    )
-
-    # Step 2: force-update target branch ref
-    patch_result = subprocess.run(
-        [
-            "gh",
-            "api",
-            "--method",
-            "PATCH",
-            f"repos/{target_repo}/git/refs/heads/{target_branch}",
-            "--field",
-            f"sha={sha}",
-            "--field",
-            "force=true",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if patch_result.returncode != 0:
-        raise RuntimeError(
-            f"Failed to update {target_repo}/{target_branch} to {sha[:8]}: "
-            f"{patch_result.stderr.strip()}"
-        )
-    logger.info(
-        "Synced %s/%s → %s/%s (%s)",
-        source_repo,
-        source_branch,
-        target_repo,
-        target_branch,
-        sha[:8],
-    )
-
 
 def assign_github_issue(repo: str, issue_number: int, agent: str) -> None:
     """Assign a GitHub issue to an agent via gh CLI.
@@ -614,6 +541,21 @@ def assign_github_issue(repo: str, issue_number: int, agent: str) -> None:
             f"{result.stderr.strip()}"
         )
     logger.info("Assigned issue #%s in %s to %s", issue_number, repo, agent)
+
+
+def sync_github_branch(
+    source_repo: str,
+    source_branch: str,
+    target_repo: str,
+    target_branch: str,
+) -> None:
+    """Sync source_branch from source_repo to target_repo via the GitHub REST API.
+
+    Raises RuntimeError on failure (propagated from RealBranchSync).
+    """
+    from azure_issue_bridge.sync import RealBranchSync
+
+    RealBranchSync().sync_branch(source_repo, source_branch, target_repo, target_branch)
 
 
 # ---------------------------------------------------------------------------

--- a/domain/scripts/azure_issue_bridge/bridge.py
+++ b/domain/scripts/azure_issue_bridge/bridge.py
@@ -11,7 +11,11 @@ Pipeline:
      - Skip PBIs that already have an open GitHub issue (dedup)
   4. Fetch the full work item from Azure DevOps REST API (create decisions only)
   5. Create a GitHub issue with the PBI link via gh CLI
-  6. Archive the email and persist processed IDs to avoid re-processing
+  6. Add role label to the issue
+  7. Sync develop branch source → target repo
+  8. Create git worktree for the issue (branch: pbi-{issue})   ← BEFORE assignment
+  9. Assign the issue to the agent                             ← ALWAYS LAST
+  10. Archive the email and persist processed IDs to avoid re-processing
 """
 
 from __future__ import annotations
@@ -28,7 +32,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from azure_issue_bridge.sync import BranchSyncAdapter
+    from azure_issue_bridge.worktree import WorktreePrepareAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +136,8 @@ _ADO_SENDER = "azuredevops@microsoft.com"
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_BRIDGE_AGENT = "claire-test-ai"
+_DEFAULT_BRIDGE_CLIENT = "fivepoints"
 _DEFAULT_SYNC_SOURCE = "CLAIRE-Fivepoints/fivepoints-test"
 _DEFAULT_SYNC_TARGET = "CLAIRE-Fivepoints/fivepoints"
 _DEFAULT_SYNC_BRANCH = "develop"
@@ -142,9 +148,11 @@ class BridgeConfig:
     """Runtime configuration for the azure issue bridge."""
 
     pbi_sender: str = _ADO_SENDER
-    sync_source_repo: str = _DEFAULT_SYNC_SOURCE
-    sync_target_repo: str = _DEFAULT_SYNC_TARGET
-    sync_branch_name: str = _DEFAULT_SYNC_BRANCH
+    agent: str = _DEFAULT_BRIDGE_AGENT
+    client: str = _DEFAULT_BRIDGE_CLIENT
+    source_repo: str = _DEFAULT_SYNC_SOURCE
+    target_repo: str = _DEFAULT_SYNC_TARGET
+    sync_branch: str = _DEFAULT_SYNC_BRANCH
 
 
 def _get_env_or_file(key: str) -> str:
@@ -178,20 +186,24 @@ def load_bridge_config() -> BridgeConfig:
         or _get_env_or_file("PBI_SENDER")
         or _ADO_SENDER
     )
-    sync_source_repo = (
+    agent = _get_env_or_file("ADO_BRIDGE_AGENT") or _DEFAULT_BRIDGE_AGENT
+    client = _get_env_or_file("ADO_BRIDGE_CLIENT") or _DEFAULT_BRIDGE_CLIENT
+    source_repo = (
         _get_env_or_file("ADO_BRIDGE_SYNC_SOURCE") or _DEFAULT_SYNC_SOURCE
     )
-    sync_target_repo = (
-        _get_env_or_file("ADO_BRIDGE_SYNC_TARGET") or _DEFAULT_SYNC_TARGET
+    target_repo = (
+        _get_env_or_file("ADO_BRIDGE_SYNC_TARGET")
+        or _get_env_or_file("ADO_BRIDGE_REPO")
+        or _DEFAULT_SYNC_TARGET
     )
-    sync_branch_name = (
-        _get_env_or_file("ADO_BRIDGE_SYNC_BRANCH") or _DEFAULT_SYNC_BRANCH
-    )
+    sync_branch = _get_env_or_file("ADO_BRIDGE_SYNC_BRANCH") or _DEFAULT_SYNC_BRANCH
     return BridgeConfig(
         pbi_sender=pbi_sender,
-        sync_source_repo=sync_source_repo,
-        sync_target_repo=sync_target_repo,
-        sync_branch_name=sync_branch_name,
+        agent=agent,
+        client=client,
+        source_repo=source_repo,
+        target_repo=target_repo,
+        sync_branch=sync_branch,
     )
 
 
@@ -371,12 +383,31 @@ def _strip_html(html: str) -> str:
     return text
 
 
-def create_github_issue(work_item: WorkItem) -> str:
+_ISSUE_NUMBER_RE = re.compile(r"/issues/(\d+)$")
+
+
+@dataclass
+class GitHubIssue:
+    """Reference to a created GitHub issue."""
+
+    url: str
+    number: int
+
+
+def _extract_issue_number(url: str) -> int:
+    """Extract the issue number from a GitHub issue URL."""
+    m = _ISSUE_NUMBER_RE.search(url)
+    if not m:
+        raise RuntimeError(f"Cannot extract issue number from URL: {url!r}")
+    return int(m.group(1))
+
+
+def create_github_issue(work_item: WorkItem) -> GitHubIssue:
     """Create a GitHub issue from an ADO work item.
 
     For Tasks with a parent PBI, fetches the parent and includes its description
     and acceptance criteria so the issue contains full business context.
-    Returns the GitHub issue URL.
+    Returns a GitHubIssue with url and number.
     """
     repo = os.environ.get("ADO_BRIDGE_REPO", _DEFAULT_GH_REPO)
     org = os.environ.get("ADO_ORG", _DEFAULT_ADO_ORG)
@@ -435,8 +466,11 @@ def create_github_issue(work_item: WorkItem) -> str:
         raise RuntimeError(f"gh issue create failed: {result.stderr.strip()}")
 
     issue_url = result.stdout.strip()
-    logger.info("Created GitHub issue for PBI #%s: %s", work_item.id, issue_url)
-    return issue_url
+    issue_number = _extract_issue_number(issue_url)
+    logger.info(
+        "Created GitHub issue #%s for PBI #%s: %s", issue_number, work_item.id, issue_url
+    )
+    return GitHubIssue(url=issue_url, number=issue_number)
 
 
 # ---------------------------------------------------------------------------
@@ -445,6 +479,141 @@ def create_github_issue(work_item: WorkItem) -> str:
 
 # Default: fivepoints-test (safe). Override: ADO_BRIDGE_REPO=claire-labs/fivepoints
 _DEFAULT_GH_REPO = os.environ.get("ADO_BRIDGE_REPO", "claire-labs/fivepoints-test")
+
+
+# ---------------------------------------------------------------------------
+# GitHub issue operations
+# ---------------------------------------------------------------------------
+
+
+def add_issue_label(repo: str, issue_number: int, label: str) -> None:
+    """Add a label to a GitHub issue via gh CLI.
+
+    Raises RuntimeError on failure.
+    """
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--add-label",
+            label,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh issue edit --add-label failed for issue #{issue_number} in {repo}: "
+            f"{result.stderr.strip()}"
+        )
+    logger.info("Added label %r to issue #%s in %s", label, issue_number, repo)
+
+
+def sync_github_branch(
+    source_repo: str,
+    source_branch: str,
+    target_repo: str,
+    target_branch: str,
+) -> None:
+    """Force-sync target_repo/target_branch to the current HEAD of source_repo/source_branch.
+
+    Uses the GitHub REST API via gh CLI to:
+      1. Fetch the SHA of source_repo/source_branch
+      2. Force-update target_repo/target_branch to that SHA
+
+    Raises RuntimeError on any failure — the caller should abort the pipeline.
+    """
+    # Step 1: resolve source branch SHA
+    sha_result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{source_repo}/git/ref/heads/{source_branch}",
+            "--jq",
+            ".object.sha",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if sha_result.returncode != 0 or not sha_result.stdout.strip():
+        raise RuntimeError(
+            f"Failed to resolve SHA for {source_repo}/{source_branch}: "
+            f"{sha_result.stderr.strip()}"
+        )
+    sha = sha_result.stdout.strip()
+    logger.info(
+        "Syncing %s/%s → %s/%s (SHA %s)",
+        source_repo,
+        source_branch,
+        target_repo,
+        target_branch,
+        sha[:8],
+    )
+
+    # Step 2: force-update target branch ref
+    patch_result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{target_repo}/git/refs/heads/{target_branch}",
+            "--field",
+            f"sha={sha}",
+            "--field",
+            "force=true",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if patch_result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to update {target_repo}/{target_branch} to {sha[:8]}: "
+            f"{patch_result.stderr.strip()}"
+        )
+    logger.info(
+        "Synced %s/%s → %s/%s (%s)",
+        source_repo,
+        source_branch,
+        target_repo,
+        target_branch,
+        sha[:8],
+    )
+
+
+def assign_github_issue(repo: str, issue_number: int, agent: str) -> None:
+    """Assign a GitHub issue to an agent via gh CLI.
+
+    Raises RuntimeError on failure.
+    """
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--add-assignee",
+            agent,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh issue edit --add-assignee failed for issue #{issue_number} in {repo}: "
+            f"{result.stderr.strip()}"
+        )
+    logger.info("Assigned issue #%s in %s to %s", issue_number, repo, agent)
 
 
 # ---------------------------------------------------------------------------
@@ -876,7 +1045,7 @@ def process_emails(
     max_process: int | None = None,
     lookback_days: int | None = None,
     config: BridgeConfig | None = None,
-    branch_sync: BranchSyncAdapter | None = None,
+    worktree_prepare: WorktreePrepareAdapter | None = None,
 ) -> list[ProcessingResult]:
     """Scan Gmail inbox for ADO assignment emails and process each one.
 
@@ -889,13 +1058,18 @@ def process_emails(
         dry_run: If True, log what would be created without touching GitHub or archiving.
         max_process: If set, limit the number of new work items created.
         lookback_days: If set, only scan emails from the last N days (Gmail newer_than filter).
+        worktree_prepare: Adapter for creating git worktrees.  When None, uses
+            RealWorktreePrepare().  Pass a MockWorktreePrepare in tests.
 
     Returns a list of ProcessingResult for each unique ADO work item found.
     """
+    from azure_issue_bridge.worktree import RealWorktreePrepare
     from claire_py.email.watcher import list_unread_replies
 
     if config is None:
         config = load_bridge_config()
+    if worktree_prepare is None:
+        worktree_prepare = RealWorktreePrepare()
 
     processed_ids = load_processed_ids()
     results: list[ProcessingResult] = []
@@ -994,14 +1168,6 @@ def process_emails(
             if dry_run:
                 title = f"{work_item.title} (PBI #{work_item.id})"
                 logger.info("[dry-run] Would create issue: %s", title)
-                if branch_sync is not None:
-                    logger.info(
-                        "[dry-run] Would sync %s/%s → %s/%s",
-                        config.sync_source_repo,
-                        config.sync_branch_name,
-                        config.sync_target_repo,
-                        config.sync_branch_name,
-                    )
                 result.github_issue_url = "(dry-run)"
             else:
                 # Step 2: Pre-creation duplicate guard — re-check GitHub right before
@@ -1022,18 +1188,35 @@ def process_emails(
                         archive_email(email.message_id)
                 else:
                     # Step 3: Create GitHub issue
-                    issue_url = create_github_issue(work_item)
-                    result.github_issue_url = issue_url
+                    issue = create_github_issue(work_item)
+                    result.github_issue_url = issue.url
 
-                    # Step 4: Sync source branch to target repo before worktree/assign.
-                    # Raises on failure → caught by outer except → pipeline aborted.
-                    if branch_sync is not None:
-                        branch_sync.sync_branch(
-                            source_repo=config.sync_source_repo,
-                            source_branch=config.sync_branch_name,
-                            target_repo=config.sync_target_repo,
-                            target_branch=config.sync_branch_name,
-                        )
+                    # Step 4: Add role label
+                    add_issue_label(
+                        config.target_repo,
+                        issue.number,
+                        f"role:{config.client}-dev",
+                    )
+
+                    # Step 5: Sync develop branch source → target repo
+                    sync_github_branch(
+                        config.source_repo,
+                        config.sync_branch,
+                        config.target_repo,
+                        config.sync_branch,
+                    )
+
+                    # Step 6: Create worktree for the issue (BEFORE assignment)
+                    branch_name = f"pbi-{issue.number}"
+                    worktree_prepare.prepare(
+                        repo=config.target_repo,
+                        issue=issue.number,
+                        base_branch=config.sync_branch,
+                        branch_name=branch_name,
+                    )
+
+                    # Step 7: Assign the issue to the agent (ALWAYS LAST)
+                    assign_github_issue(config.target_repo, issue.number, config.agent)
 
                     # Mark ALL emails for this PBI as processed and archive them
                     for email in decision.emails:

--- a/domain/scripts/azure_issue_bridge/tests/test_concurrent_lock.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_concurrent_lock.py
@@ -13,6 +13,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from azure_issue_bridge.bridge import GitHubIssue, process_emails
+from azure_issue_bridge.worktree import MockWorktreePrepare
 
 
 def make_email(subject: str, message_id: str = "msg-001") -> Any:
@@ -141,7 +142,7 @@ class TestPreCreationDuplicateGuard:
             patch("azure_issue_bridge.bridge.archive_email"),
             patch("azure_issue_bridge.bridge.save_state"),
         ):
-            results = process_emails()
+            results = process_emails(worktree_prepare=MockWorktreePrepare())
 
         # create_github_issue must have been called exactly once
         mock_create.assert_called_once()

--- a/domain/scripts/azure_issue_bridge/tests/test_concurrent_lock.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_concurrent_lock.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from azure_issue_bridge.bridge import process_emails
+from azure_issue_bridge.bridge import GitHubIssue, process_emails
 
 
 def make_email(subject: str, message_id: str = "msg-001") -> Any:
@@ -129,8 +129,14 @@ class TestPreCreationDuplicateGuard:
             ),
             patch(
                 "azure_issue_bridge.bridge.create_github_issue",
-                return_value="https://github.com/claire-labs/fivepoints/issues/105",
+                return_value=GitHubIssue(
+                    url="https://github.com/claire-labs/fivepoints/issues/105",
+                    number=105,
+                ),
             ) as mock_create,
+            patch("azure_issue_bridge.bridge.add_issue_label"),
+            patch("azure_issue_bridge.bridge.sync_github_branch"),
+            patch("azure_issue_bridge.bridge.assign_github_issue"),
             patch("azure_issue_bridge.bridge.save_processed_id"),
             patch("azure_issue_bridge.bridge.archive_email"),
             patch("azure_issue_bridge.bridge.save_state"),

--- a/domain/scripts/azure_issue_bridge/tests/test_concurrent_lock.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_concurrent_lock.py
@@ -13,6 +13,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from azure_issue_bridge.bridge import GitHubIssue, process_emails
+from azure_issue_bridge.sync import MockBranchSync
 from azure_issue_bridge.worktree import MockWorktreePrepare
 
 
@@ -136,13 +137,15 @@ class TestPreCreationDuplicateGuard:
                 ),
             ) as mock_create,
             patch("azure_issue_bridge.bridge.add_issue_label"),
-            patch("azure_issue_bridge.bridge.sync_github_branch"),
             patch("azure_issue_bridge.bridge.assign_github_issue"),
             patch("azure_issue_bridge.bridge.save_processed_id"),
             patch("azure_issue_bridge.bridge.archive_email"),
             patch("azure_issue_bridge.bridge.save_state"),
         ):
-            results = process_emails(worktree_prepare=MockWorktreePrepare())
+            results = process_emails(
+                branch_sync=MockBranchSync(),
+                worktree_prepare=MockWorktreePrepare(),
+            )
 
         # create_github_issue must have been called exactly once
         mock_create.assert_called_once()

--- a/domain/scripts/azure_issue_bridge/tests/test_sync.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_sync.py
@@ -82,7 +82,7 @@ class TestMockBranchSync:
 
 
 # ---------------------------------------------------------------------------
-# process_emails() + sync_github_branch integration tests
+# process_emails() + branch_sync integration tests
 # ---------------------------------------------------------------------------
 
 
@@ -108,13 +108,14 @@ def _default_config() -> Any:
 
 
 class TestProcessEmailsSync:
-    """process_emails() must call sync_github_branch after issue creation, before archiving."""
+    """process_emails() must call branch_sync.sync_branch after issue creation, before archiving."""
 
     def _run_process_emails(
         self,
         dry_run: bool = False,
+        branch_sync: Any = None,
     ) -> tuple[list[Any], Any, Any, Any]:
-        """Standard fixture: returns (results, mock_sync, mock_save, mock_archive)."""
+        """Standard fixture: returns (results, mock_bs, mock_save, mock_archive)."""
         from azure_issue_bridge.bridge import process_emails
         from azure_issue_bridge.worktree import MockWorktreePrepare
 
@@ -122,6 +123,7 @@ class TestProcessEmailsSync:
         work_item = make_work_item()
         decision = make_create_decision(emails=[email])
         config = _default_config()
+        mock_bs = branch_sync if branch_sync is not None else MockBranchSync()
 
         with (
             patch("claire_py.email.watcher.list_unread_replies", return_value=[email]),
@@ -137,7 +139,6 @@ class TestProcessEmailsSync:
                 return_value=_make_github_issue(42),
             ),
             patch("azure_issue_bridge.bridge.add_issue_label"),
-            patch("azure_issue_bridge.bridge.sync_github_branch") as mock_sync,
             patch("azure_issue_bridge.bridge.assign_github_issue"),
             patch("azure_issue_bridge.bridge.save_processed_id") as mock_save,
             patch("azure_issue_bridge.bridge.archive_email") as mock_archive,
@@ -146,22 +147,25 @@ class TestProcessEmailsSync:
             results = process_emails(
                 dry_run=dry_run,
                 config=config,
+                branch_sync=mock_bs,
                 worktree_prepare=MockWorktreePrepare(),
             )
 
-        return results, mock_sync, mock_save, mock_archive
+        return results, mock_bs, mock_save, mock_archive
 
     def test_sync_called_once_after_issue_creation(self) -> None:
-        results, mock_sync, mock_save, _ = self._run_process_emails()
+        results, mock_bs, mock_save, _ = self._run_process_emails()
 
         assert len(results) == 1
         assert results[0].error is None
-        mock_sync.assert_called_once_with(
-            "CLAIRE-Fivepoints/fivepoints-test",
-            "develop",
-            "CLAIRE-Fivepoints/fivepoints",
-            "develop",
-        )
+        assert mock_bs.syncs == [
+            (
+                "CLAIRE-Fivepoints/fivepoints-test",
+                "develop",
+                "CLAIRE-Fivepoints/fivepoints",
+                "develop",
+            )
+        ]
         mock_save.assert_called_once()
 
     def test_sync_called_before_email_archiving(self) -> None:
@@ -174,8 +178,9 @@ class TestProcessEmailsSync:
         work_item = make_work_item()
         decision = make_create_decision(emails=[email])
 
-        def fake_sync(*args: Any, **kwargs: Any) -> None:
-            call_order.append("sync")
+        class OrderTrackingBranchSync:
+            def sync_branch(self, *args: Any, **kwargs: Any) -> None:
+                call_order.append("sync")
 
         def fake_archive(msg_id: str) -> None:
             call_order.append("archive")
@@ -196,7 +201,6 @@ class TestProcessEmailsSync:
                 ),
             ),
             patch("azure_issue_bridge.bridge.add_issue_label"),
-            patch("azure_issue_bridge.bridge.sync_github_branch", side_effect=fake_sync),
             patch("azure_issue_bridge.bridge.assign_github_issue"),
             patch("azure_issue_bridge.bridge.save_processed_id"),
             patch("azure_issue_bridge.bridge.archive_email", side_effect=fake_archive),
@@ -204,6 +208,7 @@ class TestProcessEmailsSync:
         ):
             process_emails(
                 config=_default_config(),
+                branch_sync=OrderTrackingBranchSync(),
                 worktree_prepare=MockWorktreePrepare(),
             )
 
@@ -216,6 +221,11 @@ class TestProcessEmailsSync:
         email = make_email()
         work_item = make_work_item()
         decision = make_create_decision(emails=[email])
+
+        failing_sync = MockBranchSync()
+        failing_sync.sync_branch = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("git push failed: unauthorized")
+        )
 
         with (
             patch("claire_py.email.watcher.list_unread_replies", return_value=[email]),
@@ -233,10 +243,6 @@ class TestProcessEmailsSync:
                 ),
             ),
             patch("azure_issue_bridge.bridge.add_issue_label"),
-            patch(
-                "azure_issue_bridge.bridge.sync_github_branch",
-                side_effect=RuntimeError("git push failed: unauthorized"),
-            ),
             patch("azure_issue_bridge.bridge.assign_github_issue"),
             patch("azure_issue_bridge.bridge.save_processed_id") as mock_save,
             patch("azure_issue_bridge.bridge.archive_email") as mock_archive,
@@ -244,6 +250,7 @@ class TestProcessEmailsSync:
         ):
             results = process_emails(
                 config=_default_config(),
+                branch_sync=failing_sync,
                 worktree_prepare=MockWorktreePrepare(),
             )
 
@@ -254,17 +261,17 @@ class TestProcessEmailsSync:
         mock_archive.assert_not_called()
 
     def test_dry_run_does_not_call_sync(self) -> None:
-        results, mock_sync, _, _ = self._run_process_emails(dry_run=True)
+        results, mock_bs, _, _ = self._run_process_emails(dry_run=True)
 
-        mock_sync.assert_not_called()
+        assert mock_bs.syncs == []
         assert len(results) == 1
         assert results[0].github_issue_url == "(dry-run)"
 
     def test_sync_is_always_called(self) -> None:
-        """sync_github_branch is always called — no optional adapter."""
-        results, mock_sync, mock_save, _ = self._run_process_emails()
+        """branch_sync.sync_branch is always called — defaults to RealBranchSync when None."""
+        results, mock_bs, mock_save, _ = self._run_process_emails()
 
         assert len(results) == 1
         assert results[0].error is None
-        mock_sync.assert_called_once()
+        assert len(mock_bs.syncs) == 1
         mock_save.assert_called_once()

--- a/domain/scripts/azure_issue_bridge/tests/test_sync.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_sync.py
@@ -1,20 +1,18 @@
 """
-Tests for azure_issue_bridge.sync and the sync_branch step in process_emails().
+Tests for azure_issue_bridge.sync and the sync_github_branch step in process_emails().
 
 Covers:
 - MockBranchSync.syncs records each call
-- process_emails() calls sync_branch after issue creation, before archiving
+- process_emails() calls sync_github_branch after issue creation, before archiving
 - Sync failure aborts the pipeline (result.error set, emails not archived)
-- dry-run logs the sync intent without calling sync_branch
-- No sync when branch_sync=None (backward-compatible default)
+- dry-run does not call sync_github_branch
+- sync_github_branch is always called (no optional adapter)
 """
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 from azure_issue_bridge.sync import MockBranchSync
 
@@ -84,62 +82,81 @@ class TestMockBranchSync:
 
 
 # ---------------------------------------------------------------------------
-# process_emails() + branch_sync integration tests
+# process_emails() + sync_github_branch integration tests
 # ---------------------------------------------------------------------------
 
-_ISSUE_URL = "https://github.com/org/repo/issues/42"
+
+def _make_github_issue(number: int = 42) -> Any:
+    from azure_issue_bridge.bridge import GitHubIssue
+
+    return GitHubIssue(
+        url=f"https://github.com/org/repo/issues/{number}",
+        number=number,
+    )
+
+
+def _default_config() -> Any:
+    from azure_issue_bridge.bridge import BridgeConfig
+
+    return BridgeConfig(
+        agent="claire-test-ai",
+        client="fivepoints",
+        source_repo="CLAIRE-Fivepoints/fivepoints-test",
+        target_repo="CLAIRE-Fivepoints/fivepoints",
+        sync_branch="develop",
+    )
 
 
 class TestProcessEmailsSync:
+    """process_emails() must call sync_github_branch after issue creation, before archiving."""
+
     def _run_process_emails(
         self,
-        branch_sync: Any = None,
         dry_run: bool = False,
-        extra_patches: dict | None = None,
-    ) -> tuple[list[Any], Any, Any]:
-        """Run process_emails with standard mocks, returning (results, mock_save, mock_archive)."""
+    ) -> tuple[list[Any], Any, Any, Any]:
+        """Standard fixture: returns (results, mock_sync, mock_save, mock_archive)."""
         from azure_issue_bridge.bridge import process_emails
+        from azure_issue_bridge.worktree import MockWorktreePrepare
 
         email = make_email()
         work_item = make_work_item()
         decision = make_create_decision(emails=[email])
+        config = _default_config()
 
         with (
-            patch(
-                "claire_py.email.watcher.list_unread_replies",
-                return_value=[email],
-            ),
+            patch("claire_py.email.watcher.list_unread_replies", return_value=[email]),
             patch("azure_issue_bridge.bridge.load_processed_ids", return_value=set()),
-            patch(
-                "azure_issue_bridge.bridge.triage_emails", return_value=[decision]
-            ),
-            patch(
-                "azure_issue_bridge.bridge.fetch_work_item", return_value=work_item
-            ),
+            patch("azure_issue_bridge.bridge.triage_emails", return_value=[decision]),
+            patch("azure_issue_bridge.bridge.fetch_work_item", return_value=work_item),
             patch(
                 "azure_issue_bridge.bridge.find_existing_github_issue",
                 return_value=None,
             ),
             patch(
                 "azure_issue_bridge.bridge.create_github_issue",
-                return_value=_ISSUE_URL,
+                return_value=_make_github_issue(42),
             ),
+            patch("azure_issue_bridge.bridge.add_issue_label"),
+            patch("azure_issue_bridge.bridge.sync_github_branch") as mock_sync,
+            patch("azure_issue_bridge.bridge.assign_github_issue"),
             patch("azure_issue_bridge.bridge.save_processed_id") as mock_save,
             patch("azure_issue_bridge.bridge.archive_email") as mock_archive,
             patch("azure_issue_bridge.bridge.save_state"),
         ):
-            results = process_emails(dry_run=dry_run, branch_sync=branch_sync)
+            results = process_emails(
+                dry_run=dry_run,
+                config=config,
+                worktree_prepare=MockWorktreePrepare(),
+            )
 
-        return results, mock_save, mock_archive
+        return results, mock_sync, mock_save, mock_archive
 
     def test_sync_called_once_after_issue_creation(self) -> None:
-        mock_sync = MockBranchSync()
-        results, mock_save, _ = self._run_process_emails(branch_sync=mock_sync)
+        results, mock_sync, mock_save, _ = self._run_process_emails()
 
         assert len(results) == 1
         assert results[0].error is None
-        assert len(mock_sync.syncs) == 1
-        assert mock_sync.syncs[0] == (
+        mock_sync.assert_called_once_with(
             "CLAIRE-Fivepoints/fivepoints-test",
             "develop",
             "CLAIRE-Fivepoints/fivepoints",
@@ -150,56 +167,85 @@ class TestProcessEmailsSync:
     def test_sync_called_before_email_archiving(self) -> None:
         call_order: list[str] = []
 
-        class OrderedMockSync:
-            def sync_branch(self, *args: Any, **kwargs: Any) -> None:
-                call_order.append("sync")
-
-        from azure_issue_bridge.bridge import process_emails
+        from azure_issue_bridge.bridge import GitHubIssue, process_emails
+        from azure_issue_bridge.worktree import MockWorktreePrepare
 
         email = make_email()
         work_item = make_work_item()
         decision = make_create_decision(emails=[email])
 
+        def fake_sync(*args: Any, **kwargs: Any) -> None:
+            call_order.append("sync")
+
         def fake_archive(msg_id: str) -> None:
             call_order.append("archive")
 
         with (
-            patch(
-                "claire_py.email.watcher.list_unread_replies",
-                return_value=[email],
-            ),
+            patch("claire_py.email.watcher.list_unread_replies", return_value=[email]),
             patch("azure_issue_bridge.bridge.load_processed_ids", return_value=set()),
-            patch(
-                "azure_issue_bridge.bridge.triage_emails", return_value=[decision]
-            ),
-            patch(
-                "azure_issue_bridge.bridge.fetch_work_item", return_value=work_item
-            ),
+            patch("azure_issue_bridge.bridge.triage_emails", return_value=[decision]),
+            patch("azure_issue_bridge.bridge.fetch_work_item", return_value=work_item),
             patch(
                 "azure_issue_bridge.bridge.find_existing_github_issue",
                 return_value=None,
             ),
             patch(
                 "azure_issue_bridge.bridge.create_github_issue",
-                return_value=_ISSUE_URL,
+                return_value=GitHubIssue(
+                    url="https://github.com/org/repo/issues/42", number=42
+                ),
             ),
+            patch("azure_issue_bridge.bridge.add_issue_label"),
+            patch("azure_issue_bridge.bridge.sync_github_branch", side_effect=fake_sync),
+            patch("azure_issue_bridge.bridge.assign_github_issue"),
             patch("azure_issue_bridge.bridge.save_processed_id"),
             patch("azure_issue_bridge.bridge.archive_email", side_effect=fake_archive),
             patch("azure_issue_bridge.bridge.save_state"),
         ):
-            process_emails(branch_sync=OrderedMockSync())
+            process_emails(
+                config=_default_config(),
+                worktree_prepare=MockWorktreePrepare(),
+            )
 
         assert call_order == ["sync", "archive"]
 
     def test_sync_failure_sets_error_and_skips_archiving(self) -> None:
-        failing_sync = MagicMock()
-        failing_sync.sync_branch.side_effect = RuntimeError(
-            "git push failed: unauthorized"
-        )
+        from azure_issue_bridge.bridge import GitHubIssue, process_emails
+        from azure_issue_bridge.worktree import MockWorktreePrepare
 
-        results, mock_save, mock_archive = self._run_process_emails(
-            branch_sync=failing_sync
-        )
+        email = make_email()
+        work_item = make_work_item()
+        decision = make_create_decision(emails=[email])
+
+        with (
+            patch("claire_py.email.watcher.list_unread_replies", return_value=[email]),
+            patch("azure_issue_bridge.bridge.load_processed_ids", return_value=set()),
+            patch("azure_issue_bridge.bridge.triage_emails", return_value=[decision]),
+            patch("azure_issue_bridge.bridge.fetch_work_item", return_value=work_item),
+            patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ),
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue",
+                return_value=GitHubIssue(
+                    url="https://github.com/org/repo/issues/42", number=42
+                ),
+            ),
+            patch("azure_issue_bridge.bridge.add_issue_label"),
+            patch(
+                "azure_issue_bridge.bridge.sync_github_branch",
+                side_effect=RuntimeError("git push failed: unauthorized"),
+            ),
+            patch("azure_issue_bridge.bridge.assign_github_issue"),
+            patch("azure_issue_bridge.bridge.save_processed_id") as mock_save,
+            patch("azure_issue_bridge.bridge.archive_email") as mock_archive,
+            patch("azure_issue_bridge.bridge.save_state"),
+        ):
+            results = process_emails(
+                config=_default_config(),
+                worktree_prepare=MockWorktreePrepare(),
+            )
 
         assert len(results) == 1
         assert results[0].error is not None
@@ -208,16 +254,17 @@ class TestProcessEmailsSync:
         mock_archive.assert_not_called()
 
     def test_dry_run_does_not_call_sync(self) -> None:
-        mock_sync = MockBranchSync()
-        results, _, _ = self._run_process_emails(branch_sync=mock_sync, dry_run=True)
+        results, mock_sync, _, _ = self._run_process_emails(dry_run=True)
 
-        assert mock_sync.syncs == []
+        mock_sync.assert_not_called()
         assert len(results) == 1
         assert results[0].github_issue_url == "(dry-run)"
 
-    def test_no_sync_when_adapter_is_none(self) -> None:
-        results, mock_save, _ = self._run_process_emails(branch_sync=None)
+    def test_sync_is_always_called(self) -> None:
+        """sync_github_branch is always called — no optional adapter."""
+        results, mock_sync, mock_save, _ = self._run_process_emails()
 
         assert len(results) == 1
         assert results[0].error is None
+        mock_sync.assert_called_once()
         mock_save.assert_called_once()

--- a/domain/scripts/azure_issue_bridge/tests/test_worktree_prepare.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_worktree_prepare.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from azure_issue_bridge.sync import MockBranchSync
 from azure_issue_bridge.worktree import MockWorktreePrepare
 
 
@@ -237,7 +238,6 @@ class TestPipelineWorktreeIntegration:
                 ),
             ))
             stack.enter_context(patch("azure_issue_bridge.bridge.add_issue_label"))
-            stack.enter_context(patch("azure_issue_bridge.bridge.sync_github_branch"))
             stack.enter_context(patch(
                 "azure_issue_bridge.bridge.assign_github_issue",
                 side_effect=mock_assign,
@@ -248,7 +248,11 @@ class TestPipelineWorktreeIntegration:
             stack.enter_context(patch(
                 "azure_issue_bridge.bridge.load_processed_ids", return_value=set()
             ))
-            process_emails(config=config, worktree_prepare=mock_wt)
+            process_emails(
+                config=config,
+                branch_sync=MockBranchSync(),
+                worktree_prepare=mock_wt,
+            )
 
         assert call_order == ["prepare", "assign"], (
             "Expected prepare before assign, got: {}".format(call_order)
@@ -287,7 +291,6 @@ class TestPipelineWorktreeIntegration:
                 ),
             ))
             stack.enter_context(patch("azure_issue_bridge.bridge.add_issue_label"))
-            stack.enter_context(patch("azure_issue_bridge.bridge.sync_github_branch"))
             mock_assign = stack.enter_context(
                 patch("azure_issue_bridge.bridge.assign_github_issue")
             )
@@ -297,7 +300,11 @@ class TestPipelineWorktreeIntegration:
             stack.enter_context(patch(
                 "azure_issue_bridge.bridge.load_processed_ids", return_value=set()
             ))
-            results = process_emails(config=config, worktree_prepare=mock_wt)
+            results = process_emails(
+                config=config,
+                branch_sync=MockBranchSync(),
+                worktree_prepare=mock_wt,
+            )
 
         # assign must NOT be called when prepare raises
         mock_assign.assert_not_called()
@@ -337,7 +344,6 @@ class TestPipelineWorktreeIntegration:
                 ),
             ))
             stack.enter_context(patch("azure_issue_bridge.bridge.add_issue_label"))
-            stack.enter_context(patch("azure_issue_bridge.bridge.sync_github_branch"))
             stack.enter_context(patch("azure_issue_bridge.bridge.assign_github_issue"))
             stack.enter_context(patch("azure_issue_bridge.bridge.save_processed_id"))
             stack.enter_context(patch("azure_issue_bridge.bridge.archive_email"))
@@ -345,7 +351,11 @@ class TestPipelineWorktreeIntegration:
             stack.enter_context(patch(
                 "azure_issue_bridge.bridge.load_processed_ids", return_value=set()
             ))
-            process_emails(config=config, worktree_prepare=mock_wt)
+            process_emails(
+                config=config,
+                branch_sync=MockBranchSync(),
+                worktree_prepare=mock_wt,
+            )
 
         assert len(mock_wt.prepared) == 1
         assert mock_wt.prepared[0]["branch"] == "pbi-77"
@@ -386,7 +396,6 @@ class TestPipelineWorktreeIntegration:
             mock_add_label = stack.enter_context(
                 patch("azure_issue_bridge.bridge.add_issue_label")
             )
-            stack.enter_context(patch("azure_issue_bridge.bridge.sync_github_branch"))
             stack.enter_context(patch("azure_issue_bridge.bridge.assign_github_issue"))
             stack.enter_context(patch("azure_issue_bridge.bridge.save_processed_id"))
             stack.enter_context(patch("azure_issue_bridge.bridge.archive_email"))
@@ -394,6 +403,10 @@ class TestPipelineWorktreeIntegration:
             stack.enter_context(patch(
                 "azure_issue_bridge.bridge.load_processed_ids", return_value=set()
             ))
-            process_emails(config=config, worktree_prepare=mock_wt)
+            process_emails(
+                config=config,
+                branch_sync=MockBranchSync(),
+                worktree_prepare=mock_wt,
+            )
 
         mock_add_label.assert_called_once_with("org/target", 88, "role:myapp-dev")

--- a/domain/scripts/azure_issue_bridge/tests/test_worktree_prepare.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_worktree_prepare.py
@@ -181,21 +181,26 @@ def _make_work_item(item_id: int, title: str) -> MagicMock:
     )
 
 
+def _make_config(client: str = "fivepoints"):
+    from azure_issue_bridge.bridge import BridgeConfig
+    return BridgeConfig(
+        agent="claire-test-ai",
+        client=client,
+        source_repo="org/source",
+        target_repo="org/target",
+        sync_branch="develop",
+    )
+
+
 class TestPipelineWorktreeIntegration:
     """process_emails must call prepare_worktree before assign_github_issue."""
 
     def test_worktree_called_before_assign(self) -> None:
-        from azure_issue_bridge.bridge import BridgeConfig, GitHubIssue, process_emails
+        from azure_issue_bridge.bridge import GitHubIssue, process_emails
 
         mock_wt = MockWorktreePrepare()
         email = _make_email("Task 42 - DEV - some task")
-        config = BridgeConfig(
-            agent="claire-test-ai",
-            client="fivepoints",
-            source_repo="org/source",
-            target_repo="org/target",
-            sync_branch="develop",
-        )
+        config = _make_config()
 
         call_order: list[str] = []
 
@@ -209,7 +214,6 @@ class TestPipelineWorktreeIntegration:
         mock_wt.prepare = mock_prepare
 
         with ExitStack() as stack:
-            # list_unread_replies is imported locally inside process_emails
             stack.enter_context(patch(
                 "claire_py.email.watcher.list_unread_replies",
                 return_value=[email],
@@ -251,22 +255,15 @@ class TestPipelineWorktreeIntegration:
         )
 
     def test_pipeline_aborts_when_prepare_raises(self) -> None:
-        from azure_issue_bridge.bridge import BridgeConfig, GitHubIssue, process_emails
+        from azure_issue_bridge.bridge import GitHubIssue, process_emails
 
         mock_wt = MockWorktreePrepare()
         mock_wt.prepare = MagicMock(side_effect=RuntimeError("git worktree add failed"))
 
         email = _make_email("Task 55 - DEV - failing task")
-        config = BridgeConfig(
-            agent="claire-test-ai",
-            client="fivepoints",
-            source_repo="org/source",
-            target_repo="org/target",
-            sync_branch="develop",
-        )
+        config = _make_config()
 
         with ExitStack() as stack:
-            # list_unread_replies is imported locally inside process_emails
             stack.enter_context(patch(
                 "claire_py.email.watcher.list_unread_replies",
                 return_value=[email],
@@ -310,20 +307,13 @@ class TestPipelineWorktreeIntegration:
         assert "git worktree add failed" in results[0].error
 
     def test_branch_name_uses_issue_number(self) -> None:
-        from azure_issue_bridge.bridge import BridgeConfig, GitHubIssue, process_emails
+        from azure_issue_bridge.bridge import GitHubIssue, process_emails
 
         mock_wt = MockWorktreePrepare()
         email = _make_email("Task 77 - DEV - branch name test")
-        config = BridgeConfig(
-            agent="claire-test-ai",
-            client="fivepoints",
-            source_repo="org/source",
-            target_repo="org/target",
-            sync_branch="develop",
-        )
+        config = _make_config()
 
         with ExitStack() as stack:
-            # list_unread_replies is imported locally inside process_emails
             stack.enter_context(patch(
                 "claire_py.email.watcher.list_unread_replies",
                 return_value=[email],
@@ -364,20 +354,13 @@ class TestPipelineWorktreeIntegration:
         assert mock_wt.prepared[0]["repo"] == "org/target"
 
     def test_label_uses_client_config(self) -> None:
-        from azure_issue_bridge.bridge import BridgeConfig, GitHubIssue, process_emails
+        from azure_issue_bridge.bridge import GitHubIssue, process_emails
 
         mock_wt = MockWorktreePrepare()
         email = _make_email("Task 88 - DEV - label test")
-        config = BridgeConfig(
-            agent="claire-test-ai",
-            client="myapp",
-            source_repo="org/source",
-            target_repo="org/target",
-            sync_branch="develop",
-        )
+        config = _make_config(client="myapp")
 
         with ExitStack() as stack:
-            # list_unread_replies is imported locally inside process_emails
             stack.enter_context(patch(
                 "claire_py.email.watcher.list_unread_replies",
                 return_value=[email],

--- a/domain/scripts/azure_issue_bridge/tests/test_worktree_prepare.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_worktree_prepare.py
@@ -1,0 +1,416 @@
+"""
+Unit tests for WorktreePrepare adapters and pipeline integration.
+
+Tests:
+- MockWorktreePrepare records calls in self.prepared
+- RealWorktreePrepare raises on git failures
+- process_emails calls prepare_worktree before assign_github_issue
+- process_emails aborts (no assignment) when prepare_worktree raises
+- Branch name is configurable (not hard-coded)
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azure_issue_bridge.worktree import MockWorktreePrepare
+
+
+# ---------------------------------------------------------------------------
+# MockWorktreePrepare
+# ---------------------------------------------------------------------------
+
+
+class TestMockWorktreePrepare:
+    def test_prepare_records_call(self) -> None:
+        mock = MockWorktreePrepare()
+        path = mock.prepare(
+            repo="CLAIRE-Fivepoints/fivepoints",
+            issue=42,
+            base_branch="develop",
+            branch_name="pbi-42",
+        )
+        assert path == "/mock/worktrees/pbi-42"
+        assert len(mock.prepared) == 1
+        assert mock.prepared[0] == {
+            "repo": "CLAIRE-Fivepoints/fivepoints",
+            "issue": 42,
+            "base_branch": "develop",
+            "branch": "pbi-42",
+        }
+
+    def test_prepare_records_multiple_calls(self) -> None:
+        mock = MockWorktreePrepare()
+        mock.prepare(repo="org/repo", issue=1, base_branch="main", branch_name="pbi-1")
+        mock.prepare(repo="org/repo", issue=2, base_branch="main", branch_name="pbi-2")
+        assert len(mock.prepared) == 2
+        assert mock.prepared[0]["issue"] == 1
+        assert mock.prepared[1]["issue"] == 2
+
+    def test_prepare_returns_path_with_branch_name(self) -> None:
+        mock = MockWorktreePrepare()
+        path = mock.prepare(
+            repo="org/repo",
+            issue=99,
+            base_branch="develop",
+            branch_name="custom-branch",
+        )
+        assert path == "/mock/worktrees/custom-branch"
+
+    def test_instances_do_not_share_prepared_list(self) -> None:
+        m1 = MockWorktreePrepare()
+        m2 = MockWorktreePrepare()
+        m1.prepare(repo="r", issue=1, base_branch="b", branch_name="pbi-1")
+        assert len(m1.prepared) == 1
+        assert len(m2.prepared) == 0
+
+    def test_branch_name_configurable(self) -> None:
+        mock = MockWorktreePrepare()
+        branch = "feature/custom-name"
+        mock.prepare(repo="r", issue=10, base_branch="develop", branch_name=branch)
+        assert mock.prepared[0]["branch"] == branch
+        assert mock.prepared[0]["branch"] != "pbi-10"
+
+
+# ---------------------------------------------------------------------------
+# RealWorktreePrepare
+# ---------------------------------------------------------------------------
+
+
+class TestRealWorktreePrepare:
+    def test_raises_when_git_fetch_fails(self, tmp_path) -> None:
+        from azure_issue_bridge.worktree import RealWorktreePrepare
+
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="fatal: error")
+            with pytest.raises(RuntimeError, match="git command failed"):
+                prepare.prepare(
+                    repo="org/repo",
+                    issue=1,
+                    base_branch="develop",
+                    branch_name="pbi-1",
+                )
+
+    def test_raises_when_git_worktree_add_fails(self, tmp_path) -> None:
+        from azure_issue_bridge.worktree import RealWorktreePrepare
+
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+
+        def run_side_effect(cmd, **kwargs):
+            if "fetch" in cmd:
+                return MagicMock(returncode=0, stderr="", stdout="")
+            return MagicMock(returncode=128, stderr="fatal: branch already exists")
+
+        with patch("subprocess.run", side_effect=run_side_effect):
+            with pytest.raises(RuntimeError, match="git command failed"):
+                prepare.prepare(
+                    repo="org/repo",
+                    issue=2,
+                    base_branch="develop",
+                    branch_name="pbi-2",
+                )
+
+    def test_returns_existing_worktree_without_git_call(self, tmp_path) -> None:
+        from azure_issue_bridge.worktree import RealWorktreePrepare
+
+        worktree_path = tmp_path / ".claire" / "worktrees" / "issue-5"
+        worktree_path.mkdir(parents=True)
+
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+
+        with patch("subprocess.run") as mock_run:
+            result = prepare.prepare(
+                repo="org/repo",
+                issue=5,
+                base_branch="develop",
+                branch_name="pbi-5",
+            )
+        # Existing worktree: no subprocess calls
+        mock_run.assert_not_called()
+        assert result == str(worktree_path)
+
+    def test_successful_prepare_returns_worktree_path(self, tmp_path) -> None:
+        from azure_issue_bridge.worktree import RealWorktreePrepare
+
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+        expected_path = tmp_path / ".claire" / "worktrees" / "issue-7"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")):
+            result = prepare.prepare(
+                repo="org/repo",
+                issue=7,
+                base_branch="develop",
+                branch_name="pbi-7",
+            )
+        assert result == str(expected_path)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration: process_emails calls worktree then assign
+# ---------------------------------------------------------------------------
+
+
+def _make_email(subject: str, message_id: str = "msg-001") -> MagicMock:
+    email = MagicMock()
+    email.subject = subject
+    email.message_id = message_id
+    return email
+
+
+def _metadata_task_to_do(pbi_id: str) -> dict:
+    return {pbi_id: {"type": "Task", "parent_id": None, "state": "To Do"}}
+
+
+def _make_work_item(item_id: int, title: str) -> MagicMock:
+    return MagicMock(
+        id=item_id,
+        title=title,
+        description="",
+        acceptance_criteria="",
+        tags=[],
+        area_path="",
+        state="To Do",
+        assigned_to="",
+        parent_id=None,
+        work_item_type="Task",
+    )
+
+
+class TestPipelineWorktreeIntegration:
+    """process_emails must call prepare_worktree before assign_github_issue."""
+
+    def test_worktree_called_before_assign(self) -> None:
+        from azure_issue_bridge.bridge import BridgeConfig, GitHubIssue, process_emails
+
+        mock_wt = MockWorktreePrepare()
+        email = _make_email("Task 42 - DEV - some task")
+        config = BridgeConfig(
+            agent="claire-test-ai",
+            client="fivepoints",
+            source_repo="org/source",
+            target_repo="org/target",
+            sync_branch="develop",
+        )
+
+        call_order: list[str] = []
+
+        def mock_prepare(*args, **kwargs):
+            call_order.append("prepare")
+            return "/mock/worktrees/pbi-42"
+
+        def mock_assign(*args, **kwargs):
+            call_order.append("assign")
+
+        mock_wt.prepare = mock_prepare
+
+        with ExitStack() as stack:
+            # list_unread_replies is imported locally inside process_emails
+            stack.enter_context(patch(
+                "claire_py.email.watcher.list_unread_replies",
+                return_value=[email],
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.fetch_work_item_metadata",
+                return_value=_metadata_task_to_do("42"),
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.fetch_work_item",
+                return_value=_make_work_item(42, "Some Task"),
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.create_github_issue",
+                return_value=GitHubIssue(
+                    url="https://github.com/org/target/issues/42", number=42
+                ),
+            ))
+            stack.enter_context(patch("azure_issue_bridge.bridge.add_issue_label"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.sync_github_branch"))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.assign_github_issue",
+                side_effect=mock_assign,
+            ))
+            stack.enter_context(patch("azure_issue_bridge.bridge.save_processed_id"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.archive_email"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.save_state"))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.load_processed_ids", return_value=set()
+            ))
+            process_emails(config=config, worktree_prepare=mock_wt)
+
+        assert call_order == ["prepare", "assign"], (
+            "Expected prepare before assign, got: {}".format(call_order)
+        )
+
+    def test_pipeline_aborts_when_prepare_raises(self) -> None:
+        from azure_issue_bridge.bridge import BridgeConfig, GitHubIssue, process_emails
+
+        mock_wt = MockWorktreePrepare()
+        mock_wt.prepare = MagicMock(side_effect=RuntimeError("git worktree add failed"))
+
+        email = _make_email("Task 55 - DEV - failing task")
+        config = BridgeConfig(
+            agent="claire-test-ai",
+            client="fivepoints",
+            source_repo="org/source",
+            target_repo="org/target",
+            sync_branch="develop",
+        )
+
+        with ExitStack() as stack:
+            # list_unread_replies is imported locally inside process_emails
+            stack.enter_context(patch(
+                "claire_py.email.watcher.list_unread_replies",
+                return_value=[email],
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.fetch_work_item_metadata",
+                return_value=_metadata_task_to_do("55"),
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.fetch_work_item",
+                return_value=_make_work_item(55, "Failing Task"),
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.create_github_issue",
+                return_value=GitHubIssue(
+                    url="https://github.com/org/target/issues/55", number=55
+                ),
+            ))
+            stack.enter_context(patch("azure_issue_bridge.bridge.add_issue_label"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.sync_github_branch"))
+            mock_assign = stack.enter_context(
+                patch("azure_issue_bridge.bridge.assign_github_issue")
+            )
+            stack.enter_context(patch("azure_issue_bridge.bridge.save_processed_id"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.archive_email"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.save_state"))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.load_processed_ids", return_value=set()
+            ))
+            results = process_emails(config=config, worktree_prepare=mock_wt)
+
+        # assign must NOT be called when prepare raises
+        mock_assign.assert_not_called()
+        # The result should record the error
+        assert len(results) == 1
+        assert results[0].error is not None
+        assert "git worktree add failed" in results[0].error
+
+    def test_branch_name_uses_issue_number(self) -> None:
+        from azure_issue_bridge.bridge import BridgeConfig, GitHubIssue, process_emails
+
+        mock_wt = MockWorktreePrepare()
+        email = _make_email("Task 77 - DEV - branch name test")
+        config = BridgeConfig(
+            agent="claire-test-ai",
+            client="fivepoints",
+            source_repo="org/source",
+            target_repo="org/target",
+            sync_branch="develop",
+        )
+
+        with ExitStack() as stack:
+            # list_unread_replies is imported locally inside process_emails
+            stack.enter_context(patch(
+                "claire_py.email.watcher.list_unread_replies",
+                return_value=[email],
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.fetch_work_item_metadata",
+                return_value=_metadata_task_to_do("77"),
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.fetch_work_item",
+                return_value=_make_work_item(77, "Branch Name Task"),
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.create_github_issue",
+                return_value=GitHubIssue(
+                    url="https://github.com/org/target/issues/77", number=77
+                ),
+            ))
+            stack.enter_context(patch("azure_issue_bridge.bridge.add_issue_label"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.sync_github_branch"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.assign_github_issue"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.save_processed_id"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.archive_email"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.save_state"))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.load_processed_ids", return_value=set()
+            ))
+            process_emails(config=config, worktree_prepare=mock_wt)
+
+        assert len(mock_wt.prepared) == 1
+        assert mock_wt.prepared[0]["branch"] == "pbi-77"
+        assert mock_wt.prepared[0]["issue"] == 77
+        assert mock_wt.prepared[0]["base_branch"] == "develop"
+        assert mock_wt.prepared[0]["repo"] == "org/target"
+
+    def test_label_uses_client_config(self) -> None:
+        from azure_issue_bridge.bridge import BridgeConfig, GitHubIssue, process_emails
+
+        mock_wt = MockWorktreePrepare()
+        email = _make_email("Task 88 - DEV - label test")
+        config = BridgeConfig(
+            agent="claire-test-ai",
+            client="myapp",
+            source_repo="org/source",
+            target_repo="org/target",
+            sync_branch="develop",
+        )
+
+        with ExitStack() as stack:
+            # list_unread_replies is imported locally inside process_emails
+            stack.enter_context(patch(
+                "claire_py.email.watcher.list_unread_replies",
+                return_value=[email],
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.fetch_work_item_metadata",
+                return_value=_metadata_task_to_do("88"),
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.find_existing_github_issue",
+                return_value=None,
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.fetch_work_item",
+                return_value=_make_work_item(88, "Label Test"),
+            ))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.create_github_issue",
+                return_value=GitHubIssue(
+                    url="https://github.com/org/target/issues/88", number=88
+                ),
+            ))
+            mock_add_label = stack.enter_context(
+                patch("azure_issue_bridge.bridge.add_issue_label")
+            )
+            stack.enter_context(patch("azure_issue_bridge.bridge.sync_github_branch"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.assign_github_issue"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.save_processed_id"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.archive_email"))
+            stack.enter_context(patch("azure_issue_bridge.bridge.save_state"))
+            stack.enter_context(patch(
+                "azure_issue_bridge.bridge.load_processed_ids", return_value=set()
+            ))
+            process_emails(config=config, worktree_prepare=mock_wt)
+
+        mock_add_label.assert_called_once_with("org/target", 88, "role:myapp-dev")

--- a/domain/scripts/azure_issue_bridge/worktree.py
+++ b/domain/scripts/azure_issue_bridge/worktree.py
@@ -1,0 +1,176 @@
+"""
+azure_issue_bridge.worktree — WorktreePrepare adapter: Protocol + real/mock implementations.
+
+Responsible for creating a git worktree for a GitHub issue on a named branch
+before the issue is assigned to the agent.  The worktree is created in the
+standard path (<local_path>/.claire/worktrees/issue-<N>) so that claire start
+--issue N --repo R reuses it without re-creating (idempotent hand-off).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class WorktreePrepareAdapter(Protocol):
+    """Protocol for creating a git worktree before issue assignment."""
+
+    def prepare(
+        self,
+        repo: str,
+        issue: int,
+        base_branch: str,
+        branch_name: str,
+    ) -> str:
+        """Create a worktree on base_branch with a new branch branch_name.
+
+        Args:
+            repo:        GitHub repo slug, e.g. "CLAIRE-Fivepoints/fivepoints".
+            issue:       GitHub issue number.
+            base_branch: Branch to base the new branch on, e.g. "develop".
+            branch_name: Name of the new branch, e.g. "pbi-42".
+
+        Returns:
+            Absolute filesystem path to the created (or already-existing) worktree.
+
+        Raises:
+            RuntimeError: When the worktree cannot be created.
+        """
+        ...
+
+
+class RealWorktreePrepare:
+    """Creates a git worktree under <local_path>/.claire/worktrees/issue-<N>.
+
+    The local_path is resolved from ~/.config/claire/github_repos.yaml.  If not
+    found there, falls back to ~/.claire/repos/<owner>/<name> (auto-clone cache).
+    """
+
+    def __init__(self, local_path: str | Path | None = None) -> None:
+        self._local_path = str(local_path) if local_path is not None else None
+
+    def prepare(
+        self,
+        repo: str,
+        issue: int,
+        base_branch: str,
+        branch_name: str,
+    ) -> str:
+        local_path = Path(self._local_path or self._resolve_local_path(repo))
+        worktree_path = local_path / ".claire" / "worktrees" / f"issue-{issue}"
+
+        if worktree_path.exists():
+            logger.info(
+                "Worktree already exists at %s — reusing", worktree_path
+            )
+            return str(worktree_path)
+
+        logger.info(
+            "Fetching %s from origin to get latest %s", repo, base_branch
+        )
+        self._run(
+            ["git", "-C", str(local_path), "fetch", "origin", base_branch],
+            repo=repo,
+        )
+
+        logger.info(
+            "Creating worktree %s on branch %s (from origin/%s)",
+            worktree_path,
+            branch_name,
+            base_branch,
+        )
+        self._run(
+            [
+                "git",
+                "-C",
+                str(local_path),
+                "worktree",
+                "add",
+                "--track",
+                "-b",
+                branch_name,
+                str(worktree_path),
+                f"origin/{base_branch}",
+            ],
+            repo=repo,
+        )
+
+        logger.info("Worktree created at %s (branch: %s)", worktree_path, branch_name)
+        return str(worktree_path)
+
+    @staticmethod
+    def _run(cmd: list[str], *, repo: str) -> None:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"git command failed for {repo!r}: {' '.join(cmd)}\n"
+                f"stderr: {result.stderr.strip()}"
+            )
+
+    @staticmethod
+    def _resolve_local_path(repo: str) -> str:
+        """Resolve the local checkout path for repo from config or auto-clone cache."""
+        try:
+            import yaml  # type: ignore[import-untyped]
+
+            config = Path("~/.config/claire/github_repos.yaml").expanduser()
+            if config.exists():
+                with open(config) as f:
+                    data = yaml.safe_load(f)
+                for entry in (data or {}).get("repos", []):
+                    slug = f"{entry.get('owner', '')}/{entry.get('name', '')}"
+                    if slug == repo:
+                        lp = entry.get("local_path")
+                        if lp:
+                            return str(Path(lp).expanduser())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not read github_repos.yaml: %s", exc)
+
+        owner, name = repo.split("/", 1)
+        cache = Path("~/.claire/repos").expanduser() / owner / name
+        if cache.exists():
+            return str(cache)
+
+        raise RuntimeError(
+            f"Cannot resolve local path for repo {repo!r}. "
+            "Add a local_path entry in ~/.config/claire/github_repos.yaml "
+            "or ensure the auto-clone cache exists at ~/.claire/repos/<owner>/<name>."
+        )
+
+
+class MockWorktreePrepare:
+    """Test double for WorktreePrepareAdapter.
+
+    Records every prepare() call in self.prepared for assertion in tests.
+    Never touches the filesystem.
+    """
+
+    def __init__(self) -> None:
+        self.prepared: list[dict] = []
+
+    def prepare(
+        self,
+        repo: str,
+        issue: int,
+        base_branch: str,
+        branch_name: str,
+    ) -> str:
+        entry = {
+            "repo": repo,
+            "issue": issue,
+            "base_branch": base_branch,
+            "branch": branch_name,
+        }
+        self.prepared.append(entry)
+        logger.debug("MockWorktreePrepare.prepare called: %s", entry)
+        return f"/mock/worktrees/{branch_name}"


### PR DESCRIPTION
## Summary

- Adds `worktree.py` with `WorktreePrepareAdapter` protocol, `RealWorktreePrepare` (idempotent `git worktree add` to `.claire/worktrees/issue-N`), and `MockWorktreePrepare` for tests
- Extends `BridgeConfig` with `agent`, `client`, `source_repo`, `target_repo`, `sync_branch` fields (env-var-overridable)
- Adds `GitHubIssue` dataclass so downstream steps can access the issue number
- Pipeline order: `create_github_issue` → `add_issue_label` → `sync_github_branch` → `prepare_worktree` → `assign_github_issue` (always last)
- If `prepare_worktree()` raises, pipeline aborts — assignment is never called

## Verification Log

```
$ python3 -m pytest domain/scripts/azure_issue_bridge/tests/ -v
============================= test session starts ==============================
...
89 passed in 0.62s
```

All 89 tests pass, including 13 new tests in `test_worktree_prepare.py` covering:
- `MockWorktreePrepare.prepared` records every call (AC4)
- `RealWorktreePrepare` raises on git failures
- Pipeline calls `prepare_worktree` before `assign_github_issue` (AC1)
- Pipeline aborts with no assignment when `prepare_worktree` raises (AC3)
- Branch name is derived from the issue number via config, not hard-coded (AC5)

## AC2 — Session-monitor reuse

`RealWorktreePrepare` creates the worktree at `.claire/worktrees/issue-{N}`, which is the standard path that `claire start --issue N --repo R` uses. Since `claire start` is idempotent (reuses an existing worktree), the session-monitor will find the path already present and launch from it — no double spawn.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQvf9wmruD3H3Tx79kiPdU