### PR TITLE
feat(bridge): add inject subcommand for e2e testing without PBI_TEST_SENDER

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -3,7 +3,7 @@ domain: fivepoints
 category: operational
 name: AZURE_ISSUE_BRIDGE
 title: "Five Points — Azure DevOps Email Bridge (PBI Assignment → GitHub Issue Pipeline)"
-keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_TEST_SENDER, PBI_SENDER, test-sender, configurable-sender, branch-sync, ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH, ADO_BRIDGE_AGENT, ADO_BRIDGE_CLIENT, worktree, role-label]
+keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_SENDER, configurable-sender, branch-sync, inject, synthetic-email, ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH, ADO_BRIDGE_AGENT, ADO_BRIDGE_CLIENT, worktree, role-label]
 updated: 2026-06-28
 ---
 
@@ -140,6 +140,17 @@ claire fivepoints azure-issue-bridge start --lookback 30d  # Daemon: limit each 
 claire fivepoints azure-issue-bridge stop              # Stop background daemon
 claire fivepoints azure-issue-bridge status            # Show daemon state + last run stats
 claire fivepoints azure-issue-bridge restore-inbox     # Restore archived ADO emails to inbox + reset processed.json
+
+# inject — synthetic email injection (no Gmail or ADO auth required)
+claire fivepoints azure-issue-bridge inject \
+  --from "azuredevops@microsoft.com" \
+  --subject "Product Backlog Item 12345 - DEV - Client Management test" \
+  --dry-run   # Print parsed result, create nothing
+
+claire fivepoints azure-issue-bridge inject \
+  --from "azuredevops@microsoft.com" \
+  --subject "Product Backlog Item 12345 - DEV - Client Management test"
+  # Creates issue in fivepoints-test (default)
 ```
 
 > **Backward compat:** `claire azure-issue-bridge <cmd>` delegates to `claire fivepoints azure-issue-bridge <cmd>` via the bridge shim in claire core.
@@ -168,6 +179,43 @@ The daemon only polls during business hours — polls outside the window are ski
 | `ADO_BRIDGE_HOUR_END` | `17` | End hour (0–23, local time, exclusive) |
 
 Example: to restrict to 9AM–6PM, set `ADO_BRIDGE_HOUR_START=9` and `ADO_BRIDGE_HOUR_END=18`.
+
+### inject — synthetic email injection
+
+`claire fivepoints azure-issue-bridge inject` feeds a synthetic email directly into the bridge pipeline without polling Gmail or calling the ADO REST API. It is designed for e2e testing: no `AZURE_DEVOPS_PAT` required, no Gmail auth required.
+
+The command:
+1. Constructs an `EmailMessage` from `--from` and `--subject`
+2. Validates it with `is_pbi_email()` (subject must match the ADO PBI pattern)
+3. Builds a synthetic `WorkItem` from the parsed subject (no ADO fetch — subject data only)
+4. In live mode: calls `gh issue create` in the target repo (GitHub auth still required)
+5. In `--dry-run` mode: prints the parsed PBI and issue body preview, creates nothing
+
+```bash
+# Dry-run — print parsed PBI + issue body, create nothing
+claire fivepoints azure-issue-bridge inject \
+  --from "azuredevops@microsoft.com" \
+  --subject "Product Backlog Item 12345 - DEV - Client Management test" \
+  --dry-run
+
+# Live — create issue in fivepoints-test (default staging repo)
+claire fivepoints azure-issue-bridge inject \
+  --from "azuredevops@microsoft.com" \
+  --subject "Product Backlog Item 12345 - DEV - Client Management test"
+
+# Target a specific repo
+claire fivepoints azure-issue-bridge inject \
+  --from "azuredevops@microsoft.com" \
+  --subject "Product Backlog Item 12345 - DEV - Client Management test" \
+  --repo CLAIRE-Fivepoints/fivepoints
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--from ADDRESS` | _(required)_ | Sender address (e.g. `azuredevops@microsoft.com`) |
+| `--subject SUBJECT` | _(required)_ | Email subject matching the ADO PBI pattern |
+| `--dry-run` | false | Print parsed result without creating any GitHub issue |
+| `--repo OWNER/NAME` | `ADO_BRIDGE_REPO` or `claire-labs/fivepoints-test` | Target GitHub repo override |
 
 ### Auto-start via infra
 
@@ -225,7 +273,6 @@ The azure-issue-bridge uses `AZURE_DEVOPS_PAT`. The fivepoints plugin (`ado_comm
 | `ADO_PROJECT` | `TFIOne` | Azure DevOps project |
 | `ADO_BRIDGE_HOUR_START` | `8` | Business hours start (local time, inclusive) |
 | `ADO_BRIDGE_HOUR_END` | `17` | Business hours end (local time, exclusive) |
-| `PBI_TEST_SENDER` | _(unset)_ | Override accepted email sender for testing (e.g. `andreoperez@gmail.com`). Takes priority over `PBI_SENDER`. Emails from this address with the standard ADO subject format are processed identically to real ADO emails. |
 | `PBI_SENDER` | `azuredevops@microsoft.com` | Override the production ADO sender. Use when ADO notifications come from a custom address. Falls back to the ADO default when unset. |
 | `ADO_BRIDGE_AGENT` | `claire-test-ai` | GitHub username assigned to each new issue. **Set this explicitly in production** — the default targets the test account. |
 | `ADO_BRIDGE_CLIENT` | `fivepoints` | Client slug used to build the role label: `role:{ADO_BRIDGE_CLIENT}-dev`. Determines which agent persona is activated by the spawn daemon. |

--- a/domain/scripts/azure_issue_bridge/bridge.py
+++ b/domain/scripts/azure_issue_bridge/bridge.py
@@ -175,16 +175,14 @@ def load_bridge_config() -> BridgeConfig:
     """Load bridge configuration from environment variables or ~/.config/claire/.env.
 
     Priority:
-      1. PBI_TEST_SENDER  — test override (e.g. andreoperez@gmail.com)
-      2. PBI_SENDER       — custom production sender
-      3. azuredevops@microsoft.com — ADO default
+      1. PBI_SENDER       — custom production sender
+      2. azuredevops@microsoft.com — ADO default
 
     Sync vars (ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH)
     fall back to CLAIRE-Fivepoints/fivepoints-test → CLAIRE-Fivepoints/fivepoints / develop.
     """
     pbi_sender = (
-        _get_env_or_file("PBI_TEST_SENDER")
-        or _get_env_or_file("PBI_SENDER")
+        _get_env_or_file("PBI_SENDER")
         or _ADO_SENDER
     )
     agent = _get_env_or_file("ADO_BRIDGE_AGENT") or _DEFAULT_BRIDGE_AGENT
@@ -233,6 +231,25 @@ def parse_pbi_id(subject: str) -> str | None:
     """
     m = _PBI_SUBJECT_RE.search(subject)
     return m.group(1) if m else None
+
+
+def parse_subject_parts(subject: str) -> tuple[str, str]:
+    """Extract (area, title) from an ADO assignment email subject.
+
+    For "Product Backlog Item 12345 - DEV - Client Management test"
+    returns ("DEV", "Client Management test").
+
+    Returns ("", "") if the subject cannot be parsed beyond the ID.
+    """
+    m = _PBI_SUBJECT_RE.search(subject)
+    if not m:
+        return "", ""
+    # Split the remainder by " - " without pre-stripping to preserve empty leading token.
+    rest = subject[m.end():]
+    parts = [p.strip() for p in rest.split(" - ") if p.strip()]
+    area = parts[0] if parts else ""
+    title = " - ".join(parts[1:]) if len(parts) > 1 else ""
+    return area, title
 
 
 # ---------------------------------------------------------------------------

--- a/domain/scripts/azure_issue_bridge/cli.py
+++ b/domain/scripts/azure_issue_bridge/cli.py
@@ -4,6 +4,7 @@ azure_issue_bridge.cli — Command-line interface.
 Subcommands:
   run     One-shot: scan inbox and process any pending ADO assignment emails
   start   Polling loop: run repeatedly on a configurable interval
+  inject  Feed a synthetic email directly into the bridge pipeline (no auth required)
   status  Show the last run state
 """
 
@@ -15,6 +16,7 @@ import logging
 import os
 import sys
 import time
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -192,6 +194,75 @@ def cmd_test(args: argparse.Namespace) -> int:
 
     failures = [r for r in results if not r.success and not r.skipped]
     return 1 if failures else 0
+
+
+def cmd_inject(args: argparse.Namespace) -> int:
+    """Feed a synthetic email into the bridge pipeline without Gmail or ADO auth."""
+    from azure_issue_bridge.bridge import (
+        WorkItem,
+        _DEFAULT_GH_REPO,
+        create_github_issue,
+        is_pbi_email,
+        parse_pbi_id,
+        parse_subject_parts,
+    )
+
+    msg = SimpleNamespace(subject=args.subject, message_id="inject")
+    if not is_pbi_email(msg):
+        print(f"✗ Subject does not match ADO PBI pattern: {args.subject!r}")
+        return 1
+
+    pbi_id = parse_pbi_id(args.subject)
+    if not pbi_id:
+        print("✗ Could not parse PBI ID from subject")
+        return 1
+
+    area, title = parse_subject_parts(args.subject)
+    if not title:
+        title = f"PBI {pbi_id}"
+
+    work_item = WorkItem(
+        id=int(pbi_id),
+        title=title,
+        description="",
+        acceptance_criteria="",
+        area_path=area,
+        state="To Do",
+        work_item_type="Task",
+    )
+
+    repo = args.repo or os.environ.get("ADO_BRIDGE_REPO", _DEFAULT_GH_REPO)
+
+    if args.dry_run:
+        ado_org = os.environ.get("ADO_ORG", "FivePointsTechnology")
+        ado_project = os.environ.get("ADO_PROJECT", "TFIOne")
+        ado_url = (
+            f"https://dev.azure.com/{ado_org}/{ado_project}"
+            f"/_workitems/edit/{pbi_id}"
+        )
+        print(f"[dry-run] Parsed PBI #{pbi_id}")
+        print(f"  from:    {args.from_addr}")
+        print(f"  title:   {work_item.title} (PBI #{pbi_id})")
+        print(f"  area:    {work_item.area_path or '(none)'}")
+        print(f"  repo:    {repo}")
+        print()
+        print("[dry-run] Issue body preview:")
+        print(f"  **Azure DevOps:** {ado_url}")
+        print(f"  **State:** {work_item.state}")
+        print(f"  **Area:** {work_item.area_path}")
+        print(f"  **Type:** {work_item.work_item_type}")
+        return 0
+
+    os.environ["ADO_BRIDGE_REPO"] = repo
+    try:
+        issue_url = create_github_issue(work_item)
+    except RuntimeError as exc:
+        print(f"✗ {exc}")
+        return 1
+
+    print(f"✓ PBI #{pbi_id}: {work_item.title}")
+    print(f"  → {issue_url}")
+    return 0
 
 
 def cmd_restore_inbox(_args: argparse.Namespace) -> int:
@@ -394,6 +465,36 @@ def build_parser() -> argparse.ArgumentParser:
         help="Format only, do NOT spawn analyst session",
     )
 
+    # inject
+    inject_p = sub.add_parser(
+        "inject",
+        help="Feed a synthetic email into the bridge pipeline (no Gmail or ADO auth required)",
+    )
+    inject_p.add_argument(
+        "--from",
+        dest="from_addr",
+        required=True,
+        metavar="ADDRESS",
+        help="Sender address (e.g. azuredevops@microsoft.com)",
+    )
+    inject_p.add_argument(
+        "--subject",
+        required=True,
+        metavar="SUBJECT",
+        help="Email subject matching the ADO PBI pattern",
+    )
+    inject_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print parsed result without creating any GitHub issue",
+    )
+    inject_p.add_argument(
+        "--repo",
+        default=None,
+        metavar="OWNER/NAME",
+        help="Target GitHub repo (default: ADO_BRIDGE_REPO env or claire-labs/fivepoints-test)",
+    )
+
     # restore-inbox
     sub.add_parser(
         "restore-inbox",
@@ -423,6 +524,7 @@ def main() -> None:
         "run": cmd_run,
         "start": cmd_start,
         "test": cmd_test,
+        "inject": cmd_inject,
         "restore-inbox": cmd_restore_inbox,
         "status": cmd_status,
     }
@@ -463,6 +565,29 @@ notifications arrive for the same PBI.
   Runs in foreground, polling inbox every N minutes (default: 15).
   Use for always-on daemon. Pair with a process manager or cron.
 
+### inject — synthetic email injection (no Gmail or ADO auth required)
+  claire azure-issue-bridge inject --from ADDRESS --subject SUBJECT [--dry-run] [--repo OWNER/NAME]
+
+  Feeds a synthetic email directly into the bridge pipeline without polling Gmail
+  or calling the ADO REST API. Use for e2e testing without AZURE_DEVOPS_PAT.
+
+  --from ADDRESS      Sender address (e.g. azuredevops@microsoft.com)
+  --subject SUBJECT   Email subject matching the ADO PBI pattern
+  --dry-run           Print parsed result without creating any GitHub issue
+  --repo OWNER/NAME   Target repo override (default: ADO_BRIDGE_REPO or fivepoints-test)
+
+  Examples:
+    # Dry-run — parse subject, print what would be created
+    claire azure-issue-bridge inject \\
+      --from "azuredevops@microsoft.com" \\
+      --subject "Product Backlog Item 12345 - DEV - Client Management test" \\
+      --dry-run
+
+    # Live — create issue in fivepoints-test (default)
+    claire azure-issue-bridge inject \\
+      --from "azuredevops@microsoft.com" \\
+      --subject "Product Backlog Item 12345 - DEV - Client Management test"
+
 ### restore-inbox — restore archived ADO emails for re-processing
   claire azure-issue-bridge restore-inbox
 
@@ -477,7 +602,7 @@ notifications arrive for the same PBI.
   and processed email registry location.
 
 ## Email Filter
-- Sender: azuredevops@microsoft.com (default) — overridable via PBI_TEST_SENDER or PBI_SENDER
+- Sender: azuredevops@microsoft.com (default) — overridable via PBI_SENDER
 - Subject: must match "Product Backlog Item {ID}" or similar ADO work item patterns
 
 ## Pipeline
@@ -513,6 +638,7 @@ Output symbols:
 ## Required Credentials
   AZURE_DEVOPS_PAT    — ADO REST API auth (read from env or ~/.config/claire/.env)
   Gmail OAuth2        — configured via: claire email auth
+  (inject subcommand requires neither — no Gmail or ADO auth needed)
 
 ## State Files
   ~/.claire/azure-issue-bridge/state.json     — last run metadata
@@ -536,9 +662,6 @@ Output symbols:
   ADO_PROJECT         Azure DevOps project (default: TFIOne)
   ADO_BRIDGE_REPO     Target GitHub repo (default: claire-labs/fivepoints-test)
                       Set to claire-labs/fivepoints to go live
-  PBI_TEST_SENDER     Override accepted email sender for testing (e.g. andreoperez@gmail.com)
-                      Takes priority over PBI_SENDER. Emails from this address with the
-                      standard ADO subject format are processed identically to ADO emails.
   PBI_SENDER          Override the production ADO sender (default: azuredevops@microsoft.com)
 """
 

--- a/domain/scripts/azure_issue_bridge/tests/test_email_filter.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_email_filter.py
@@ -5,7 +5,7 @@ Tests cover:
 - is_pbi_email() returns True for PBI subjects regardless of sender value
 - is_pbi_email() returns False for non-PBI subjects
 - MockEmailFilter binds a sender and exposes is_pbi_email as an instance method
-- load_bridge_config() resolves pbi_sender from PBI_TEST_SENDER > PBI_SENDER > default
+- load_bridge_config() resolves pbi_sender from PBI_SENDER > default
 """
 
 from __future__ import annotations
@@ -112,39 +112,13 @@ class TestBridgeConfig:
     """Tests for BridgeConfig and load_bridge_config()."""
 
     def test_default_sender_is_ado(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("PBI_TEST_SENDER", raising=False)
         monkeypatch.delenv("PBI_SENDER", raising=False)
         config = load_bridge_config()
         assert config.pbi_sender == "azuredevops@microsoft.com"
 
-    def test_pbi_test_sender_env_overrides_default(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("PBI_TEST_SENDER", "andreoperez@gmail.com")
-        monkeypatch.delenv("PBI_SENDER", raising=False)
-        config = load_bridge_config()
-        assert config.pbi_sender == "andreoperez@gmail.com"
-
     def test_pbi_sender_env_overrides_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv("PBI_TEST_SENDER", raising=False)
-        monkeypatch.setenv("PBI_SENDER", "custom@example.com")
-        config = load_bridge_config()
-        assert config.pbi_sender == "custom@example.com"
-
-    def test_pbi_test_sender_takes_priority_over_pbi_sender(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("PBI_TEST_SENDER", "andreoperez@gmail.com")
-        monkeypatch.setenv("PBI_SENDER", "custom@example.com")
-        config = load_bridge_config()
-        assert config.pbi_sender == "andreoperez@gmail.com"
-
-    def test_empty_pbi_test_sender_falls_through_to_pbi_sender(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("PBI_TEST_SENDER", "")
         monkeypatch.setenv("PBI_SENDER", "custom@example.com")
         config = load_bridge_config()
         assert config.pbi_sender == "custom@example.com"

--- a/domain/scripts/azure_issue_bridge/tests/test_inject.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_inject.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for azure_issue_bridge inject subcommand and parse_subject_parts helper.
+
+Tests cover:
+- parse_subject_parts() extracts (area, title) from ADO subject formats
+- cmd_inject dry-run: prints parsed result, no gh calls
+- cmd_inject live mode: calls create_github_issue with synthetic WorkItem
+- cmd_inject rejects non-PBI subjects
+- cmd_inject --repo override sets target repo
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azure_issue_bridge.bridge import parse_subject_parts
+from azure_issue_bridge.cli import cmd_inject
+
+
+# ---------------------------------------------------------------------------
+# parse_subject_parts
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubjectParts:
+    def test_standard_pbi_format(self) -> None:
+        area, title = parse_subject_parts(
+            "Product Backlog Item 12345 - DEV - Client Management test"
+        )
+        assert area == "DEV"
+        assert title == "Client Management test"
+
+    def test_task_format(self) -> None:
+        area, title = parse_subject_parts(
+            "Task 13644 - DEV - implement feature X"
+        )
+        assert area == "DEV"
+        assert title == "implement feature X"
+
+    def test_title_with_dashes(self) -> None:
+        area, title = parse_subject_parts(
+            "Product Backlog Item 999 - QA - Fix bug - edge case"
+        )
+        assert area == "QA"
+        assert title == "Fix bug - edge case"
+
+    def test_no_area_no_title(self) -> None:
+        area, title = parse_subject_parts("Product Backlog Item 42")
+        assert area == ""
+        assert title == ""
+
+    def test_non_pbi_subject_returns_empty(self) -> None:
+        area, title = parse_subject_parts("Hello from someone")
+        assert area == ""
+        assert title == ""
+
+
+# ---------------------------------------------------------------------------
+# cmd_inject
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    defaults = {
+        "from_addr": "azuredevops@microsoft.com",
+        "subject": "Product Backlog Item 12345 - DEV - Client Management test",
+        "dry_run": False,
+        "repo": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestCmdInjectDryRun:
+    def test_dry_run_prints_parsed_pbi(self, capsys: pytest.CaptureFixture) -> None:
+        args = _make_args(dry_run=True)
+        rc = cmd_inject(args)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[dry-run]" in out
+        assert "12345" in out
+        assert "Client Management test" in out
+        assert "DEV" in out
+
+    def test_dry_run_no_gh_calls(self) -> None:
+        args = _make_args(dry_run=True)
+        with patch("azure_issue_bridge.bridge.subprocess.run") as mock_run:
+            cmd_inject(args)
+            mock_run.assert_not_called()
+
+    def test_dry_run_shows_repo_override(self, capsys: pytest.CaptureFixture) -> None:
+        args = _make_args(dry_run=True, repo="CLAIRE-Fivepoints/fivepoints-test")
+        cmd_inject(args)
+        out = capsys.readouterr().out
+        assert "CLAIRE-Fivepoints/fivepoints-test" in out
+
+
+class TestCmdInjectLive:
+    def test_live_calls_create_github_issue(self) -> None:
+        args = _make_args()
+        with patch(
+            "azure_issue_bridge.bridge.create_github_issue",
+            return_value="https://github.com/org/repo/issues/99",
+        ) as mock_create:
+            rc = cmd_inject(args)
+        assert rc == 0
+        mock_create.assert_called_once()
+        work_item = mock_create.call_args[0][0]
+        assert work_item.id == 12345
+        assert work_item.title == "Client Management test"
+        assert work_item.area_path == "DEV"
+        assert work_item.state == "To Do"
+        assert work_item.work_item_type == "Task"
+
+    def test_live_prints_issue_url(self, capsys: pytest.CaptureFixture) -> None:
+        args = _make_args()
+        with patch(
+            "azure_issue_bridge.bridge.create_github_issue",
+            return_value="https://github.com/org/repo/issues/99",
+        ):
+            cmd_inject(args)
+        out = capsys.readouterr().out
+        assert "https://github.com/org/repo/issues/99" in out
+
+    def test_live_repo_override_sets_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        args = _make_args(repo="CLAIRE-Fivepoints/fivepoints-test")
+        captured_repo: list[str] = []
+
+        def fake_create(work_item):  # type: ignore[no-untyped-def]
+            import os
+            captured_repo.append(os.environ.get("ADO_BRIDGE_REPO", ""))
+            return "https://github.com/org/repo/issues/1"
+
+        with patch("azure_issue_bridge.bridge.create_github_issue", side_effect=fake_create):
+            cmd_inject(args)
+
+        assert captured_repo == ["CLAIRE-Fivepoints/fivepoints-test"]
+
+    def test_live_runtime_error_returns_nonzero(self, capsys: pytest.CaptureFixture) -> None:
+        args = _make_args()
+        with patch(
+            "azure_issue_bridge.bridge.create_github_issue",
+            side_effect=RuntimeError("gh issue create failed: permission denied"),
+        ):
+            rc = cmd_inject(args)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+
+
+class TestCmdInjectRejectsNonPBI:
+    def test_non_pbi_subject_returns_1(self, capsys: pytest.CaptureFixture) -> None:
+        args = _make_args(subject="Hello from someone", dry_run=True)
+        rc = cmd_inject(args)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+
+    def test_empty_subject_returns_1(self, capsys: pytest.CaptureFixture) -> None:
+        args = _make_args(subject="", dry_run=True)
+        rc = cmd_inject(args)
+        assert rc == 1


### PR DESCRIPTION
Closes #153

## Summary

- Adds `inject` subcommand to the azure-issue-bridge CLI: constructs a synthetic `EmailMessage` from `--from`/`--subject`, validates via `is_pbi_email()`, builds a `WorkItem` from subject data only (no ADO REST call), and creates the GitHub issue via `gh`. No Gmail auth or `AZURE_DEVOPS_PAT` required.
- Adds `parse_subject_parts()` helper in `bridge.py` to extract `(area, title)` from an ADO subject without an ADO API call.
- Removes `PBI_TEST_SENDER` from `load_bridge_config()` and all docs — superseded by `inject`.
- Adds 14 tests covering `parse_subject_parts()` and `cmd_inject()` (dry-run, live, --repo override, runtime error, non-PBI rejection).
- Updates `AZURE_ISSUE_BRIDGE.md`: adds inject section, removes `PBI_TEST_SENDER` from env vars and keywords.

## Verification Log

```
$ python3 -m pytest domain/scripts/azure_issue_bridge/tests/ -q
109 passed in 0.10s

$ PYTHONPATH=domain/scripts python3 -m azure_issue_bridge.cli inject \
    --from "azuredevops@microsoft.com" \
    --subject "Product Backlog Item 12345 - DEV - Client Management test" \
    --dry-run
[dry-run] Parsed PBI #12345
  from:    azuredevops@microsoft.com
  title:   Client Management test (PBI #12345)
  area:    DEV
  repo:    claire-labs/fivepoints-test

[dry-run] Issue body preview:
  **Azure DevOps:** https://dev.azure.com/FivePointsTechnology/TFIOne/_workitems/edit/12345
  **State:** To Do
  **Area:** DEV
  **Type:** Task

$ PYTHONPATH=domain/scripts python3 -m azure_issue_bridge.cli inject \
    --from "azuredevops@microsoft.com" --subject "Non PBI email" --dry-run; echo "exit $?"
✗ Subject does not match ADO PBI pattern: 'Non PBI email'
exit 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2T7fWdRNzMh36XtHomfwC