### PR TITLE
feat(bridge): extend inject subcommand with full pipeline (label, sync, worktree, assign)

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -4,7 +4,7 @@ category: operational
 name: AZURE_ISSUE_BRIDGE
 title: "Five Points — Azure DevOps Email Bridge (PBI Assignment → GitHub Issue Pipeline)"
 keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_SENDER, configurable-sender, branch-sync, inject, synthetic-email, ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH, ADO_BRIDGE_AGENT, ADO_BRIDGE_CLIENT, worktree, role-label]
-updated: 2026-06-28
+updated: 2026-06-29
 ---
 
 # Azure DevOps Email Bridge
@@ -188,8 +188,8 @@ The command:
 1. Constructs an `EmailMessage` from `--from` and `--subject`
 2. Validates it with `is_pbi_email()` (subject must match the ADO PBI pattern)
 3. Builds a synthetic `WorkItem` from the parsed subject (no ADO fetch — subject data only)
-4. In live mode: calls `gh issue create` in the target repo (GitHub auth still required)
-5. In `--dry-run` mode: prints the parsed PBI and issue body preview, creates nothing
+4. In live mode: runs the full pipeline — `create_issue → add_label → sync_branch → prepare_worktree → assign` (GitHub auth required, no Gmail or ADO auth)
+5. In `--dry-run` mode: prints the parsed PBI and the planned pipeline steps, creates nothing
 
 ```bash
 # Dry-run — print parsed PBI + issue body, create nothing
@@ -214,8 +214,9 @@ claire fivepoints azure-issue-bridge inject \
 |------|---------|-------------|
 | `--from ADDRESS` | _(required)_ | Sender address (e.g. `azuredevops@microsoft.com`) |
 | `--subject SUBJECT` | _(required)_ | Email subject matching the ADO PBI pattern |
-| `--dry-run` | false | Print parsed result without creating any GitHub issue |
-| `--repo OWNER/NAME` | `ADO_BRIDGE_REPO` or `claire-labs/fivepoints-test` | Target GitHub repo override |
+| `--dry-run` | false | Print parsed result + pipeline plan without creating anything |
+| `--repo OWNER/NAME` | `ADO_BRIDGE_SYNC_TARGET` or `claire-labs/fivepoints-test` | Target GitHub repo override |
+| `--agent USERNAME` | `ADO_BRIDGE_AGENT` or `claire-test-ai` | GitHub assignee for the created issue |
 
 ### Auto-start via infra
 

--- a/domain/scripts/azure_issue_bridge/cli.py
+++ b/domain/scripts/azure_issue_bridge/cli.py
@@ -197,15 +197,25 @@ def cmd_test(args: argparse.Namespace) -> int:
 
 
 def cmd_inject(args: argparse.Namespace) -> int:
-    """Feed a synthetic email into the bridge pipeline without Gmail or ADO auth."""
+    """Feed a synthetic email into the bridge pipeline without Gmail or ADO auth.
+
+    Runs the full pipeline: create_issue → add_label → sync_branch →
+    prepare_worktree → assign. No cleanup is performed — use the displayed
+    commands to clean up manually.
+    """
     from azure_issue_bridge.bridge import (
         WorkItem,
         _DEFAULT_GH_REPO,
+        add_issue_label,
+        assign_github_issue,
         create_github_issue,
         is_pbi_email,
+        load_bridge_config,
         parse_pbi_id,
         parse_subject_parts,
     )
+    from azure_issue_bridge.sync import RealBranchSync
+    from azure_issue_bridge.worktree import RealWorktreePrepare
 
     msg = SimpleNamespace(subject=args.subject, message_id="inject")
     if not is_pbi_email(msg):
@@ -231,7 +241,11 @@ def cmd_inject(args: argparse.Namespace) -> int:
         work_item_type="Task",
     )
 
-    repo = args.repo or os.environ.get("ADO_BRIDGE_REPO", _DEFAULT_GH_REPO)
+    config = load_bridge_config()
+    repo = args.repo or config.target_repo
+    agent = getattr(args, "agent", None) or config.agent
+    label = f"role:{config.client}-dev"
+    sync_branch = config.sync_branch
 
     if args.dry_run:
         ado_org = os.environ.get("ADO_ORG", "FivePointsTechnology")
@@ -251,17 +265,71 @@ def cmd_inject(args: argparse.Namespace) -> int:
         print(f"  **State:** {work_item.state}")
         print(f"  **Area:** {work_item.area_path}")
         print(f"  **Type:** {work_item.work_item_type}")
+        print()
+        print("[dry-run] Pipeline steps:")
+        print(f"  1. create_issue   → {work_item.title} (PBI #{pbi_id}) in {repo}")
+        print(f"  2. add_label      → {label}")
+        print(
+            f"  3. sync_branch    → {config.source_repo}/{sync_branch} → {repo}/{sync_branch}"
+        )
+        print(f"  4. prepare_worktree → branch pbi-<N>")
+        print(f"  5. assign         → {agent}")
         return 0
 
     os.environ["ADO_BRIDGE_REPO"] = repo
     try:
-        issue_url = create_github_issue(work_item)
+        issue = create_github_issue(work_item)
     except RuntimeError as exc:
         print(f"✗ {exc}")
         return 1
 
-    print(f"✓ PBI #{pbi_id}: {work_item.title}")
-    print(f"  → {issue_url}")
+    try:
+        add_issue_label(repo, issue.number, label)
+    except RuntimeError as exc:
+        print(f"✗ add_label failed: {exc}")
+        return 1
+
+    branch_sync = RealBranchSync()
+    try:
+        branch_sync.sync_branch(config.source_repo, sync_branch, repo, sync_branch)
+    except RuntimeError as exc:
+        print(f"✗ sync_branch failed: {exc}")
+        return 1
+
+    branch_name = f"pbi-{issue.number}"
+    worktree_prepare = RealWorktreePrepare()
+    worktree_path = ""
+    try:
+        worktree_path = worktree_prepare.prepare(
+            repo=repo,
+            issue=issue.number,
+            base_branch=sync_branch,
+            branch_name=branch_name,
+        )
+    except RuntimeError as exc:
+        print(f"✗ prepare_worktree failed: {exc}")
+        return 1
+
+    try:
+        assign_github_issue(repo, issue.number, agent)
+    except RuntimeError as exc:
+        print(f"✗ assign failed: {exc}")
+        return 1
+
+    print(f"\n✓ Pipeline complet\n")
+    print(f"Issue créée   : {issue.url}")
+    print(f"Label         : {label}")
+    print(
+        f"Branch sync   : {config.source_repo}/{sync_branch} → {repo}/{sync_branch}"
+    )
+    print(f"Branch        : {branch_name}")
+    if worktree_path:
+        print(f"Worktree      : {worktree_path}")
+    print(f"Assigné à     : {agent}")
+    print(f"\nPour nettoyer :")
+    print(f"  gh issue close {issue.number} --repo {repo}")
+    if worktree_path:
+        print(f"  git worktree remove {worktree_path}")
     return 0
 
 
@@ -492,7 +560,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--repo",
         default=None,
         metavar="OWNER/NAME",
-        help="Target GitHub repo (default: ADO_BRIDGE_REPO env or claire-labs/fivepoints-test)",
+        help="Target GitHub repo (default: ADO_BRIDGE_SYNC_TARGET or claire-labs/fivepoints-test)",
+    )
+    inject_p.add_argument(
+        "--agent",
+        default=None,
+        metavar="USERNAME",
+        help="GitHub assignee (default: ADO_BRIDGE_AGENT or claire-test-ai)",
     )
 
     # restore-inbox
@@ -566,15 +640,20 @@ notifications arrive for the same PBI.
   Use for always-on daemon. Pair with a process manager or cron.
 
 ### inject — synthetic email injection (no Gmail or ADO auth required)
-  claire azure-issue-bridge inject --from ADDRESS --subject SUBJECT [--dry-run] [--repo OWNER/NAME]
+  claire azure-issue-bridge inject --from ADDRESS --subject SUBJECT [--dry-run] [--repo OWNER/NAME] [--agent USERNAME]
 
   Feeds a synthetic email directly into the bridge pipeline without polling Gmail
-  or calling the ADO REST API. Use for e2e testing without AZURE_DEVOPS_PAT.
+  or calling the ADO REST API. Runs the FULL pipeline:
+    create_issue → add_label → sync_branch → prepare_worktree → assign
+
+  No cleanup is performed — use the displayed commands to clean up manually.
+  GitHub auth (gh CLI) is still required in live mode.
 
   --from ADDRESS      Sender address (e.g. azuredevops@microsoft.com)
   --subject SUBJECT   Email subject matching the ADO PBI pattern
-  --dry-run           Print parsed result without creating any GitHub issue
-  --repo OWNER/NAME   Target repo override (default: ADO_BRIDGE_REPO or fivepoints-test)
+  --dry-run           Print each pipeline step without any side effects
+  --repo OWNER/NAME   Target repo override (default: ADO_BRIDGE_SYNC_TARGET)
+  --agent USERNAME    GitHub assignee override (default: ADO_BRIDGE_AGENT)
 
   Examples:
     # Dry-run — parse subject, print what would be created

--- a/domain/scripts/azure_issue_bridge/tests/test_inject.py
+++ b/domain/scripts/azure_issue_bridge/tests/test_inject.py
@@ -3,15 +3,18 @@ Unit tests for azure_issue_bridge inject subcommand and parse_subject_parts help
 
 Tests cover:
 - parse_subject_parts() extracts (area, title) from ADO subject formats
-- cmd_inject dry-run: prints parsed result, no gh calls
-- cmd_inject live mode: calls create_github_issue with synthetic WorkItem
+- cmd_inject dry-run: prints parsed result + full pipeline plan, no side effects
+- cmd_inject live mode: runs full pipeline (create_issue, add_label, sync_branch,
+  prepare_worktree, assign) in order, with cleanup commands in output
 - cmd_inject rejects non-PBI subjects
-- cmd_inject --repo override sets target repo
+- cmd_inject --repo and --agent overrides
+- cmd_inject aborts and returns 1 on each step failure (no assignment if worktree fails)
 """
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -59,7 +62,7 @@ class TestParseSubjectParts:
 
 
 # ---------------------------------------------------------------------------
-# cmd_inject
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -69,9 +72,28 @@ def _make_args(**kwargs: object) -> argparse.Namespace:
         "subject": "Product Backlog Item 12345 - DEV - Client Management test",
         "dry_run": False,
         "repo": None,
+        "agent": None,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
+
+
+@dataclass
+class _FakeIssue:
+    url: str
+    number: int
+
+
+def _fake_issue(number: int = 99) -> _FakeIssue:
+    return _FakeIssue(
+        url=f"https://github.com/org/repo/issues/{number}",
+        number=number,
+    )
+
+
+# ---------------------------------------------------------------------------
+# cmd_inject — dry-run
+# ---------------------------------------------------------------------------
 
 
 class TestCmdInjectDryRun:
@@ -85,6 +107,18 @@ class TestCmdInjectDryRun:
         assert "Client Management test" in out
         assert "DEV" in out
 
+    def test_dry_run_prints_all_pipeline_steps(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        args = _make_args(dry_run=True)
+        cmd_inject(args)
+        out = capsys.readouterr().out
+        assert "create_issue" in out
+        assert "add_label" in out
+        assert "sync_branch" in out
+        assert "prepare_worktree" in out
+        assert "assign" in out
+
     def test_dry_run_no_gh_calls(self) -> None:
         args = _make_args(dry_run=True)
         with patch("azure_issue_bridge.bridge.subprocess.run") as mock_run:
@@ -97,49 +131,183 @@ class TestCmdInjectDryRun:
         out = capsys.readouterr().out
         assert "CLAIRE-Fivepoints/fivepoints-test" in out
 
+    def test_dry_run_shows_agent_override(self, capsys: pytest.CaptureFixture) -> None:
+        args = _make_args(dry_run=True, agent="my-bot")
+        cmd_inject(args)
+        out = capsys.readouterr().out
+        assert "my-bot" in out
+
+
+# ---------------------------------------------------------------------------
+# cmd_inject — live (mocked)
+# ---------------------------------------------------------------------------
+
 
 class TestCmdInjectLive:
-    def test_live_calls_create_github_issue(self) -> None:
-        args = _make_args()
-        with patch(
-            "azure_issue_bridge.bridge.create_github_issue",
-            return_value="https://github.com/org/repo/issues/99",
-        ) as mock_create:
+    def _run_live(
+        self,
+        args: argparse.Namespace,
+        issue_number: int = 99,
+    ):
+        """Run cmd_inject with all external calls mocked. Returns (rc, mocks dict)."""
+        fake = _fake_issue(issue_number)
+
+        with (
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue",
+                return_value=fake,
+            ) as mock_create,
+            patch("azure_issue_bridge.bridge.add_issue_label") as mock_label,
+            patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
+            patch(
+                "azure_issue_bridge.worktree.RealWorktreePrepare"
+            ) as MockWorktreeClass,
+            patch(
+                "azure_issue_bridge.bridge.assign_github_issue"
+            ) as mock_assign,
+        ):
+            mock_sync = MagicMock()
+            MockSyncClass.return_value = mock_sync
+            mock_worktree = MagicMock()
+            mock_worktree.prepare.return_value = f"/mock/worktrees/pbi-{issue_number}"
+            MockWorktreeClass.return_value = mock_worktree
+
             rc = cmd_inject(args)
+            return rc, {
+                "create": mock_create,
+                "label": mock_label,
+                "sync": mock_sync,
+                "worktree": mock_worktree,
+                "assign": mock_assign,
+            }
+
+    def test_happy_path_exits_0(self) -> None:
+        rc, _ = self._run_live(_make_args())
         assert rc == 0
-        mock_create.assert_called_once()
-        work_item = mock_create.call_args[0][0]
+
+    def test_live_calls_create_github_issue(self) -> None:
+        _, mocks = self._run_live(_make_args())
+        mocks["create"].assert_called_once()
+        work_item = mocks["create"].call_args[0][0]
         assert work_item.id == 12345
         assert work_item.title == "Client Management test"
         assert work_item.area_path == "DEV"
         assert work_item.state == "To Do"
         assert work_item.work_item_type == "Task"
 
-    def test_live_prints_issue_url(self, capsys: pytest.CaptureFixture) -> None:
-        args = _make_args()
-        with patch(
-            "azure_issue_bridge.bridge.create_github_issue",
-            return_value="https://github.com/org/repo/issues/99",
+    def test_label_called_with_role_label(self) -> None:
+        _, mocks = self._run_live(_make_args())
+        mocks["label"].assert_called_once()
+        _, issue_number, label = mocks["label"].call_args[0]
+        assert label.startswith("role:")
+        assert label.endswith("-dev")
+        assert issue_number == 99
+
+    def test_sync_branch_called(self) -> None:
+        _, mocks = self._run_live(_make_args())
+        mocks["sync"].sync_branch.assert_called_once()
+
+    def test_worktree_prepare_called_with_pbi_branch(self) -> None:
+        _, mocks = self._run_live(_make_args(), issue_number=99)
+        mocks["worktree"].prepare.assert_called_once()
+        kw = mocks["worktree"].prepare.call_args[1]
+        assert kw["branch_name"] == "pbi-99"
+        assert kw["issue"] == 99
+
+    def test_assign_called_with_agent(self) -> None:
+        _, mocks = self._run_live(_make_args())
+        mocks["assign"].assert_called_once()
+
+    def test_pipeline_order_label_sync_worktree_assign(self) -> None:
+        """Verify execution order: label → sync → worktree → assign."""
+        call_order: list[str] = []
+        fake = _fake_issue(42)
+
+        with (
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue", return_value=fake
+            ),
+            patch(
+                "azure_issue_bridge.bridge.add_issue_label",
+                side_effect=lambda *a, **kw: call_order.append("label"),
+            ),
+            patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
+            patch(
+                "azure_issue_bridge.worktree.RealWorktreePrepare"
+            ) as MockWorktreeClass,
+            patch(
+                "azure_issue_bridge.bridge.assign_github_issue",
+                side_effect=lambda *a, **kw: call_order.append("assign"),
+            ),
         ):
-            cmd_inject(args)
+            mock_sync = MagicMock()
+            mock_sync.sync_branch.side_effect = (
+                lambda *a, **kw: call_order.append("sync")
+            )
+            MockSyncClass.return_value = mock_sync
+            mock_worktree = MagicMock()
+            mock_worktree.prepare.side_effect = (
+                lambda *a, **kw: call_order.append("worktree") or "/mock/path"
+            )
+            MockWorktreeClass.return_value = mock_worktree
+
+            rc = cmd_inject(_make_args())
+
+        assert rc == 0
+        assert call_order == ["label", "sync", "worktree", "assign"]
+
+    def test_happy_path_prints_summary(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        self._run_live(_make_args(), issue_number=151)
+        out = capsys.readouterr().out
+        assert "✓ Pipeline complet" in out
+        assert "Issue créée" in out
+        assert "Label" in out
+        assert "Branch" in out
+        assert "Assigné à" in out
+        assert "Pour nettoyer" in out
+        assert "gh issue close 151" in out
+
+    def test_happy_path_prints_worktree_path(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        self._run_live(_make_args(), issue_number=42)
+        out = capsys.readouterr().out
+        assert "/mock/worktrees/pbi-42" in out
+        assert "git worktree remove" in out
+
+    def test_live_prints_issue_url(self, capsys: pytest.CaptureFixture) -> None:
+        self._run_live(_make_args(), issue_number=99)
         out = capsys.readouterr().out
         assert "https://github.com/org/repo/issues/99" in out
 
-    def test_live_repo_override_sets_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_repo_override(self) -> None:
         args = _make_args(repo="CLAIRE-Fivepoints/fivepoints-test")
-        captured_repo: list[str] = []
+        fake = _fake_issue(1)
 
-        def fake_create(work_item):  # type: ignore[no-untyped-def]
-            import os
-            captured_repo.append(os.environ.get("ADO_BRIDGE_REPO", ""))
-            return "https://github.com/org/repo/issues/1"
-
-        with patch("azure_issue_bridge.bridge.create_github_issue", side_effect=fake_create):
+        with (
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue", return_value=fake
+            ) as mock_create,
+            patch("azure_issue_bridge.bridge.add_issue_label"),
+            patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
+            patch("azure_issue_bridge.worktree.RealWorktreePrepare") as MockWorktreeClass,
+            patch("azure_issue_bridge.bridge.assign_github_issue"),
+        ):
+            MockSyncClass.return_value = MagicMock()
+            mock_wt = MagicMock()
+            mock_wt.prepare.return_value = "/mock/path"
+            MockWorktreeClass.return_value = mock_wt
             cmd_inject(args)
 
-        assert captured_repo == ["CLAIRE-Fivepoints/fivepoints-test"]
+        import os
 
-    def test_live_runtime_error_returns_nonzero(self, capsys: pytest.CaptureFixture) -> None:
+        assert os.environ.get("ADO_BRIDGE_REPO") == "CLAIRE-Fivepoints/fivepoints-test"
+
+    def test_live_runtime_error_on_create_returns_nonzero(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
         args = _make_args()
         with patch(
             "azure_issue_bridge.bridge.create_github_issue",
@@ -149,6 +317,104 @@ class TestCmdInjectLive:
         assert rc == 1
         out = capsys.readouterr().out
         assert "✗" in out
+
+    def test_add_label_failure_exits_1(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        fake = _fake_issue(1)
+        with (
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue", return_value=fake
+            ),
+            patch(
+                "azure_issue_bridge.bridge.add_issue_label",
+                side_effect=RuntimeError("label not found"),
+            ),
+        ):
+            rc = cmd_inject(_make_args())
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "add_label failed" in out
+
+    def test_sync_branch_failure_exits_1(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        fake = _fake_issue(1)
+        with (
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue", return_value=fake
+            ),
+            patch("azure_issue_bridge.bridge.add_issue_label"),
+            patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
+        ):
+            mock_sync = MagicMock()
+            mock_sync.sync_branch.side_effect = RuntimeError("branch not found")
+            MockSyncClass.return_value = mock_sync
+            rc = cmd_inject(_make_args())
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "sync_branch failed" in out
+
+    def test_prepare_worktree_failure_exits_1_no_assign(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        fake = _fake_issue(1)
+        with (
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue", return_value=fake
+            ),
+            patch("azure_issue_bridge.bridge.add_issue_label"),
+            patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
+            patch(
+                "azure_issue_bridge.worktree.RealWorktreePrepare"
+            ) as MockWorktreeClass,
+            patch(
+                "azure_issue_bridge.bridge.assign_github_issue"
+            ) as mock_assign,
+        ):
+            MockSyncClass.return_value = MagicMock()
+            mock_wt = MagicMock()
+            mock_wt.prepare.side_effect = RuntimeError("git failed")
+            MockWorktreeClass.return_value = mock_wt
+            rc = cmd_inject(_make_args())
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "prepare_worktree failed" in out
+        mock_assign.assert_not_called()
+
+    def test_assign_failure_exits_1(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        fake = _fake_issue(1)
+        with (
+            patch(
+                "azure_issue_bridge.bridge.create_github_issue", return_value=fake
+            ),
+            patch("azure_issue_bridge.bridge.add_issue_label"),
+            patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
+            patch(
+                "azure_issue_bridge.worktree.RealWorktreePrepare"
+            ) as MockWorktreeClass,
+            patch(
+                "azure_issue_bridge.bridge.assign_github_issue",
+                side_effect=RuntimeError("assignee not found"),
+            ),
+        ):
+            MockSyncClass.return_value = MagicMock()
+            mock_wt = MagicMock()
+            mock_wt.prepare.return_value = "/mock/path"
+            MockWorktreeClass.return_value = mock_wt
+            rc = cmd_inject(_make_args())
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "assign failed" in out
+
+
+# ---------------------------------------------------------------------------
+# cmd_inject — invalid subjects
+# ---------------------------------------------------------------------------
 
 
 class TestCmdInjectRejectsNonPBI:


### PR DESCRIPTION
## Summary

- Extends `cmd_inject` to run the complete bridge pipeline after creating the GitHub issue: `add_issue_label` → `sync_branch` → `prepare_worktree` → `assign_github_issue` (always last)
- Fixes bug where `create_github_issue()` returns a `GitHubIssue` object but was used as a string (now correctly uses `.url` and `.number`)
- Adds `--agent` CLI flag for GitHub assignee override
- Dry-run now logs all five pipeline steps instead of only the issue creation
- Summary output includes: URL, label, branch sync info, worktree path, assignee, and cleanup commands

## Verification Log

```
$ python3 -m pytest domain/scripts/azure_issue_bridge/tests/ -v
123 passed in 0.11s
```

```
$ python3 -m pytest domain/scripts/azure_issue_bridge/tests/test_inject.py -v
28 passed in 0.04s
```

```
$ python3 -m azure_issue_bridge.cli inject --from "azuredevops@microsoft.com" --subject "Product Backlog Item 99999 - DEV - System Test" --dry-run
[dry-run] Parsed PBI #99999
  from:    azuredevops@microsoft.com
  title:   System Test (PBI #99999)
  area:    DEV
  repo:    CLAIRE-Fivepoints/fivepoints

[dry-run] Pipeline steps:
  1. create_issue   → System Test (PBI #99999) in CLAIRE-Fivepoints/fivepoints
  2. add_label      → role:fivepoints-dev
  3. sync_branch    → CLAIRE-Fivepoints/fivepoints-test/develop → CLAIRE-Fivepoints/fivepoints/develop
  4. prepare_worktree → branch pbi-<N>
  5. assign         → claire-test-ai
EXIT: 0
```

Tests for `cmd_inject`:
- `test_dry_run_prints_all_pipeline_steps` — all 5 steps visible in dry-run output
- `test_pipeline_order_label_sync_worktree_assign` — execution order enforced
- `test_prepare_worktree_failure_exits_1_no_assign` — no assignment if worktree fails
- `test_happy_path_prints_summary` — cleanup commands present in output

## Test plan

- [x] `python3 -m pytest domain/scripts/azure_issue_bridge/tests/test_inject.py -v` → 28 passed
- [x] `python3 -m pytest domain/scripts/azure_issue_bridge/tests/ -v` → 123 passed
- [x] Dry-run: `claire azure-issue-bridge inject --from "azuredevops@microsoft.com" --subject "Product Backlog Item 99999 - DEV - System Test" --dry-run` prints all 5 pipeline steps and exits 0

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gWhkJine6T8k4NPE4nPxH
