### PR TITLE
feat(bridge): add_label step — label GitHub issue with role:{client}-dev after creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "claire-workflows",
     "google-api-python-client>=2.0",
     "google-auth>=2.0",
+    "typer>=0.9",
 ]
 
 [tool.uv.sources]
@@ -33,7 +34,6 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=9.1.1",
-    "typer>=0.26.8",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ fivepoints = "claire_fivepoints:plugin_info"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+    "typer>=0.26.8",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/claire_fivepoints", "domain/scripts/azure_issue_bridge"]
 

--- a/src/claire_fivepoints/azure_issue_bridge/adapters.py
+++ b/src/claire_fivepoints/azure_issue_bridge/adapters.py
@@ -1,4 +1,4 @@
-"""azure_issue_bridge.adapters — EmailAdapter, GitHubAdapter protocols, concrete adapters, and test doubles.
+"""azure_issue_bridge.adapters — EmailAdapter, GitHubAdapter, LabelAdapter protocols, concrete adapters, and test doubles.
 
 - GmailApiAdapter: accesses Gmail via the Google API directly (OAuth2) — no subprocess.
 - CLI-backed adapters (GhCliAdapter) remain in cli.py (subprocess.run in CLI entry points only).
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
@@ -23,10 +24,17 @@ class GitHubAdapter(Protocol):
         ...
 
 
+class LabelAdapter(Protocol):
+    def add_label(self, repo: str, issue: int, label: str) -> None:
+        """Add a label to a GitHub issue. Creates the label if it does not exist."""
+        ...
+
+
 @dataclass
 class BridgeAdapters:
     email: EmailAdapter
     github: GitHubAdapter
+    labels: LabelAdapter
 
 
 # ---------------------------------------------------------------------------
@@ -91,9 +99,35 @@ class GmailApiAdapter:
         return emails
 
 
+class RealLabelAdapter:
+    def add_label(self, repo: str, issue: int, label: str) -> None:
+        result = subprocess.run(
+            ["gh", "issue", "edit", str(issue), "--repo", repo, "--add-label", label],
+            check=False, capture_output=True,
+        )
+        if result.returncode != 0:
+            # Label may not exist — create it then retry
+            subprocess.run(
+                ["gh", "label", "create", label, "--repo", repo, "--color", "0075ca"],
+                check=False, capture_output=True,
+            )
+            subprocess.run(
+                ["gh", "issue", "edit", str(issue), "--repo", repo, "--add-label", label],
+                check=True, capture_output=True,
+            )
+
+
 # ---------------------------------------------------------------------------
 # Test doubles
 # ---------------------------------------------------------------------------
+
+
+class MockLabelAdapter:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def add_label(self, repo: str, issue: int, label: str) -> None:
+        self.calls.append({"repo": repo, "issue": issue, "label": label})
 
 
 class MockEmailAdapter:

--- a/src/claire_fivepoints/azure_issue_bridge/adapters.py
+++ b/src/claire_fivepoints/azure_issue_bridge/adapters.py
@@ -1,12 +1,11 @@
 """azure_issue_bridge.adapters — EmailAdapter, GitHubAdapter, LabelAdapter protocols, concrete adapters, and test doubles.
 
 - GmailApiAdapter: accesses Gmail via the Google API directly (OAuth2) — no subprocess.
-- CLI-backed adapters (GhCliAdapter) remain in cli.py (subprocess.run in CLI entry points only).
+- CLI-backed adapters (GhCliAdapter, RealLabelAdapter) remain in cli.py (subprocess.run in CLI entry points only).
 """
 from __future__ import annotations
 
 import json
-import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
@@ -97,24 +96,6 @@ class GmailApiAdapter:
                 }
             )
         return emails
-
-
-class RealLabelAdapter:
-    def add_label(self, repo: str, issue: int, label: str) -> None:
-        result = subprocess.run(
-            ["gh", "issue", "edit", str(issue), "--repo", repo, "--add-label", label],
-            check=False, capture_output=True,
-        )
-        if result.returncode != 0:
-            # Label may not exist — create it then retry
-            subprocess.run(
-                ["gh", "label", "create", label, "--repo", repo, "--color", "0075ca"],
-                check=False, capture_output=True,
-            )
-            subprocess.run(
-                ["gh", "issue", "edit", str(issue), "--repo", repo, "--add-label", label],
-                check=True, capture_output=True,
-            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/claire_fivepoints/azure_issue_bridge/pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/pipeline.py
@@ -5,6 +5,7 @@ from claire_core.pipeline import pipe
 from claire_core.types import Task
 
 from claire_fivepoints.azure_issue_bridge.steps import (
+    add_label_step,
     create_issues_step,
     fetch_emails_step,
     filter_pbi_step,
@@ -16,10 +17,12 @@ class BridgeTask(Task):
     sender: str = "azuredevops@microsoft.com"
     max_results: int = 20
     dry_run: bool = False
+    client: str = "fivepoints"
 
 
 bridge_pipeline = pipe(
     fetch_emails_step,
     filter_pbi_step,
     create_issues_step,
+    add_label_step,
 )

--- a/src/claire_fivepoints/azure_issue_bridge/steps.py
+++ b/src/claire_fivepoints/azure_issue_bridge/steps.py
@@ -52,3 +52,21 @@ def create_issues_step(task, ctx: dict, adapters) -> StepResult:
         created.append({"subject": e["subject"], "issue": issue_number})
 
     return StepResult(ok=True, data={"created": created})
+
+
+def add_label_step(task, ctx: dict, adapters) -> StepResult:
+    """Add role:{client}-dev label to each created issue."""
+    label = f"role:{task.client}-dev"
+    labeled = []
+    for item in ctx.get("created", []):
+        issue_number = item.get("issue")
+        if issue_number is None:
+            # dry_run item — log only
+            labeled.append({"subject": item.get("subject"), "label": label, "dry_run": True})
+            continue
+        try:
+            adapters.labels.add_label(task.repo, issue_number, label)
+        except Exception as exc:
+            return StepResult(ok=False, error=f"add_label failed: {exc}")
+        labeled.append({"issue": issue_number, "label": label})
+    return StepResult(ok=True, data={"labeled": labeled})

--- a/src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py
@@ -7,8 +7,10 @@ from claire_fivepoints.azure_issue_bridge.adapters import (
     BridgeAdapters,
     MockEmailAdapter,
     MockGitHubAdapter,
+    MockLabelAdapter,
 )
 from claire_fivepoints.azure_issue_bridge.pipeline import BridgeTask, bridge_pipeline
+from claire_fivepoints.azure_issue_bridge.steps import add_label_step
 
 _ADO_SENDER = "azuredevops@microsoft.com"
 _TEST_SENDER = "andreoperez@gmail.com"
@@ -23,6 +25,14 @@ def _make_email(subject: str, sender: str = _ADO_SENDER, thread_id: str = "t1") 
     }
 
 
+def _make_adapters(emails: list[dict], gh: MockGitHubAdapter | None = None) -> BridgeAdapters:
+    return BridgeAdapters(
+        email=MockEmailAdapter(emails),
+        github=gh or MockGitHubAdapter(),
+        labels=MockLabelAdapter(),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
@@ -30,10 +40,7 @@ def _make_email(subject: str, sender: str = _ADO_SENDER, thread_id: str = "t1") 
 
 def test_bridge_detects_pbi_email() -> None:
     emails = [_make_email("Product Backlog Item 42 - DEV - Title")]
-    adapters = BridgeAdapters(
-        email=MockEmailAdapter(emails),
-        github=MockGitHubAdapter(),
-    )
+    adapters = _make_adapters(emails)
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
     result = bridge_pipeline(task, adapters)
     assert result.ok
@@ -45,7 +52,7 @@ def test_bridge_creates_issue_with_correct_title() -> None:
     subject = "Product Backlog Item 99 - AREA - My Feature"
     emails = [_make_email(subject)]
     gh = MockGitHubAdapter()
-    adapters = BridgeAdapters(email=MockEmailAdapter(emails), github=gh)
+    adapters = _make_adapters(emails, gh)
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
     bridge_pipeline(task, adapters)
     assert gh.created[0]["title"] == f"PBI: {subject}"
@@ -54,10 +61,7 @@ def test_bridge_creates_issue_with_correct_title() -> None:
 
 def test_bridge_test_sender() -> None:
     emails = [_make_email("Product Backlog Item 7 - DEV - Test", sender=_TEST_SENDER)]
-    adapters = BridgeAdapters(
-        email=MockEmailAdapter(emails),
-        github=MockGitHubAdapter(),
-    )
+    adapters = _make_adapters(emails)
     task = BridgeTask(sender=_TEST_SENDER, repo="owner/repo")
     result = bridge_pipeline(task, adapters)
     assert result.ok
@@ -72,7 +76,7 @@ def test_bridge_test_sender() -> None:
 def test_bridge_dry_run_no_issues_created() -> None:
     emails = [_make_email("Product Backlog Item 1 - DEV - Title")]
     gh = MockGitHubAdapter()
-    adapters = BridgeAdapters(email=MockEmailAdapter(emails), github=gh)
+    adapters = _make_adapters(emails, gh)
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", dry_run=True)
     result = bridge_pipeline(task, adapters)
     assert result.ok
@@ -82,10 +86,7 @@ def test_bridge_dry_run_no_issues_created() -> None:
 
 def test_bridge_dry_run_no_repo_required() -> None:
     emails = [_make_email("Product Backlog Item 1 - DEV - Title")]
-    adapters = BridgeAdapters(
-        email=MockEmailAdapter(emails),
-        github=MockGitHubAdapter(),
-    )
+    adapters = _make_adapters(emails)
     task = BridgeTask(sender=_ADO_SENDER, dry_run=True)  # no repo
     result = bridge_pipeline(task, adapters)
     assert result.ok
@@ -103,7 +104,7 @@ def test_bridge_filters_non_pbi_emails() -> None:
         _make_email("Your invoice is ready"),
     ]
     gh = MockGitHubAdapter()
-    adapters = BridgeAdapters(email=MockEmailAdapter(emails), github=gh)
+    adapters = _make_adapters(emails, gh)
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
     result = bridge_pipeline(task, adapters)
     assert result.ok
@@ -114,7 +115,7 @@ def test_bridge_sender_mismatch_filtered() -> None:
     """Emails from a different sender are dropped even with a valid subject."""
     emails = [_make_email("Product Backlog Item 5 - DEV - Title", sender=_TEST_SENDER)]
     gh = MockGitHubAdapter()
-    adapters = BridgeAdapters(email=MockEmailAdapter(emails), github=gh)
+    adapters = _make_adapters(emails, gh)
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
     result = bridge_pipeline(task, adapters)
     assert result.ok
@@ -122,10 +123,7 @@ def test_bridge_sender_mismatch_filtered() -> None:
 
 
 def test_bridge_empty_inbox() -> None:
-    adapters = BridgeAdapters(
-        email=MockEmailAdapter([]),
-        github=MockGitHubAdapter(),
-    )
+    adapters = _make_adapters([])
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
     result = bridge_pipeline(task, adapters)
     assert result.ok
@@ -139,10 +137,7 @@ def test_bridge_empty_inbox() -> None:
 
 def test_bridge_fails_without_repo_when_not_dry_run() -> None:
     emails = [_make_email("Product Backlog Item 1 - DEV - Title")]
-    adapters = BridgeAdapters(
-        email=MockEmailAdapter(emails),
-        github=MockGitHubAdapter(),
-    )
+    adapters = _make_adapters(emails)
     task = BridgeTask(sender=_ADO_SENDER, dry_run=False)  # repo=None
     result = bridge_pipeline(task, adapters)
     assert not result.ok
@@ -152,8 +147,108 @@ def test_bridge_fails_without_repo_when_not_dry_run() -> None:
 def test_bridge_max_results_respected() -> None:
     emails = [_make_email(f"Product Backlog Item {i} - DEV - Title") for i in range(10)]
     gh = MockGitHubAdapter()
-    adapters = BridgeAdapters(email=MockEmailAdapter(emails), github=gh)
+    adapters = _make_adapters(emails, gh)
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", max_results=3)
     result = bridge_pipeline(task, adapters)
     assert result.ok
     assert len(result.data["created"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# add_label_step — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _simple_adapters() -> tuple[MockLabelAdapter, BridgeAdapters]:
+    labels = MockLabelAdapter()
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter([]),
+        github=MockGitHubAdapter(),
+        labels=labels,
+    )
+    return labels, adapters
+
+
+def test_add_label_step_calls_adapter() -> None:
+    labels, adapters = _simple_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", client="fivepoints")
+    ctx = {"created": [{"subject": "S", "issue": 42}]}
+    result = add_label_step(task, ctx, adapters)
+    assert result.ok
+    assert labels.calls == [{"repo": "owner/repo", "issue": 42, "label": "role:fivepoints-dev"}]
+    assert result.data["labeled"][0]["label"] == "role:fivepoints-dev"
+
+
+def test_add_label_step_custom_client() -> None:
+    labels, adapters = _simple_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", client="acme")
+    ctx = {"created": [{"subject": "S", "issue": 7}]}
+    result = add_label_step(task, ctx, adapters)
+    assert result.ok
+    assert labels.calls[0]["label"] == "role:acme-dev"
+
+
+def test_add_label_step_multiple_issues() -> None:
+    labels, adapters = _simple_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    ctx = {"created": [{"subject": "A", "issue": 1}, {"subject": "B", "issue": 2}]}
+    result = add_label_step(task, ctx, adapters)
+    assert result.ok
+    assert len(labels.calls) == 2
+    assert labels.calls[0]["issue"] == 1
+    assert labels.calls[1]["issue"] == 2
+
+
+def test_add_label_step_dry_run_skips_adapter() -> None:
+    labels, adapters = _simple_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", dry_run=True)
+    # dry_run items have no "issue" key
+    ctx = {"created": [{"subject": "S", "dry_run": True}]}
+    result = add_label_step(task, ctx, adapters)
+    assert result.ok
+    assert labels.calls == []
+    assert result.data["labeled"][0]["dry_run"] is True
+
+
+def test_add_label_step_empty_created() -> None:
+    labels, adapters = _simple_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    result = add_label_step(task, {"created": []}, adapters)
+    assert result.ok
+    assert labels.calls == []
+
+
+def test_add_label_step_failure_aborts_pipeline() -> None:
+    class FailingLabelAdapter:
+        def add_label(self, repo: str, issue: int, label: str) -> None:
+            raise RuntimeError("gh error")
+
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter([]),
+        github=MockGitHubAdapter(),
+        labels=FailingLabelAdapter(),
+    )
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    ctx = {"created": [{"subject": "S", "issue": 1}]}
+    result = add_label_step(task, ctx, adapters)
+    assert not result.ok
+    assert "add_label failed" in result.error
+
+
+def test_bridge_pipeline_labels_created_issues() -> None:
+    """Full pipeline: label adapter receives call for each created issue."""
+    emails = [
+        _make_email("Product Backlog Item 10 - DEV - Feature A"),
+        _make_email("Product Backlog Item 11 - DEV - Feature B"),
+    ]
+    labels = MockLabelAdapter()
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter(emails),
+        github=MockGitHubAdapter(),
+        labels=labels,
+    )
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", client="fivepoints")
+    result = bridge_pipeline(task, adapters)
+    assert result.ok
+    assert len(labels.calls) == 2
+    assert all(c["label"] == "role:fivepoints-dev" for c in labels.calls)

--- a/src/claire_fivepoints/cli.py
+++ b/src/claire_fivepoints/cli.py
@@ -267,6 +267,32 @@ class _GhCliAdapter:
         return int(url.split("/")[-1])
 
 
+class _RealLabelAdapter:
+    """Calls `gh issue edit --add-label` via subprocess. Creates the label if absent."""
+
+    def add_label(self, repo: str, issue: int, label: str) -> None:
+        import subprocess
+
+        result = subprocess.run(
+            ["gh", "issue", "edit", str(issue), "--repo", repo, "--add-label", label],
+            check=False, capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            create_result = subprocess.run(
+                ["gh", "label", "create", label, "--repo", repo, "--color", "0075ca"],
+                check=False, capture_output=True, text=True,
+            )
+            retry = subprocess.run(
+                ["gh", "issue", "edit", str(issue), "--repo", repo, "--add-label", label],
+                check=False, capture_output=True, text=True,
+            )
+            if retry.returncode != 0:
+                label_stderr = create_result.stderr.strip()
+                issue_stderr = retry.stderr.strip()
+                context = f"label create: {label_stderr or '(no stderr)'} | issue edit: {issue_stderr}"
+                raise RuntimeError(f"gh add-label failed: {context}")
+
+
 @bridge_app.callback()
 def _bridge_root(
     agent_help: bool = typer.Option(
@@ -289,14 +315,17 @@ def bridge_run_cmd(
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show detected emails without creating issues."),
     max_results: int = typer.Option(20, "--max-results", help="Max inbox emails to scan."),
-    client: str = typer.Option("fivepoints", "--client", help="Client slug for the role:{client}-dev label."),
+    client: str = typer.Option(
+        "fivepoints", "--client", envvar="ADO_BRIDGE_CLIENT",
+        help="Client slug for the role:{client}-dev label.",
+    ),
     agent_help: bool = typer.Option(
         False, "--agent-help", callback=_bridge_agent_help_callback,
         is_eager=True, hidden=True,
     ),
 ) -> None:
     """Scan Gmail for ADO PBI assignment emails and create GitHub issues."""
-    from claire_fivepoints.azure_issue_bridge.adapters import BridgeAdapters, GmailApiAdapter, RealLabelAdapter
+    from claire_fivepoints.azure_issue_bridge.adapters import BridgeAdapters, GmailApiAdapter
     from claire_fivepoints.azure_issue_bridge.pipeline import BridgeTask, bridge_pipeline
 
     _console.print(f"[dim]Sender:[/dim] {sender}")
@@ -307,7 +336,7 @@ def bridge_run_cmd(
     adapters = BridgeAdapters(
         email=GmailApiAdapter(),
         github=_GhCliAdapter(),
-        labels=RealLabelAdapter(),
+        labels=_RealLabelAdapter(),
     )
     result = bridge_pipeline(task, adapters)
     if not result.ok:

--- a/src/claire_fivepoints/cli.py
+++ b/src/claire_fivepoints/cli.py
@@ -48,7 +48,7 @@ _BRIDGE_AGENT_HELP = """\
 
 ## Commands
 
-  claire fivepoints azure-issue-bridge run [--from SENDER] [--repo owner/name] [--dry-run] [--max-results N]
+  claire fivepoints azure-issue-bridge run [--from SENDER] [--repo owner/name] [--dry-run] [--max-results N] [--client SLUG]
   claire fivepoints azure-issue-bridge inject --from ADDRESS --subject SUBJECT [--dry-run] [--repo OWNER/NAME] [--agent USERNAME]
 
 ## Options (run)
@@ -57,6 +57,7 @@ _BRIDGE_AGENT_HELP = """\
   --repo TEXT       Target GitHub repo (default: claire-labs/fivepoints-test)
   --dry-run         Show detected emails without creating issues
   --max-results N   Max inbox emails to scan (default: 20)
+  --client SLUG     Client slug for the role:{client}-dev label (default: fivepoints)
 
 ## Options (inject)
 
@@ -288,23 +289,25 @@ def bridge_run_cmd(
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show detected emails without creating issues."),
     max_results: int = typer.Option(20, "--max-results", help="Max inbox emails to scan."),
+    client: str = typer.Option("fivepoints", "--client", help="Client slug for the role:{client}-dev label."),
     agent_help: bool = typer.Option(
         False, "--agent-help", callback=_bridge_agent_help_callback,
         is_eager=True, hidden=True,
     ),
 ) -> None:
     """Scan Gmail for ADO PBI assignment emails and create GitHub issues."""
-    from claire_fivepoints.azure_issue_bridge.adapters import BridgeAdapters, GmailApiAdapter
+    from claire_fivepoints.azure_issue_bridge.adapters import BridgeAdapters, GmailApiAdapter, RealLabelAdapter
     from claire_fivepoints.azure_issue_bridge.pipeline import BridgeTask, bridge_pipeline
 
     _console.print(f"[dim]Sender:[/dim] {sender}")
     if dry_run:
         _console.print("[dim]Mode:[/dim] dry-run — no issues will be created")
 
-    task = BridgeTask(sender=sender, max_results=max_results, dry_run=dry_run, repo=repo)
+    task = BridgeTask(sender=sender, max_results=max_results, dry_run=dry_run, repo=repo, client=client)
     adapters = BridgeAdapters(
         email=GmailApiAdapter(),
         github=_GhCliAdapter(),
+        labels=RealLabelAdapter(),
     )
     result = bridge_pipeline(task, adapters)
     if not result.ok:


### PR DESCRIPTION
Closes #155

## Summary

- **`LabelAdapter` Protocol** + **`RealLabelAdapter`** (with `gh label create` fallback si inexistant) + **`MockLabelAdapter`** dans `adapters.py`
- **`add_label_step`** dans `steps.py` : itère sur `ctx['created']`, skip les items dry-run (pas de numéro d'issue), avorte le pipeline en cas d'échec
- **`BridgeTask`** : champ `client: str = "fivepoints"` ajouté
- **`bridge_pipeline`** : `add_label_step` inséré après `create_issues_step`
- **CLI `bridge run`** : option `--client SLUG` (défaut: `fivepoints`), `RealLabelAdapter` câblé dans `BridgeAdapters`

## Verification Log

```
$ uv run python -m pytest src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py -v
============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.1.1

test_bridge_detects_pbi_email PASSED
test_bridge_creates_issue_with_correct_title PASSED
test_bridge_test_sender PASSED
test_bridge_dry_run_no_issues_created PASSED
test_bridge_dry_run_no_repo_required PASSED
test_bridge_filters_non_pbi_emails PASSED
test_bridge_sender_mismatch_filtered PASSED
test_bridge_empty_inbox PASSED
test_bridge_fails_without_repo_when_not_dry_run PASSED
test_bridge_max_results_respected PASSED
test_add_label_step_calls_adapter PASSED
test_add_label_step_custom_client PASSED
test_add_label_step_multiple_issues PASSED
test_add_label_step_dry_run_skips_adapter PASSED
test_add_label_step_empty_created PASSED
test_add_label_step_failure_aborts_pipeline PASSED
test_bridge_pipeline_labels_created_issues PASSED

============================== 17 passed in 0.72s ==============================
```

## Notes d'implémentation

- `add_label_step` itère sur **toute** la liste `ctx['created']` (le spec supposait 1:1, mais un run peut créer plusieurs issues)
- `RealLabelAdapter` : premier essai sans `check=True`, si échec → `gh label create` (ignorer si déjà existant) → retry avec `check=True`
- Dry-run : les items sans `"issue"` sont loggés dans `labeled` avec `dry_run=True`, sans appeler l'adaptateur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9aYhYXFz8sVZQTPazZeZv