### PR TITLE
feat(bridge): add sync_branch step — sync source/develop to target/develop

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -279,7 +279,7 @@ The azure-issue-bridge uses `AZURE_DEVOPS_PAT`. The fivepoints plugin (`ado_comm
 | `ADO_BRIDGE_CLIENT` | `fivepoints` | Client slug used to build the role label: `role:{ADO_BRIDGE_CLIENT}-dev`. Determines which agent persona is activated by the spawn daemon. |
 | `ADO_BRIDGE_SYNC_SOURCE` | `CLAIRE-Fivepoints/fivepoints-test` | Source GitHub repo for branch sync (the repo Claire agents push to). |
 | `ADO_BRIDGE_SYNC_TARGET` | `CLAIRE-Fivepoints/fivepoints` | Target GitHub repo where issues are created, where the worktree branch is pushed, and where the issue is assigned. |
-| `ADO_BRIDGE_SYNC_BRANCH` | `develop` | Branch name synced from source to target and used as base for the new `pbi-{N}` branch. |
+| `ADO_BRIDGE_SYNC_BRANCH` | `develop` | Branch name synced from source to target (legacy scripts only). The Python package (`claire fivepoints azure-issue-bridge`) hardcodes `develop` in `sync_branch_step`; this variable has no effect on the Typer CLI. |
 
 ---
 
@@ -296,16 +296,26 @@ The azure-issue-bridge uses `AZURE_DEVOPS_PAT`. The fivepoints plugin (`ado_comm
 
 ## Source Files (in this plugin)
 
+### Python package (`claire fivepoints azure-issue-bridge` CLI)
+
 | File | Role |
 |------|------|
-| `domain/scripts/azure_issue_bridge/bridge.py` | Core pipeline logic |
-| `domain/scripts/azure_issue_bridge/sync.py` | Branch sync adapter — `RealBranchSync` (GitHub REST API) and `MockBranchSync` (test double) |
-| `domain/scripts/azure_issue_bridge/worktree.py` | Worktree adapter — `WorktreePrepareAdapter` Protocol, `RealWorktreePrepare` (git worktree add), `MockWorktreePrepare` (test double) |
-| `domain/scripts/azure_issue_bridge/cli.py` | CLI entry point (`python3 -m azure_issue_bridge.cli`) |
-| `domain/scripts/azure_issue_bridge/tests/` | Unit tests (triage, sync, worktree, concurrent lock) |
-| `domain/commands/azure-issue-bridge.sh` | Bash router — sets PYTHONPATH and dispatches to the python CLI |
+| `src/claire_fivepoints/azure_issue_bridge/adapters.py` | Protocols (`EmailAdapter`, `GitHubAdapter`, `LabelAdapter`, `BranchSyncAdapter`), `RealBranchSync` (GitHub REST API, no subprocess), `GmailApiAdapter`, and test doubles (`MockBranchSync`, `MockLabelAdapter`, `MockEmailAdapter`, `MockGitHubAdapter`) |
+| `src/claire_fivepoints/azure_issue_bridge/steps.py` | Pure pipeline steps: `fetch_emails_step`, `filter_pbi_step`, `create_issues_step`, `add_label_step`, `sync_branch_step` |
+| `src/claire_fivepoints/azure_issue_bridge/pipeline.py` | `BridgeTask` (pydantic task), `bridge_pipeline` (`pipe()` composition) |
+| `src/claire_fivepoints/azure_issue_bridge/bridge.py` | `is_pbi_email()` filter predicate |
+| `src/claire_fivepoints/azure_issue_bridge/tests/` | Unit tests — zero network calls, zero subprocess |
+| `src/claire_fivepoints/cli.py` | Typer CLI entry point (`claire fivepoints azure-issue-bridge run / inject`) — subprocess-backed adapters (`_GhCliAdapter`, `_RealLabelAdapter`) live here |
 
-The bash router prepends `domain/scripts` to `PYTHONPATH` so the package is importable as `azure_issue_bridge`. The module still imports `claire_py.email.auth` and `claire_py.email.watcher` from claire core (which remain there).
+### Legacy scripts (domain/scripts — predecessor, retained for reference)
+
+| File | Role |
+|------|------|
+| `domain/scripts/azure_issue_bridge/bridge.py` | Original core pipeline logic (predecessor to the Python package) |
+| `domain/scripts/azure_issue_bridge/sync.py` | Original branch sync adapter (`RealBranchSync` using GitHub REST API) |
+| `domain/scripts/azure_issue_bridge/worktree.py` | Original worktree adapter (`RealWorktreePrepare`) |
+| `domain/scripts/azure_issue_bridge/cli.py` | Original CLI entry point (`python3 -m azure_issue_bridge.cli`) |
+| `domain/commands/azure-issue-bridge.sh` | Bash router — sets PYTHONPATH and dispatches to the original python CLI |
 
 ---
 

--- a/src/claire_fivepoints/azure_issue_bridge/adapters.py
+++ b/src/claire_fivepoints/azure_issue_bridge/adapters.py
@@ -74,6 +74,8 @@ class RealBranchSync:
         target_branch: str,
     ) -> None:
         gh_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+        if not gh_token:
+            logger.debug("No GitHub token found — proceeding unauthenticated")
         headers: dict[str, str] = {
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
@@ -90,7 +92,7 @@ class RealBranchSync:
 
     @staticmethod
     def _get_branch_sha(repo: str, branch: str, headers: dict[str, str]) -> str:
-        url = f"{_GITHUB_API}/repos/{repo}/git/ref/heads/{branch}"
+        url = f"{_GITHUB_API}/repos/{repo}/git/refs/heads/{branch}"
         req = urllib.request.Request(url, headers=headers)
         try:
             with urllib.request.urlopen(req) as resp:
@@ -121,7 +123,12 @@ class RealBranchSync:
                 raise RuntimeError(
                     f"Cannot update {repo}/{branch}: GitHub API returned HTTP {exc.code}"
                 ) from exc
-        # 422 → ref does not exist yet; create it
+            body = exc.read().decode(errors="replace")
+            if "Reference does not exist" not in body:
+                raise RuntimeError(
+                    f"Cannot update {repo}/{branch}: GitHub API returned HTTP 422: {body}"
+                ) from exc
+        # 422 "Reference does not exist" → create it
         post_payload = json.dumps(
             {"ref": f"refs/heads/{branch}", "sha": sha}
         ).encode()

--- a/src/claire_fivepoints/azure_issue_bridge/adapters.py
+++ b/src/claire_fivepoints/azure_issue_bridge/adapters.py
@@ -1,14 +1,23 @@
-"""azure_issue_bridge.adapters — EmailAdapter, GitHubAdapter, LabelAdapter protocols, concrete adapters, and test doubles.
+"""azure_issue_bridge.adapters — EmailAdapter, GitHubAdapter, LabelAdapter, BranchSyncAdapter protocols, concrete adapters, and test doubles.
 
 - GmailApiAdapter: accesses Gmail via the Google API directly (OAuth2) — no subprocess.
+- RealBranchSync: syncs branches via the GitHub REST API (urllib) — no subprocess.
 - CLI-backed adapters (GhCliAdapter, RealLabelAdapter) remain in cli.py (subprocess.run in CLI entry points only).
 """
 from __future__ import annotations
 
 import json
+import logging
+import os
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_API = "https://api.github.com"
 
 
 class EmailAdapter(Protocol):
@@ -29,16 +38,105 @@ class LabelAdapter(Protocol):
         ...
 
 
+class BranchSyncAdapter(Protocol):
+    def sync_branch(
+        self,
+        source_repo: str,
+        source_branch: str,
+        target_repo: str,
+        target_branch: str,
+    ) -> None:
+        """Force-update target_branch in target_repo to match source_branch in source_repo."""
+        ...
+
+
 @dataclass
 class BridgeAdapters:
     email: EmailAdapter
     github: GitHubAdapter
     labels: LabelAdapter
+    branch_sync: BranchSyncAdapter
 
 
 # ---------------------------------------------------------------------------
 # Concrete adapters
 # ---------------------------------------------------------------------------
+
+
+class RealBranchSync:
+    """Syncs a branch from source_repo to target_repo via the GitHub REST API."""
+
+    def sync_branch(
+        self,
+        source_repo: str,
+        source_branch: str,
+        target_repo: str,
+        target_branch: str,
+    ) -> None:
+        gh_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+        headers: dict[str, str] = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if gh_token:
+            headers["Authorization"] = f"Bearer {gh_token}"
+
+        sha = self._get_branch_sha(source_repo, source_branch, headers)
+        self._set_branch_sha(target_repo, target_branch, sha, headers)
+        logger.info(
+            "Synced %s/%s → %s/%s (sha=%.7s)",
+            source_repo, source_branch, target_repo, target_branch, sha,
+        )
+
+    @staticmethod
+    def _get_branch_sha(repo: str, branch: str, headers: dict[str, str]) -> str:
+        url = f"{_GITHUB_API}/repos/{repo}/git/ref/heads/{branch}"
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return json.loads(resp.read())["object"]["sha"]
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Cannot read {repo}/{branch}: GitHub API returned HTTP {exc.code}"
+            ) from exc
+
+    @staticmethod
+    def _set_branch_sha(
+        repo: str, branch: str, sha: str, headers: dict[str, str]
+    ) -> None:
+        """Force-update branch in repo to sha. Creates the ref if absent."""
+        content_headers = {**headers, "Content-Type": "application/json"}
+        patch_payload = json.dumps({"sha": sha, "force": True}).encode()
+        patch_req = urllib.request.Request(
+            f"{_GITHUB_API}/repos/{repo}/git/refs/heads/{branch}",
+            data=patch_payload,
+            headers=content_headers,
+            method="PATCH",
+        )
+        try:
+            with urllib.request.urlopen(patch_req):
+                return
+        except urllib.error.HTTPError as exc:
+            if exc.code != 422:
+                raise RuntimeError(
+                    f"Cannot update {repo}/{branch}: GitHub API returned HTTP {exc.code}"
+                ) from exc
+        # 422 → ref does not exist yet; create it
+        post_payload = json.dumps(
+            {"ref": f"refs/heads/{branch}", "sha": sha}
+        ).encode()
+        post_req = urllib.request.Request(
+            f"{_GITHUB_API}/repos/{repo}/git/refs",
+            data=post_payload,
+            headers=content_headers,
+        )
+        try:
+            with urllib.request.urlopen(post_req):
+                return
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Cannot create {repo}/{branch}: GitHub API returned HTTP {exc.code}"
+            ) from exc
 
 
 @dataclass
@@ -101,6 +199,20 @@ class GmailApiAdapter:
 # ---------------------------------------------------------------------------
 # Test doubles
 # ---------------------------------------------------------------------------
+
+
+class MockBranchSync:
+    def __init__(self) -> None:
+        self.syncs: list[tuple[str, str, str, str]] = []
+
+    def sync_branch(
+        self,
+        source_repo: str,
+        source_branch: str,
+        target_repo: str,
+        target_branch: str,
+    ) -> None:
+        self.syncs.append((source_repo, source_branch, target_repo, target_branch))
 
 
 class MockLabelAdapter:

--- a/src/claire_fivepoints/azure_issue_bridge/pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/pipeline.py
@@ -9,6 +9,7 @@ from claire_fivepoints.azure_issue_bridge.steps import (
     create_issues_step,
     fetch_emails_step,
     filter_pbi_step,
+    sync_branch_step,
 )
 
 
@@ -18,6 +19,7 @@ class BridgeTask(Task):
     max_results: int = 20
     dry_run: bool = False
     client: str = "fivepoints"
+    source_repo: str = "CLAIRE-Fivepoints/fivepoints-test"
 
 
 bridge_pipeline = pipe(
@@ -25,4 +27,5 @@ bridge_pipeline = pipe(
     filter_pbi_step,
     create_issues_step,
     add_label_step,
+    sync_branch_step,
 )

--- a/src/claire_fivepoints/azure_issue_bridge/steps.py
+++ b/src/claire_fivepoints/azure_issue_bridge/steps.py
@@ -54,6 +54,22 @@ def create_issues_step(task, ctx: dict, adapters) -> StepResult:
     return StepResult(ok=True, data={"created": created})
 
 
+def sync_branch_step(task, ctx: dict, adapters) -> StepResult:
+    """Sync source/develop → target/develop before worktree creation."""
+    if task.dry_run:
+        return StepResult(ok=True, data={"sync_skipped": True})
+    try:
+        adapters.branch_sync.sync_branch(
+            source_repo=task.source_repo,
+            source_branch="develop",
+            target_repo=task.repo,
+            target_branch="develop",
+        )
+    except Exception as exc:
+        return StepResult(ok=False, error=f"sync_branch failed: {exc}")
+    return StepResult(ok=True, data={"branch_synced": True})
+
+
 def add_label_step(task, ctx: dict, adapters) -> StepResult:
     """Add role:{client}-dev label to each created issue."""
     label = f"role:{task.client}-dev"

--- a/src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py
@@ -5,12 +5,13 @@ import pytest
 
 from claire_fivepoints.azure_issue_bridge.adapters import (
     BridgeAdapters,
+    MockBranchSync,
     MockEmailAdapter,
     MockGitHubAdapter,
     MockLabelAdapter,
 )
 from claire_fivepoints.azure_issue_bridge.pipeline import BridgeTask, bridge_pipeline
-from claire_fivepoints.azure_issue_bridge.steps import add_label_step
+from claire_fivepoints.azure_issue_bridge.steps import add_label_step, sync_branch_step
 
 _ADO_SENDER = "azuredevops@microsoft.com"
 _TEST_SENDER = "andreoperez@gmail.com"
@@ -25,11 +26,16 @@ def _make_email(subject: str, sender: str = _ADO_SENDER, thread_id: str = "t1") 
     }
 
 
-def _make_adapters(emails: list[dict], gh: MockGitHubAdapter | None = None) -> BridgeAdapters:
+def _make_adapters(
+    emails: list[dict],
+    gh: MockGitHubAdapter | None = None,
+    branch_sync: MockBranchSync | None = None,
+) -> BridgeAdapters:
     return BridgeAdapters(
         email=MockEmailAdapter(emails),
         github=gh or MockGitHubAdapter(),
         labels=MockLabelAdapter(),
+        branch_sync=branch_sync or MockBranchSync(),
     )
 
 
@@ -165,6 +171,7 @@ def _simple_adapters() -> tuple[MockLabelAdapter, BridgeAdapters]:
         email=MockEmailAdapter([]),
         github=MockGitHubAdapter(),
         labels=labels,
+        branch_sync=MockBranchSync(),
     )
     return labels, adapters
 
@@ -210,6 +217,136 @@ def test_add_label_step_dry_run_skips_adapter() -> None:
     assert result.data["labeled"][0]["dry_run"] is True
 
 
+# ---------------------------------------------------------------------------
+# sync_branch_step — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _sync_adapters(branch_sync: MockBranchSync | None = None) -> tuple[MockBranchSync, BridgeAdapters]:
+    sync = branch_sync or MockBranchSync()
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter([]),
+        github=MockGitHubAdapter(),
+        labels=MockLabelAdapter(),
+        branch_sync=sync,
+    )
+    return sync, adapters
+
+
+def test_sync_branch_step_calls_adapter() -> None:
+    sync, adapters = _sync_adapters()
+    task = BridgeTask(
+        sender=_ADO_SENDER,
+        repo="CLAIRE-Fivepoints/fivepoints",
+        source_repo="CLAIRE-Fivepoints/fivepoints-test",
+    )
+    result = sync_branch_step(task, {}, adapters)
+    assert result.ok
+    assert result.data == {"branch_synced": True}
+    assert sync.syncs == [
+        ("CLAIRE-Fivepoints/fivepoints-test", "develop", "CLAIRE-Fivepoints/fivepoints", "develop")
+    ]
+
+
+def test_sync_branch_step_dry_run_skips_adapter() -> None:
+    sync, adapters = _sync_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", dry_run=True)
+    result = sync_branch_step(task, {}, adapters)
+    assert result.ok
+    assert result.data == {"sync_skipped": True}
+    assert sync.syncs == []
+
+
+def test_sync_branch_step_failure_returns_error() -> None:
+    class FailingBranchSync:
+        def sync_branch(self, source_repo, source_branch, target_repo, target_branch):
+            raise RuntimeError("GitHub API returned HTTP 422")
+
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter([]),
+        github=MockGitHubAdapter(),
+        labels=MockLabelAdapter(),
+        branch_sync=FailingBranchSync(),
+    )
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    result = sync_branch_step(task, {}, adapters)
+    assert not result.ok
+    assert "sync_branch failed" in result.error
+    assert "422" in result.error
+
+
+def test_sync_branch_step_custom_source_repo() -> None:
+    sync, adapters = _sync_adapters()
+    task = BridgeTask(
+        sender=_ADO_SENDER,
+        repo="owner/target",
+        source_repo="owner/source",
+    )
+    result = sync_branch_step(task, {}, adapters)
+    assert result.ok
+    assert sync.syncs[0][0] == "owner/source"
+    assert sync.syncs[0][2] == "owner/target"
+
+
+def test_sync_branch_step_records_multiple_calls() -> None:
+    sync = MockBranchSync()
+    _, adapters = _sync_adapters(sync)
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", source_repo="owner/source")
+    sync_branch_step(task, {}, adapters)
+    sync_branch_step(task, {}, adapters)
+    assert len(sync.syncs) == 2
+
+
+def test_bridge_pipeline_includes_sync_branch() -> None:
+    """Full pipeline runs sync_branch after add_label."""
+    sync = MockBranchSync()
+    emails = [_make_email("Product Backlog Item 1 - DEV - Title")]
+    adapters = _make_adapters(emails, branch_sync=sync)
+    task = BridgeTask(
+        sender=_ADO_SENDER,
+        repo="CLAIRE-Fivepoints/fivepoints",
+        source_repo="CLAIRE-Fivepoints/fivepoints-test",
+    )
+    result = bridge_pipeline(task, adapters)
+    assert result.ok
+    assert result.data["branch_synced"] is True
+    assert len(sync.syncs) == 1
+    assert sync.syncs[0] == (
+        "CLAIRE-Fivepoints/fivepoints-test", "develop",
+        "CLAIRE-Fivepoints/fivepoints", "develop",
+    )
+
+
+def test_bridge_pipeline_sync_failure_aborts() -> None:
+    """sync_branch failure aborts the pipeline — no downstream steps run."""
+    class FailingBranchSync:
+        def sync_branch(self, source_repo, source_branch, target_repo, target_branch):
+            raise RuntimeError("network error")
+
+    emails = [_make_email("Product Backlog Item 2 - DEV - Title")]
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter(emails),
+        github=MockGitHubAdapter(),
+        labels=MockLabelAdapter(),
+        branch_sync=FailingBranchSync(),
+    )
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    result = bridge_pipeline(task, adapters)
+    assert not result.ok
+    assert "sync_branch failed" in result.error
+
+
+def test_bridge_pipeline_dry_run_skips_sync() -> None:
+    sync = MockBranchSync()
+    emails = [_make_email("Product Backlog Item 3 - DEV - Title")]
+    adapters = _make_adapters(emails, branch_sync=sync)
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", dry_run=True)
+    result = bridge_pipeline(task, adapters)
+    assert result.ok
+    assert result.data.get("sync_skipped") is True
+    assert sync.syncs == []
+
+
 def test_add_label_step_empty_created() -> None:
     labels, adapters = _simple_adapters()
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
@@ -227,6 +364,7 @@ def test_add_label_step_failure_aborts_pipeline() -> None:
         email=MockEmailAdapter([]),
         github=MockGitHubAdapter(),
         labels=FailingLabelAdapter(),
+        branch_sync=MockBranchSync(),
     )
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
     ctx = {"created": [{"subject": "S", "issue": 1}]}
@@ -246,6 +384,7 @@ def test_bridge_pipeline_labels_created_issues() -> None:
         email=MockEmailAdapter(emails),
         github=MockGitHubAdapter(),
         labels=labels,
+        branch_sync=MockBranchSync(),
     )
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", client="fivepoints")
     result = bridge_pipeline(task, adapters)

--- a/src/claire_fivepoints/cli.py
+++ b/src/claire_fivepoints/cli.py
@@ -48,7 +48,7 @@ _BRIDGE_AGENT_HELP = """\
 
 ## Commands
 
-  claire fivepoints azure-issue-bridge run [--from SENDER] [--repo owner/name] [--dry-run] [--max-results N] [--client SLUG]
+  claire fivepoints azure-issue-bridge run [--from SENDER] [--repo owner/name] [--dry-run] [--max-results N] [--client SLUG] [--source-repo OWNER/REPO]
   claire fivepoints azure-issue-bridge inject --from ADDRESS --subject SUBJECT [--dry-run] [--repo OWNER/NAME] [--agent USERNAME]
 
 ## Options (run)
@@ -57,7 +57,8 @@ _BRIDGE_AGENT_HELP = """\
   --repo TEXT       Target GitHub repo (default: claire-labs/fivepoints-test)
   --dry-run         Show detected emails without creating issues
   --max-results N   Max inbox emails to scan (default: 20)
-  --client SLUG     Client slug for the role:{client}-dev label (default: fivepoints)
+  --client SLUG        Client slug for the role:{client}-dev label (default: fivepoints)
+  --source-repo TEXT   Source repo for branch sync (default: CLAIRE-Fivepoints/fivepoints-test, envvar: ADO_BRIDGE_SYNC_SOURCE)
 
 ## Options (inject)
 
@@ -319,24 +320,32 @@ def bridge_run_cmd(
         "fivepoints", "--client", envvar="ADO_BRIDGE_CLIENT",
         help="Client slug for the role:{client}-dev label.",
     ),
+    source_repo: str = typer.Option(
+        "CLAIRE-Fivepoints/fivepoints-test", "--source-repo", envvar="ADO_BRIDGE_SYNC_SOURCE",
+        help="Source repo for branch sync (develop → target/develop).",
+    ),
     agent_help: bool = typer.Option(
         False, "--agent-help", callback=_bridge_agent_help_callback,
         is_eager=True, hidden=True,
     ),
 ) -> None:
     """Scan Gmail for ADO PBI assignment emails and create GitHub issues."""
-    from claire_fivepoints.azure_issue_bridge.adapters import BridgeAdapters, GmailApiAdapter
+    from claire_fivepoints.azure_issue_bridge.adapters import BridgeAdapters, GmailApiAdapter, RealBranchSync
     from claire_fivepoints.azure_issue_bridge.pipeline import BridgeTask, bridge_pipeline
 
     _console.print(f"[dim]Sender:[/dim] {sender}")
     if dry_run:
         _console.print("[dim]Mode:[/dim] dry-run — no issues will be created")
 
-    task = BridgeTask(sender=sender, max_results=max_results, dry_run=dry_run, repo=repo, client=client)
+    task = BridgeTask(
+        sender=sender, max_results=max_results, dry_run=dry_run,
+        repo=repo, client=client, source_repo=source_repo,
+    )
     adapters = BridgeAdapters(
         email=GmailApiAdapter(),
         github=_GhCliAdapter(),
         labels=_RealLabelAdapter(),
+        branch_sync=RealBranchSync(),
     )
     result = bridge_pipeline(task, adapters)
     if not result.ok:


### PR DESCRIPTION
## Summary

- `BranchSyncAdapter` Protocol + `RealBranchSync` (GitHub REST API via `urllib`, no subprocess) + `MockBranchSync` in `adapters.py`
- `sync_branch_step` in `steps.py`: mirrors `source_repo/develop` → `target_repo/develop`; `dry_run=True` → `sync_skipped=True`; any exception → `ok=False` (pipeline aborts)
- `BridgeTask` gains `source_repo` field (default: `CLAIRE-Fivepoints/fivepoints-test`)
- `bridge_pipeline`: `sync_branch_step` inserted after `add_label_step`, before future `prepare_worktree`
- `bridge run` CLI: `--source-repo` flag (env `ADO_BRIDGE_SYNC_SOURCE`), `RealBranchSync` wired into `BridgeAdapters`
- `MockBranchSync.syncs` records all calls for test assertions
- 8 new unit tests (step isolation + full pipeline integration)

## Verification Log

```
$ uv run pytest src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py -v
collected 25 items

test_bridge_detects_pbi_email PASSED
test_bridge_creates_issue_with_correct_title PASSED
test_bridge_test_sender PASSED
test_bridge_dry_run_no_issues_created PASSED
test_bridge_dry_run_no_repo_required PASSED
test_bridge_filters_non_pbi_emails PASSED
test_bridge_sender_mismatch_filtered PASSED
test_bridge_empty_inbox PASSED
test_bridge_fails_without_repo_when_not_dry_run PASSED
test_bridge_max_results_respected PASSED
test_add_label_step_calls_adapter PASSED
test_add_label_step_custom_client PASSED
test_add_label_step_multiple_issues PASSED
test_add_label_step_dry_run_skips_adapter PASSED
test_sync_branch_step_calls_adapter PASSED
test_sync_branch_step_dry_run_skips_adapter PASSED
test_sync_branch_step_failure_returns_error PASSED
test_sync_branch_step_custom_source_repo PASSED
test_sync_branch_step_records_multiple_calls PASSED
test_bridge_pipeline_includes_sync_branch PASSED
test_bridge_pipeline_sync_failure_aborts PASSED
test_bridge_pipeline_dry_run_skips_sync PASSED
test_add_label_step_empty_created PASSED
test_add_label_step_failure_aborts_pipeline PASSED
test_bridge_pipeline_labels_created_issues PASSED

25 passed in 0.06s
```

The 9 pre-existing failures (yaml/gmail protocol tests) are unchanged from `main`.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014x7DNwY9eJVtGptKu3BKwX