### PR TITLE
feat(bridge): prepare_worktree step — create pbi-{issue} worktree before assignment

### DIFF
--- a/src/claire_fivepoints/azure_issue_bridge/adapters.py
+++ b/src/claire_fivepoints/azure_issue_bridge/adapters.py
@@ -1,6 +1,7 @@
-"""azure_issue_bridge.adapters — EmailAdapter, GitHubAdapter, LabelAdapter protocols, concrete adapters, and test doubles.
+"""azure_issue_bridge.adapters — EmailAdapter, GitHubAdapter, LabelAdapter, WorktreePrepareAdapter protocols, concrete adapters, and test doubles.
 
 - GmailApiAdapter: accesses Gmail via the Google API directly (OAuth2) — no subprocess.
+- RealWorktreePrepare: creates git worktrees via subprocess git — no GitHub CLI.
 - CLI-backed adapters (GhCliAdapter, RealLabelAdapter) remain in cli.py (subprocess.run in CLI entry points only).
 """
 from __future__ import annotations
@@ -9,6 +10,26 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
+
+from claire_fivepoints.azure_issue_bridge.worktree import (
+    MockWorktreePrepare,
+    RealWorktreePrepare,
+    WorktreePrepareAdapter,
+)
+
+__all__ = [
+    "EmailAdapter",
+    "GitHubAdapter",
+    "LabelAdapter",
+    "WorktreePrepareAdapter",
+    "BridgeAdapters",
+    "GmailApiAdapter",
+    "MockEmailAdapter",
+    "MockGitHubAdapter",
+    "MockLabelAdapter",
+    "MockWorktreePrepare",
+    "RealWorktreePrepare",
+]
 
 
 class EmailAdapter(Protocol):
@@ -34,6 +55,7 @@ class BridgeAdapters:
     email: EmailAdapter
     github: GitHubAdapter
     labels: LabelAdapter
+    worktree: WorktreePrepareAdapter
 
 
 # ---------------------------------------------------------------------------

--- a/src/claire_fivepoints/azure_issue_bridge/pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/pipeline.py
@@ -9,6 +9,7 @@ from claire_fivepoints.azure_issue_bridge.steps import (
     create_issues_step,
     fetch_emails_step,
     filter_pbi_step,
+    prepare_worktree_step,
 )
 
 
@@ -18,6 +19,7 @@ class BridgeTask(Task):
     max_results: int = 20
     dry_run: bool = False
     client: str = "fivepoints"
+    branch_prefix: str = "pbi"
 
 
 bridge_pipeline = pipe(
@@ -25,4 +27,6 @@ bridge_pipeline = pipe(
     filter_pbi_step,
     create_issues_step,
     add_label_step,
+    # sync_branch_step goes here (issue #156)
+    prepare_worktree_step,
 )

--- a/src/claire_fivepoints/azure_issue_bridge/steps.py
+++ b/src/claire_fivepoints/azure_issue_bridge/steps.py
@@ -70,3 +70,45 @@ def add_label_step(task, ctx: dict, adapters) -> StepResult:
             return StepResult(ok=False, error=f"add_label failed: {exc}")
         labeled.append({"issue": issue_number, "label": label})
     return StepResult(ok=True, data={"labeled": labeled})
+
+
+def prepare_worktree_step(task, ctx: dict, adapters) -> StepResult:
+    """Create a pbi-{issue} worktree on develop before assignment."""
+    branch_prefix = getattr(task, "branch_prefix", "pbi")
+    prepared = []
+    for item in ctx.get("created", []):
+        issue_number = item.get("issue")
+        branch_name = (
+            f"{branch_prefix}-{issue_number}"
+            if issue_number is not None
+            else f"{branch_prefix}-dry"
+        )
+
+        if issue_number is None or task.dry_run:
+            prepared.append(
+                {
+                    "subject": item.get("subject"),
+                    "worktree_skipped": True,
+                    "branch_name": branch_name,
+                }
+            )
+            continue
+
+        try:
+            worktree_path = adapters.worktree.prepare(
+                repo=task.repo,
+                issue=issue_number,
+                base_branch="develop",
+                branch_name=branch_name,
+            )
+        except Exception as exc:
+            return StepResult(ok=False, error=f"prepare_worktree failed: {exc}")
+        prepared.append(
+            {
+                "issue": issue_number,
+                "worktree_path": worktree_path,
+                "branch_name": branch_name,
+            }
+        )
+
+    return StepResult(ok=True, data={"prepared": prepared})

--- a/src/claire_fivepoints/azure_issue_bridge/tests/test_gmail_api_adapter.py
+++ b/src/claire_fivepoints/azure_issue_bridge/tests/test_gmail_api_adapter.py
@@ -11,6 +11,8 @@ from claire_fivepoints.azure_issue_bridge.adapters import (
     BridgeAdapters,
     GmailApiAdapter,
     MockGitHubAdapter,
+    MockLabelAdapter,
+    MockWorktreePrepare,
 )
 
 
@@ -77,7 +79,12 @@ def _make_mock_creds(expired: bool = False, new_token: str = "new-token") -> Mag
 def test_gmail_api_adapter_satisfies_email_adapter_protocol(tmp_path: Path) -> None:
     """GmailApiAdapter is usable anywhere EmailAdapter is expected."""
     adapter = GmailApiAdapter(credentials_path=tmp_path / "token.json")
-    adapters = BridgeAdapters(email=adapter, github=MockGitHubAdapter())
+    adapters = BridgeAdapters(
+        email=adapter,
+        github=MockGitHubAdapter(),
+        labels=MockLabelAdapter(),
+        worktree=MockWorktreePrepare(),
+    )
     assert adapters.email is adapter
 
 

--- a/src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py
@@ -8,9 +8,10 @@ from claire_fivepoints.azure_issue_bridge.adapters import (
     MockEmailAdapter,
     MockGitHubAdapter,
     MockLabelAdapter,
+    MockWorktreePrepare,
 )
 from claire_fivepoints.azure_issue_bridge.pipeline import BridgeTask, bridge_pipeline
-from claire_fivepoints.azure_issue_bridge.steps import add_label_step
+from claire_fivepoints.azure_issue_bridge.steps import add_label_step, prepare_worktree_step
 
 _ADO_SENDER = "azuredevops@microsoft.com"
 _TEST_SENDER = "andreoperez@gmail.com"
@@ -25,11 +26,16 @@ def _make_email(subject: str, sender: str = _ADO_SENDER, thread_id: str = "t1") 
     }
 
 
-def _make_adapters(emails: list[dict], gh: MockGitHubAdapter | None = None) -> BridgeAdapters:
+def _make_adapters(
+    emails: list[dict],
+    gh: MockGitHubAdapter | None = None,
+    wt: MockWorktreePrepare | None = None,
+) -> BridgeAdapters:
     return BridgeAdapters(
         email=MockEmailAdapter(emails),
         github=gh or MockGitHubAdapter(),
         labels=MockLabelAdapter(),
+        worktree=wt or MockWorktreePrepare(),
     )
 
 
@@ -165,6 +171,7 @@ def _simple_adapters() -> tuple[MockLabelAdapter, BridgeAdapters]:
         email=MockEmailAdapter([]),
         github=MockGitHubAdapter(),
         labels=labels,
+        worktree=MockWorktreePrepare(),
     )
     return labels, adapters
 
@@ -227,6 +234,7 @@ def test_add_label_step_failure_aborts_pipeline() -> None:
         email=MockEmailAdapter([]),
         github=MockGitHubAdapter(),
         labels=FailingLabelAdapter(),
+        worktree=MockWorktreePrepare(),
     )
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
     ctx = {"created": [{"subject": "S", "issue": 1}]}
@@ -246,9 +254,128 @@ def test_bridge_pipeline_labels_created_issues() -> None:
         email=MockEmailAdapter(emails),
         github=MockGitHubAdapter(),
         labels=labels,
+        worktree=MockWorktreePrepare(),
     )
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", client="fivepoints")
     result = bridge_pipeline(task, adapters)
     assert result.ok
     assert len(labels.calls) == 2
     assert all(c["label"] == "role:fivepoints-dev" for c in labels.calls)
+
+
+# ---------------------------------------------------------------------------
+# prepare_worktree_step — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _worktree_adapters() -> tuple[MockWorktreePrepare, BridgeAdapters]:
+    wt = MockWorktreePrepare()
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter([]),
+        github=MockGitHubAdapter(),
+        labels=MockLabelAdapter(),
+        worktree=wt,
+    )
+    return wt, adapters
+
+
+def test_prepare_worktree_step_calls_adapter() -> None:
+    wt, adapters = _worktree_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    ctx = {"created": [{"subject": "S", "issue": 42}]}
+    result = prepare_worktree_step(task, ctx, adapters)
+    assert result.ok
+    assert len(wt.prepared) == 1
+    assert wt.prepared[0]["issue"] == 42
+    assert wt.prepared[0]["branch"] == "pbi-42"
+    assert wt.prepared[0]["base_branch"] == "develop"
+    assert wt.prepared[0]["repo"] == "owner/repo"
+
+
+def test_prepare_worktree_step_returns_worktree_path() -> None:
+    wt, adapters = _worktree_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    ctx = {"created": [{"subject": "S", "issue": 7}]}
+    result = prepare_worktree_step(task, ctx, adapters)
+    assert result.ok
+    assert result.data["prepared"][0]["worktree_path"] == "/mock/worktrees/pbi-7"
+    assert result.data["prepared"][0]["branch_name"] == "pbi-7"
+
+
+def test_prepare_worktree_step_dry_run_skips_adapter() -> None:
+    wt, adapters = _worktree_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", dry_run=True)
+    ctx = {"created": [{"subject": "S", "dry_run": True}]}
+    result = prepare_worktree_step(task, ctx, adapters)
+    assert result.ok
+    assert wt.prepared == []
+    assert result.data["prepared"][0]["worktree_skipped"] is True
+
+
+def test_prepare_worktree_step_custom_branch_prefix() -> None:
+    wt, adapters = _worktree_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", branch_prefix="feature")
+    ctx = {"created": [{"subject": "S", "issue": 99}]}
+    result = prepare_worktree_step(task, ctx, adapters)
+    assert result.ok
+    assert wt.prepared[0]["branch"] == "feature-99"
+
+
+def test_prepare_worktree_step_multiple_issues() -> None:
+    wt, adapters = _worktree_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    ctx = {"created": [{"subject": "A", "issue": 1}, {"subject": "B", "issue": 2}]}
+    result = prepare_worktree_step(task, ctx, adapters)
+    assert result.ok
+    assert len(wt.prepared) == 2
+    assert wt.prepared[0]["issue"] == 1
+    assert wt.prepared[1]["issue"] == 2
+
+
+def test_prepare_worktree_step_failure_returns_ok_false() -> None:
+    class FailingWorktree:
+        def prepare(self, repo: str, issue: int, base_branch: str, branch_name: str) -> str:
+            raise RuntimeError("git worktree add failed")
+
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter([]),
+        github=MockGitHubAdapter(),
+        labels=MockLabelAdapter(),
+        worktree=FailingWorktree(),
+    )
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    ctx = {"created": [{"subject": "S", "issue": 5}]}
+    result = prepare_worktree_step(task, ctx, adapters)
+    assert not result.ok
+    assert "prepare_worktree failed" in result.error
+    assert "git worktree add failed" in result.error
+
+
+def test_prepare_worktree_step_empty_created() -> None:
+    wt, adapters = _worktree_adapters()
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    result = prepare_worktree_step(task, {"created": []}, adapters)
+    assert result.ok
+    assert wt.prepared == []
+    assert result.data["prepared"] == []
+
+
+def test_bridge_pipeline_prepares_worktrees_for_created_issues() -> None:
+    """Full pipeline: worktree adapter called for each created issue."""
+    emails = [
+        _make_email("Product Backlog Item 20 - DEV - Feature C"),
+        _make_email("Product Backlog Item 21 - DEV - Feature D"),
+    ]
+    wt = MockWorktreePrepare()
+    adapters = BridgeAdapters(
+        email=MockEmailAdapter(emails),
+        github=MockGitHubAdapter(),
+        labels=MockLabelAdapter(),
+        worktree=wt,
+    )
+    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
+    result = bridge_pipeline(task, adapters)
+    assert result.ok
+    assert len(wt.prepared) == 2
+    assert wt.prepared[0]["branch"] == "pbi-1"
+    assert wt.prepared[1]["branch"] == "pbi-2"

--- a/src/claire_fivepoints/azure_issue_bridge/worktree.py
+++ b/src/claire_fivepoints/azure_issue_bridge/worktree.py
@@ -1,0 +1,171 @@
+"""azure_issue_bridge.worktree — WorktreePrepare adapter: Protocol + real/mock implementations.
+
+Responsible for creating a git worktree for a GitHub issue on a named branch
+before the issue is assigned to the agent.  The worktree is created at the
+standard path (<local_path>/.claire/worktrees/issue-<N>) so that claire start
+--issue N --repo R reuses it without re-creating (idempotent hand-off).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class WorktreePrepareAdapter(Protocol):
+    """Protocol for creating a git worktree before issue assignment."""
+
+    def prepare(
+        self,
+        repo: str,
+        issue: int,
+        base_branch: str,
+        branch_name: str,
+    ) -> str:
+        """Create a worktree on base_branch with a new branch branch_name.
+
+        Args:
+            repo:        GitHub repo slug, e.g. "CLAIRE-Fivepoints/fivepoints".
+            issue:       GitHub issue number.
+            base_branch: Branch to base the new branch on, e.g. "develop".
+            branch_name: Name of the new branch, e.g. "pbi-42".
+
+        Returns:
+            Absolute filesystem path to the created (or already-existing) worktree.
+
+        Raises:
+            RuntimeError: When the worktree cannot be created.
+        """
+        ...
+
+
+class RealWorktreePrepare:
+    """Creates a git worktree under <local_path>/.claire/worktrees/issue-<N>.
+
+    The local_path is resolved from ~/.config/claire/github_repos.yaml.  If not
+    found there, falls back to ~/.claire/repos/<owner>/<name> (auto-clone cache).
+    """
+
+    def __init__(self, local_path: str | Path | None = None) -> None:
+        self._local_path = str(local_path) if local_path is not None else None
+
+    def prepare(
+        self,
+        repo: str,
+        issue: int,
+        base_branch: str,
+        branch_name: str,
+    ) -> str:
+        local_path = Path(self._local_path or self._resolve_local_path(repo))
+        worktree_path = local_path / ".claire" / "worktrees" / f"issue-{issue}"
+
+        if worktree_path.exists():
+            logger.info("Worktree already exists at %s — reusing", worktree_path)
+            return str(worktree_path)
+
+        logger.info("Fetching %s from origin to get latest %s", repo, base_branch)
+        self._run(
+            ["git", "-C", str(local_path), "fetch", "origin", base_branch],
+            repo=repo,
+        )
+
+        logger.info(
+            "Creating worktree %s on branch %s (from origin/%s)",
+            worktree_path,
+            branch_name,
+            base_branch,
+        )
+        self._run(
+            [
+                "git",
+                "-C",
+                str(local_path),
+                "worktree",
+                "add",
+                "--track",
+                "-b",
+                branch_name,
+                str(worktree_path),
+                f"origin/{base_branch}",
+            ],
+            repo=repo,
+        )
+
+        logger.info("Worktree created at %s (branch: %s)", worktree_path, branch_name)
+        return str(worktree_path)
+
+    @staticmethod
+    def _run(cmd: list[str], *, repo: str) -> None:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"git command failed for {repo!r}: {' '.join(cmd)}\n"
+                f"stderr: {result.stderr.strip()}"
+            )
+
+    @staticmethod
+    def _resolve_local_path(repo: str) -> str:
+        """Resolve the local checkout path for repo from config or auto-clone cache."""
+        try:
+            import yaml  # type: ignore[import-untyped]
+
+            config = Path("~/.config/claire/github_repos.yaml").expanduser()
+            if config.exists():
+                with open(config) as f:
+                    data = yaml.safe_load(f)
+                for entry in (data or {}).get("repos", []):
+                    slug = f"{entry.get('owner', '')}/{entry.get('name', '')}"
+                    if slug == repo:
+                        lp = entry.get("local_path")
+                        if lp:
+                            return str(Path(lp).expanduser())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not read github_repos.yaml: %s", exc)
+
+        owner, name = repo.split("/", 1)
+        cache = Path("~/.claire/repos").expanduser() / owner / name
+        if cache.exists():
+            return str(cache)
+
+        raise RuntimeError(
+            f"Cannot resolve local path for repo {repo!r}. "
+            "Add a local_path entry in ~/.config/claire/github_repos.yaml "
+            "or ensure the auto-clone cache exists at ~/.claire/repos/<owner>/<name>."
+        )
+
+
+class MockWorktreePrepare:
+    """Test double for WorktreePrepareAdapter.
+
+    Records every prepare() call in self.prepared for assertion in tests.
+    Never touches the filesystem.
+    """
+
+    def __init__(self) -> None:
+        self.prepared: list[dict] = []
+
+    def prepare(
+        self,
+        repo: str,
+        issue: int,
+        base_branch: str,
+        branch_name: str,
+    ) -> str:
+        entry = {
+            "repo": repo,
+            "issue": issue,
+            "base_branch": base_branch,
+            "branch": branch_name,
+        }
+        self.prepared.append(entry)
+        logger.debug("MockWorktreePrepare.prepare called: %s", entry)
+        return f"/mock/worktrees/{branch_name}"


### PR DESCRIPTION
Closes #157

## Summary

- **New** `worktree.py` — `WorktreePrepareAdapter` Protocol, `RealWorktreePrepare` (git subprocess, idempotent), `MockWorktreePrepare` (records calls in `self.prepared`)
- **Updated** `adapters.py` — re-exports worktree types; adds `worktree: WorktreePrepareAdapter` field to `BridgeAdapters`
- **Updated** `steps.py` — `prepare_worktree_step` iterates `ctx["created"]`, calls `adapters.worktree.prepare()` per issue; dry-run skips adapter; failure → `ok=False`, pipeline aborted (no assignment)
- **Updated** `pipeline.py` — `branch_prefix: str = "pbi"` added to `BridgeTask`; step inserted after `add_label_step` (sync_branch_step slot reserved for #156)

## Design notes

- `RealWorktreePrepare` resolves `local_path` from `~/.config/claire/github_repos.yaml`, falls back to `~/.claire/repos/<owner>/<name>`. Worktree directory: `<local_path>/.claire/worktrees/issue-{N}` (matches claire start convention). Branch: `pbi-{N}` by default, configurable via `task.branch_prefix`.
- Idempotent: if the worktree directory already exists, `prepare()` returns the path without running git again.
- `BridgeAdapters` now requires `worktree=`. All existing test helpers updated to include `worktree=MockWorktreePrepare()`.

## Verification Log

```
$ uv run pytest src/claire_fivepoints/azure_issue_bridge/tests/ -v
...
test_prepare_worktree_step_calls_adapter PASSED
test_prepare_worktree_step_returns_worktree_path PASSED
test_prepare_worktree_step_dry_run_skips_adapter PASSED
test_prepare_worktree_step_custom_branch_prefix PASSED
test_prepare_worktree_step_multiple_issues PASSED
test_prepare_worktree_step_failure_returns_ok_false PASSED
test_prepare_worktree_step_empty_created PASSED
test_bridge_pipeline_prepares_worktrees_for_created_issues PASSED
============================== 81 passed in 0.22s ==============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6KFDLAXUGksBvrhiqcHfm