### PR TITLE
fix(bridge): retirer prepare_worktree_step du pipeline

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -28,11 +28,11 @@ ADO PBI assigned to andre.perez@dothelpllc.com
   → creates GitHub issue in ADO_BRIDGE_SYNC_TARGET repo
   → adds role label: role:{ADO_BRIDGE_CLIENT}-dev
   → syncs ADO_BRIDGE_SYNC_SOURCE/develop → ADO_BRIDGE_SYNC_TARGET/develop (GitHub REST API)
-  → creates git worktree at <local>/.claire/worktrees/issue-{N} on branch pbi-{N}  ← BEFORE assignment
   → assigns issue to ADO_BRIDGE_AGENT                                                ← ALWAYS LAST
   → archives email in Gmail
-  → claire spawn daemon (consumer.py) detects assignment, finds worktree already prepared
-  → launches Claire agent in the pre-created worktree (no re-creation)
+  → claire spawn daemon (consumer.py) detects assignment
+  → creates git worktree at <local>/.claire/worktrees/issue-{N} on branch pbi-{N}
+  → launches Claire agent in the worktree
   → agent receives CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET> for wait/PR targeting
 ```
 
@@ -104,18 +104,15 @@ Gmail inbox
 
 ## Spawn Daemon Pickup
 
-After the bridge creates the GitHub issue, adds the role label, creates the worktree, and assigns the issue, the **claire spawn daemon** (`consumer.py`) takes over:
+After the bridge creates the GitHub issue, adds the role label, syncs the branch, and assigns the issue, the **claire spawn daemon** (`consumer.py`) takes over:
 
 1. The spawn daemon monitors `ADO_BRIDGE_SYNC_TARGET` for newly assigned issues
-2. When it detects the assignment to `ADO_BRIDGE_AGENT`, it looks for an existing worktree at `.claire/worktrees/issue-{N}` — the bridge has already created it
-3. A Claire agent is launched **inside the pre-created worktree** (no re-creation); `claire start --issue N` is idempotent when the worktree already exists
+2. When it detects the assignment to `ADO_BRIDGE_AGENT`, it creates an isolated git worktree at `.claire/worktrees/issue-{N}` on branch `pbi-{N}`
+3. A Claire agent is launched inside the worktree with the issue as its task
 4. The agent receives `CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET>` in its environment so `claire wait` targets the correct repo for PR creation and review polling
 
-**Why the bridge creates the worktree before assigning:**
-The spawn daemon used to create the worktree on detection. Moving worktree creation into the bridge (before assignment) means the agent starts on a branch that already exists, avoiding a race between branch creation and the first `git push`.
-
 **`ADO_BRIDGE_SYNC_TARGET` vs `CLAIRE_WAIT_REPO`:**
-- `ADO_BRIDGE_SYNC_TARGET` — configures where the bridge creates GitHub issues and the worktree (set at bridge/operator level)
+- `ADO_BRIDGE_SYNC_TARGET` — configures where the bridge creates GitHub issues (set at bridge/operator level)
 - `CLAIRE_WAIT_REPO` — passed by the spawn daemon into the spawned agent's environment so the agent knows which repo to watch for wait events
 - Both refer to the same repo; they are different variable names at different stages of the pipeline
 

--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -75,9 +75,6 @@ Gmail inbox
   → gh issue edit --add-label role:{ADO_BRIDGE_CLIENT}-dev
   → sync ADO_BRIDGE_SYNC_SOURCE/<branch> → ADO_BRIDGE_SYNC_TARGET/<branch> (GitHub REST API)
       → failure aborts pipeline for this PBI (no archiving, no agent assignment)
-  → git worktree add -b pbi-{N} <local>/.claire/worktrees/issue-{N} origin/develop
-      → worktree created BEFORE issue assignment
-      → failure aborts pipeline (no archiving, no agent assignment)
   → gh issue edit --add-assignee <ADO_BRIDGE_AGENT>  ← ALWAYS LAST
   → persist all email IDs for this PBI to ~/.claire/azure-issue-bridge/processed.json
   → archive all emails for this PBI in Gmail (remove INBOX label)

--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -188,7 +188,7 @@ The command:
 1. Constructs an `EmailMessage` from `--from` and `--subject`
 2. Validates it with `is_pbi_email()` (subject must match the ADO PBI pattern)
 3. Builds a synthetic `WorkItem` from the parsed subject (no ADO fetch — subject data only)
-4. In live mode: runs the full pipeline — `create_issue → add_label → sync_branch → prepare_worktree → assign` (GitHub auth required, no Gmail or ADO auth)
+4. In live mode: runs the full pipeline — `create_issue → add_label → sync_branch → assign` (GitHub auth required, no Gmail or ADO auth)
 5. In `--dry-run` mode: prints the parsed PBI and the planned pipeline steps, creates nothing
 
 ```bash

--- a/src/claire_fivepoints/azure_issue_bridge/pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/pipeline.py
@@ -10,7 +10,6 @@ from claire_fivepoints.azure_issue_bridge.steps import (
     create_issues_step,
     fetch_emails_step,
     filter_pbi_step,
-    prepare_worktree_step,
     sync_branch_step,
 )
 
@@ -32,6 +31,5 @@ bridge_pipeline = pipe(
     create_issues_step,
     add_label_step,
     sync_branch_step,
-    prepare_worktree_step,
     assign_step,         # ← LAST — triggers session-monitor
 )

--- a/src/claire_fivepoints/azure_issue_bridge/tests/test_inject.py
+++ b/src/claire_fivepoints/azure_issue_bridge/tests/test_inject.py
@@ -5,10 +5,10 @@ Tests cover:
 - parse_subject_parts() extracts (area, title) from ADO subject formats
 - _cmd_inject dry-run: prints parsed result + full pipeline plan, no side effects
 - _cmd_inject live mode: runs full pipeline (create_issue, add_label, sync_branch,
-  prepare_worktree, assign) in order, with cleanup commands in output
+  assign) in order, with cleanup commands in output
 - _cmd_inject rejects non-PBI subjects
 - _cmd_inject --repo and --agent overrides
-- _cmd_inject aborts and returns 1 on each step failure (no assignment if worktree fails)
+- _cmd_inject aborts and returns 1 on each step failure
 """
 
 from __future__ import annotations
@@ -118,8 +118,8 @@ class TestCmdInjectDryRun:
         assert "create_issue" in out
         assert "add_label" in out
         assert "sync_branch" in out
-        assert "prepare_worktree" in out
         assert "assign" in out
+        assert "prepare_worktree" not in out
 
     def test_dry_run_no_gh_calls(self) -> None:
         args = _make_args(dry_run=True)
@@ -162,24 +162,17 @@ class TestCmdInjectLive:
             patch("azure_issue_bridge.bridge.add_issue_label") as mock_label,
             patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
             patch(
-                "azure_issue_bridge.worktree.RealWorktreePrepare"
-            ) as MockWorktreeClass,
-            patch(
                 "azure_issue_bridge.bridge.assign_github_issue"
             ) as mock_assign,
         ):
             mock_sync = MagicMock()
             MockSyncClass.return_value = mock_sync
-            mock_worktree = MagicMock()
-            mock_worktree.prepare.return_value = f"/mock/worktrees/pbi-{issue_number}"
-            MockWorktreeClass.return_value = mock_worktree
 
             rc = cmd_inject(args)
             return rc, {
                 "create": mock_create,
                 "label": mock_label,
                 "sync": mock_sync,
-                "worktree": mock_worktree,
                 "assign": mock_assign,
             }
 
@@ -209,19 +202,12 @@ class TestCmdInjectLive:
         _, mocks = self._run_live(_make_args())
         mocks["sync"].sync_branch.assert_called_once()
 
-    def test_worktree_prepare_called_with_pbi_branch(self) -> None:
-        _, mocks = self._run_live(_make_args(), issue_number=99)
-        mocks["worktree"].prepare.assert_called_once()
-        kw = mocks["worktree"].prepare.call_args[1]
-        assert kw["branch_name"] == "pbi-99"
-        assert kw["issue"] == 99
-
     def test_assign_called_with_agent(self) -> None:
         _, mocks = self._run_live(_make_args())
         mocks["assign"].assert_called_once()
 
-    def test_pipeline_order_label_sync_worktree_assign(self) -> None:
-        """Verify execution order: label → sync → worktree → assign."""
+    def test_pipeline_order_label_sync_assign(self) -> None:
+        """Verify execution order: label → sync → assign."""
         call_order: list[str] = []
         fake = _fake_issue(42)
 
@@ -235,9 +221,6 @@ class TestCmdInjectLive:
             ),
             patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
             patch(
-                "azure_issue_bridge.worktree.RealWorktreePrepare"
-            ) as MockWorktreeClass,
-            patch(
                 "azure_issue_bridge.bridge.assign_github_issue",
                 side_effect=lambda *a, **kw: call_order.append("assign"),
             ),
@@ -247,16 +230,11 @@ class TestCmdInjectLive:
                 lambda *a, **kw: call_order.append("sync")
             )
             MockSyncClass.return_value = mock_sync
-            mock_worktree = MagicMock()
-            mock_worktree.prepare.side_effect = (
-                lambda *a, **kw: call_order.append("worktree") or "/mock/path"
-            )
-            MockWorktreeClass.return_value = mock_worktree
 
             rc = cmd_inject(_make_args())
 
         assert rc == 0
-        assert call_order == ["label", "sync", "worktree", "assign"]
+        assert call_order == ["label", "sync", "assign"]
 
     def test_happy_path_prints_summary(
         self, capsys: pytest.CaptureFixture
@@ -266,18 +244,10 @@ class TestCmdInjectLive:
         assert "✓ Pipeline complet" in out
         assert "Issue créée" in out
         assert "Label" in out
-        assert "Branch" in out
         assert "Assigné à" in out
         assert "Pour nettoyer" in out
         assert "gh issue close 151" in out
-
-    def test_happy_path_prints_worktree_path(
-        self, capsys: pytest.CaptureFixture
-    ) -> None:
-        self._run_live(_make_args(), issue_number=42)
-        out = capsys.readouterr().out
-        assert "/mock/worktrees/pbi-42" in out
-        assert "git worktree remove" in out
+        assert "git worktree remove" not in out
 
     def test_live_prints_issue_url(self, capsys: pytest.CaptureFixture) -> None:
         self._run_live(_make_args(), issue_number=99)
@@ -300,13 +270,9 @@ class TestCmdInjectLive:
             ),
             patch("azure_issue_bridge.bridge.add_issue_label"),
             patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
-            patch("azure_issue_bridge.worktree.RealWorktreePrepare") as MockWorktreeClass,
             patch("azure_issue_bridge.bridge.assign_github_issue"),
         ):
             MockSyncClass.return_value = MagicMock()
-            mock_wt = MagicMock()
-            mock_wt.prepare.return_value = "/mock/path"
-            MockWorktreeClass.return_value = mock_wt
             cmd_inject(args)
 
         assert captured_env["ADO_BRIDGE_REPO"] == "CLAIRE-Fivepoints/fivepoints-test"
@@ -362,34 +328,6 @@ class TestCmdInjectLive:
         out = capsys.readouterr().out
         assert "sync_branch failed" in out
 
-    def test_prepare_worktree_failure_exits_1_no_assign(
-        self, capsys: pytest.CaptureFixture
-    ) -> None:
-        fake = _fake_issue(1)
-        with (
-            patch(
-                "azure_issue_bridge.bridge.create_github_issue", return_value=fake
-            ),
-            patch("azure_issue_bridge.bridge.add_issue_label"),
-            patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
-            patch(
-                "azure_issue_bridge.worktree.RealWorktreePrepare"
-            ) as MockWorktreeClass,
-            patch(
-                "azure_issue_bridge.bridge.assign_github_issue"
-            ) as mock_assign,
-        ):
-            MockSyncClass.return_value = MagicMock()
-            mock_wt = MagicMock()
-            mock_wt.prepare.side_effect = RuntimeError("git failed")
-            MockWorktreeClass.return_value = mock_wt
-            rc = cmd_inject(_make_args())
-
-        assert rc == 1
-        out = capsys.readouterr().out
-        assert "prepare_worktree failed" in out
-        mock_assign.assert_not_called()
-
     def test_assign_failure_exits_1(
         self, capsys: pytest.CaptureFixture
     ) -> None:
@@ -401,17 +339,11 @@ class TestCmdInjectLive:
             patch("azure_issue_bridge.bridge.add_issue_label"),
             patch("azure_issue_bridge.sync.RealBranchSync") as MockSyncClass,
             patch(
-                "azure_issue_bridge.worktree.RealWorktreePrepare"
-            ) as MockWorktreeClass,
-            patch(
                 "azure_issue_bridge.bridge.assign_github_issue",
                 side_effect=RuntimeError("assignee not found"),
             ),
         ):
             MockSyncClass.return_value = MagicMock()
-            mock_wt = MagicMock()
-            mock_wt.prepare.return_value = "/mock/path"
-            MockWorktreeClass.return_value = mock_wt
             rc = cmd_inject(_make_args())
 
         assert rc == 1

--- a/src/claire_fivepoints/azure_issue_bridge/tests/test_inject.py
+++ b/src/claire_fivepoints/azure_issue_bridge/tests/test_inject.py
@@ -244,6 +244,7 @@ class TestCmdInjectLive:
         assert "✓ Pipeline complet" in out
         assert "Issue créée" in out
         assert "Label" in out
+        assert "Branch" in out
         assert "Assigné à" in out
         assert "Pour nettoyer" in out
         assert "gh issue close 151" in out

--- a/src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py
@@ -20,6 +20,11 @@ from claire_fivepoints.azure_issue_bridge.steps import (
     sync_branch_step,
 )
 
+# ---------------------------------------------------------------------------
+# NOTE: prepare_worktree_step is intentionally NOT in bridge_pipeline.
+# Its unit tests (below) remain because the step itself is preserved.
+# ---------------------------------------------------------------------------
+
 _ADO_SENDER = "azuredevops@microsoft.com"
 _TEST_SENDER = "andreoperez@gmail.com"
 
@@ -517,27 +522,6 @@ def test_prepare_worktree_step_empty_created() -> None:
     assert result.data["prepared"] == []
 
 
-def test_bridge_pipeline_prepares_worktrees_for_created_issues() -> None:
-    """Full pipeline: worktree adapter called for each created issue."""
-    emails = [
-        _make_email("Product Backlog Item 20 - DEV - Feature C"),
-        _make_email("Product Backlog Item 21 - DEV - Feature D"),
-    ]
-    wt = MockWorktreePrepare()
-    adapters = BridgeAdapters(
-        email=MockEmailAdapter(emails),
-        github=MockGitHubAdapter(),
-        labels=MockLabelAdapter(),
-        branch_sync=MockBranchSync(),
-        worktree=wt,
-        assign=MockAssignAdapter(),
-    )
-    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
-    result = bridge_pipeline(task, adapters)
-    assert result.ok
-    assert len(wt.prepared) == 2
-    assert wt.prepared[0]["branch"] == "pbi-1"
-    assert wt.prepared[1]["branch"] == "pbi-2"
 
 
 # ---------------------------------------------------------------------------
@@ -618,44 +602,12 @@ def test_assign_step_custom_agent() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Pipeline order — assign called after prepare_worktree, never before
+# Pipeline order — assign is last step
 # ---------------------------------------------------------------------------
 
 
-def test_pipeline_assign_called_after_prepare_worktree() -> None:
-    """assign is always called after prepare_worktree in the full pipeline."""
-    call_order: list[str] = []
-
-    class OrderedWorktree:
-        def prepare(self, repo, issue, base_branch, branch_name):
-            call_order.append("prepare_worktree")
-            return f"/mock/{branch_name}"
-
-    class OrderedAssign:
-        def assign(self, repo, issue, agent):
-            call_order.append("assign")
-
-    emails = [_make_email("Product Backlog Item 5 - DEV - Title")]
-    adapters = BridgeAdapters(
-        email=MockEmailAdapter(emails),
-        github=MockGitHubAdapter(),
-        labels=MockLabelAdapter(),
-        branch_sync=MockBranchSync(),
-        worktree=OrderedWorktree(),
-        assign=OrderedAssign(),
-    )
-    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
-    result = bridge_pipeline(task, adapters)
-    assert result.ok
-    assert call_order == ["prepare_worktree", "assign"]
-    prepare_idx = call_order.index("prepare_worktree")
-    assign_idx = call_order.index("assign")
-    assert prepare_idx < assign_idx, "assign must be called after prepare_worktree"
-
-
 def test_pipeline_full_end_to_end() -> None:
-    """Full pipeline: email → issue → label → sync → worktree → assign."""
-    wt = MockWorktreePrepare()
+    """Full pipeline: email → issue → label → sync → assign."""
     a = MockAssignAdapter()
     emails = [_make_email("Product Backlog Item 99 - DEV - My Feature")]
     adapters = BridgeAdapters(
@@ -663,49 +615,22 @@ def test_pipeline_full_end_to_end() -> None:
         github=MockGitHubAdapter(),
         labels=MockLabelAdapter(),
         branch_sync=MockBranchSync(),
-        worktree=wt,
+        worktree=MockWorktreePrepare(),
         assign=a,
     )
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", agent="claire-test-ai")
     result = bridge_pipeline(task, adapters)
     assert result.ok
-    assert len(wt.prepared) == 1
-    assert wt.prepared[0]["branch"] == "pbi-1"
     assert len(a.assignments) == 1
     assert a.assignments[0]["agent"] == "claire-test-ai"
     assert a.assignments[0]["issue"] == 1
 
 
-def test_pipeline_worktree_failure_aborts_before_assign() -> None:
-    """prepare_worktree failure aborts — assign is never called."""
-    class FailingWorktree:
-        def prepare(self, repo, issue, base_branch, branch_name):
-            raise RuntimeError("disk full")
-
-    a = MockAssignAdapter()
-    emails = [_make_email("Product Backlog Item 3 - DEV - Title")]
-    adapters = BridgeAdapters(
-        email=MockEmailAdapter(emails),
-        github=MockGitHubAdapter(),
-        labels=MockLabelAdapter(),
-        branch_sync=MockBranchSync(),
-        worktree=FailingWorktree(),
-        assign=a,
-    )
-    task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo")
-    result = bridge_pipeline(task, adapters)
-    assert not result.ok
-    assert "prepare_worktree failed" in result.error
-    assert a.assignments == []
-
-
-def test_pipeline_dry_run_skips_worktree_and_assign() -> None:
-    wt = MockWorktreePrepare()
+def test_pipeline_dry_run_skips_assign() -> None:
     a = MockAssignAdapter()
     emails = [_make_email("Product Backlog Item 4 - DEV - Title")]
-    adapters = _make_adapters(emails, worktree=wt, assign=a)
+    adapters = _make_adapters(emails, assign=a)
     task = BridgeTask(sender=_ADO_SENDER, repo="owner/repo", dry_run=True)
     result = bridge_pipeline(task, adapters)
     assert result.ok
-    assert wt.prepared == []
     assert a.assignments == []

--- a/src/claire_fivepoints/cli.py
+++ b/src/claire_fivepoints/cli.py
@@ -389,9 +389,8 @@ def bridge_run_cmd(
 def _cmd_inject(args: argparse.Namespace) -> int:
     """Feed a synthetic email into the bridge pipeline without Gmail or ADO auth.
 
-    Runs the full pipeline: create_issue → add_label → sync_branch →
-    prepare_worktree → assign. No cleanup is performed — use the displayed
-    commands to clean up manually.
+    Runs the full pipeline: create_issue → add_label → sync_branch → assign.
+    No cleanup is performed — use the displayed commands to clean up manually.
     """
     from azure_issue_bridge.bridge import (
         WorkItem,
@@ -404,7 +403,6 @@ def _cmd_inject(args: argparse.Namespace) -> int:
         parse_subject_parts,
     )
     from azure_issue_bridge.sync import RealBranchSync
-    from azure_issue_bridge.worktree import RealWorktreePrepare
 
     msg = SimpleNamespace(subject=args.subject, message_id="inject")
     if not is_pbi_email(msg):
@@ -461,8 +459,7 @@ def _cmd_inject(args: argparse.Namespace) -> int:
         print(
             f"  3. sync_branch    → {config.source_repo}/{sync_branch} → {repo}/{sync_branch}"
         )
-        print(f"  4. prepare_worktree → branch pbi-<N>")
-        print(f"  5. assign         → {agent}")
+        print(f"  4. assign         → {agent}")
         return 0
 
     _prev_repo = os.environ.get("ADO_BRIDGE_REPO")
@@ -491,20 +488,6 @@ def _cmd_inject(args: argparse.Namespace) -> int:
         print(f"✗ sync_branch failed: {exc}")
         return 1
 
-    branch_name = f"pbi-{issue.number}"
-    worktree_prepare = RealWorktreePrepare()
-    worktree_path = ""
-    try:
-        worktree_path = worktree_prepare.prepare(
-            repo=repo,
-            issue=issue.number,
-            base_branch=sync_branch,
-            branch_name=branch_name,
-        )
-    except RuntimeError as exc:
-        print(f"✗ prepare_worktree failed: {exc}")
-        return 1
-
     try:
         assign_github_issue(repo, issue.number, agent)
     except RuntimeError as exc:
@@ -517,14 +500,9 @@ def _cmd_inject(args: argparse.Namespace) -> int:
     print(
         f"Branch sync   : {config.source_repo}/{sync_branch} → {repo}/{sync_branch}"
     )
-    print(f"Branch        : {branch_name}")
-    if worktree_path:
-        print(f"Worktree      : {worktree_path}")
     print(f"Assigné à     : {agent}")
     print(f"\nPour nettoyer :")
     print(f"  gh issue close {issue.number} --repo {repo}")
-    if worktree_path:
-        print(f"  git worktree remove {worktree_path}")
     return 0
 
 

--- a/src/claire_fivepoints/domain/fivepoints/operational/AZURE_ISSUE_BRIDGE.md
+++ b/src/claire_fivepoints/domain/fivepoints/operational/AZURE_ISSUE_BRIDGE.md
@@ -211,7 +211,7 @@ The bash router prepends `domain/scripts` to `PYTHONPATH` so the package is impo
 |------|------|
 | `plugins/fivepoints/src/claire_fivepoints/azure_issue_bridge/bridge.py` | `is_pbi_email()` predicate + `MockEmailFilter` |
 | `plugins/fivepoints/src/claire_fivepoints/azure_issue_bridge/adapters.py` | `EmailAdapter`, `GitHubAdapter`, `LabelAdapter`, `BranchSyncAdapter`, `WorktreePrepareAdapter`, `AssignAdapter` protocols + `BridgeAdapters` + test doubles (`MockWorktreePrepare`, `MockAssignAdapter`, …) |
-| `plugins/fivepoints/src/claire_fivepoints/azure_issue_bridge/steps.py` | Pure pipeline steps: `fetch_emails_step`, `filter_pbi_step`, `create_issues_step`, `add_label_step`, `sync_branch_step`, `prepare_worktree_step`, `assign_step` |
+| `plugins/fivepoints/src/claire_fivepoints/azure_issue_bridge/steps.py` | Pure pipeline steps: `fetch_emails_step`, `filter_pbi_step`, `create_issues_step`, `add_label_step`, `sync_branch_step`, `assign_step` (`prepare_worktree_step` preserved but not in the pipeline) |
 | `plugins/fivepoints/src/claire_fivepoints/azure_issue_bridge/pipeline.py` | `BridgeTask` + `bridge_pipeline = pipe(...)` |
 | `src/claire_fivepoints/cli.py` | CLI entry point — `fivepoints azure-issue-bridge run [--from] [--repo] [--dry-run]` and `fivepoints azure-issue-bridge inject [--from] [--subject] [--dry-run] [--repo] [--agent]`; concrete subprocess adapters |
 | `src/claire_fivepoints/azure_issue_bridge/tests/` | Unit tests for email filtering, pipeline, and inject (zero subprocess, zero network) |


### PR DESCRIPTION
Closes #168

## Summary

- Retire `prepare_worktree_step` de `bridge_pipeline` (`pipeline.py`)
- Retire le bloc worktree de `_cmd_inject` dans `cli.py` (import, exécution, affichage, nettoyage)
- Adapte les tests : supprime les assertions qui vérifient la présence du step dans le pipeline ; conserve les tests unitaires du step lui-même

Pipeline résultant : `fetch → filter → create_issue → add_label → sync_branch → assign`

Step et adapters (`prepare_worktree_step`, `MockWorktreePrepare`, `RealWorktreePrepare`) conservés intacts.

## Verification Log

```
$ uv run pytest src/claire_fivepoints/azure_issue_bridge/tests/test_pipeline.py \
                src/claire_fivepoints/azure_issue_bridge/tests/test_inject.py -v
...
66 passed in 0.55s

$ uv run pytest -v (suite complète)
...
8 failed (préexistants, liés à yaml/ado_fetch_attachments), 324 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wY2u33Am3kr9myrUz3hV9