### PR TITLE
docs(bridge): add env vars section and production examples in --agent-help

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -223,7 +223,7 @@ When `AZURE_DEVOPS_PAT` is set (env or `~/.config/claire/.env`), `claire infra s
 Each issue is created with:
 - **Title:** `{PBI title} (PBI #{id})`
 - **Body:** ADO link, state, area path, description, acceptance criteria (when available)
-- **Repo:** configured via `ADO_BRIDGE_REPO` (default: `claire-labs/fivepoints-test`)
+- **Repo:** configured via `ADO_BRIDGE_REPO` (default: `CLAIRE-Fivepoints/fivepoints`)
 
 ---
 
@@ -235,7 +235,7 @@ Before the bridge can run, three things must be in place:
 |-------------|-----------------|---------------|
 | `AZURE_DEVOPS_PAT` | Fetch PBI details from ADO REST API | Set in `~/.config/claire/.env` or export in shell |
 | Gmail OAuth2 | Read + archive Gmail inbox | Run `claire email auth` (one-time browser flow) |
-| `ADO_BRIDGE_REPO` | Where GitHub issues are created | Set in `~/.config/claire/.env`; defaults to `claire-labs/fivepoints-test` |
+| `ADO_BRIDGE_REPO` | Where GitHub issues are created | Set in `~/.config/claire/.env`; defaults to `CLAIRE-Fivepoints/fivepoints` |
 
 ---
 
@@ -263,7 +263,7 @@ The azure-issue-bridge uses `AZURE_DEVOPS_PAT`. The fivepoints plugin (`ado_comm
 |----------|---------|-------------|
 | `AZURE_DEVOPS_PAT` | _(required)_ | Read-only PAT for issue bridge — auto-starts daemon via `claire infra start` when set |
 | `AZURE_DEVOPS_DEV_PAT` | _(optional)_ | Full-access PAT for fivepoints plugin — falls back to `AZURE_DEVOPS_PAT` |
-| `ADO_BRIDGE_REPO` | `claire-labs/fivepoints-test` | Target GitHub repo for created issues (also sets `CLAIRE_WAIT_REPO` in spawned agents) |
+| `ADO_BRIDGE_REPO` | `CLAIRE-Fivepoints/fivepoints` | Target GitHub repo for created issues (also sets `CLAIRE_WAIT_REPO` in spawned agents) |
 | `ADO_ORG` | `FivePointsTechnology` | Azure DevOps organization |
 | `ADO_PROJECT` | `TFIOne` | Azure DevOps project |
 | `ADO_BRIDGE_HOUR_START` | `8` | Business hours start (local time, inclusive) |
@@ -271,7 +271,7 @@ The azure-issue-bridge uses `AZURE_DEVOPS_PAT`. The fivepoints plugin (`ado_comm
 | `PBI_SENDER` | `azuredevops@microsoft.com` | Override the production ADO sender. Use when ADO notifications come from a custom address. Falls back to the ADO default when unset. |
 | `ADO_BRIDGE_AGENT` | `claire-test-ai` | GitHub username assigned to each new issue. **Set this explicitly in production** — the default targets the test account. |
 | `ADO_BRIDGE_CLIENT` | `fivepoints` | Client slug used to build the role label: `role:{ADO_BRIDGE_CLIENT}-dev`. Determines which agent persona is activated by the spawn daemon. |
-| `ADO_BRIDGE_SYNC_SOURCE` | `CLAIRE-Fivepoints/fivepoints-test` | Source GitHub repo for branch sync (the repo Claire agents push to). |
+| `ADO_BRIDGE_SYNC_SOURCE` | `CLAIRE-Fivepoints/fivepoints` | Source GitHub repo for branch sync (the repo Claire agents push to). |
 | `ADO_BRIDGE_SYNC_TARGET` | `CLAIRE-Fivepoints/fivepoints` | Target GitHub repo where issues are created, where the worktree branch is pushed, and where the issue is assigned. |
 | `ADO_BRIDGE_SYNC_BRANCH` | `develop` | Branch name synced from source to target (legacy scripts only). The Python package (`claire fivepoints azure-issue-bridge`) hardcodes `develop` in `sync_branch_step`; this variable has no effect on the Typer CLI. |
 

--- a/src/claire_fivepoints/cli.py
+++ b/src/claire_fivepoints/cli.py
@@ -51,14 +51,21 @@ _BRIDGE_AGENT_HELP = """\
   claire fivepoints azure-issue-bridge run [--from SENDER] [--repo owner/name] [--dry-run] [--max-results N] [--client SLUG] [--source-repo OWNER/REPO]
   claire fivepoints azure-issue-bridge inject --from ADDRESS --subject SUBJECT [--dry-run] [--repo OWNER/NAME] [--agent USERNAME]
 
+## Required env vars
+
+  GH_TOKEN              GitHub token — required for gh issue create / gh issue edit
+                        (or GITHUB_TOKEN; gh CLI picks up either)
+  ADO_BRIDGE_SYNC_SOURCE  Override --source-repo (e.g. CLAIRE-Fivepoints/fivepoints)
+  ADO_BRIDGE_CLIENT       Override --client slug (e.g. fivepoints)
+
 ## Options (run)
 
   --from TEXT       Sender email filter (default: azuredevops@microsoft.com)
-  --repo TEXT       Target GitHub repo (default: claire-labs/fivepoints-test)
+  --repo TEXT       Target GitHub repo (default: CLAIRE-Fivepoints/fivepoints)
   --dry-run         Show detected emails without creating issues
   --max-results N   Max inbox emails to scan (default: 20)
-  --client SLUG        Client slug for the role:{client}-dev label (default: fivepoints)
-  --source-repo TEXT   Source repo for branch sync (default: CLAIRE-Fivepoints/fivepoints-test, envvar: ADO_BRIDGE_SYNC_SOURCE)
+  --client SLUG     Client slug for the role:{client}-dev label (default: fivepoints, envvar: ADO_BRIDGE_CLIENT)
+  --source-repo TEXT  Source repo for branch sync (default: CLAIRE-Fivepoints/fivepoints, envvar: ADO_BRIDGE_SYNC_SOURCE)
 
 ## Options (inject)
 
@@ -72,12 +79,29 @@ _BRIDGE_AGENT_HELP = """\
 
   Product Backlog Item {ID} - {area} - {title}
 
-## Example
+## Examples
 
-  fivepoints azure-issue-bridge run --from andreoperez@gmail.com --dry-run
-  fivepoints azure-issue-bridge run --repo claire-labs/fivepoints-test
-  fivepoints azure-issue-bridge inject --from azuredevops@microsoft.com \\
-    --subject "Product Backlog Item 12345 - DEV - Client Management test" --dry-run
+  # dry-run — vérifier les emails détectés sans créer d'issues
+  claire fivepoints azure-issue-bridge run --dry-run
+
+  # run réel — créer les issues GitHub depuis les emails ADO
+  claire fivepoints azure-issue-bridge run
+
+  # run avec repo et sender explicites
+  claire fivepoints azure-issue-bridge run \\
+    --from azuredevops@microsoft.com \\
+    --repo CLAIRE-Fivepoints/fivepoints
+
+  # inject dry-run — tester le parsing sans Gmail ni ADO
+  claire fivepoints azure-issue-bridge inject \\
+    --from azuredevops@microsoft.com \\
+    --subject "Product Backlog Item 12345 - DEV - Client Management" \\
+    --dry-run
+
+  # inject réel — pipeline complet (create issue → label → sync → worktree → assign)
+  claire fivepoints azure-issue-bridge inject \\
+    --from azuredevops@microsoft.com \\
+    --subject "Product Backlog Item 12345 - DEV - Client Management"
 """
 
 _STEP_AGENT_HELP = """\
@@ -325,7 +349,7 @@ def bridge_run_cmd(
         help="Sender email filter (ADO default).",
     ),
     repo: str = typer.Option(
-        "claire-labs/fivepoints-test", "--repo",
+        "CLAIRE-Fivepoints/fivepoints", "--repo",
         help="Target GitHub repo (owner/name).",
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show detected emails without creating issues."),
@@ -335,7 +359,7 @@ def bridge_run_cmd(
         help="Client slug for the role:{client}-dev label.",
     ),
     source_repo: str = typer.Option(
-        "CLAIRE-Fivepoints/fivepoints-test", "--source-repo", envvar="ADO_BRIDGE_SYNC_SOURCE",
+        "CLAIRE-Fivepoints/fivepoints", "--source-repo", envvar="ADO_BRIDGE_SYNC_SOURCE",
         help="Source repo for branch sync (develop → target/develop).",
     ),
     agent: str = typer.Option(


### PR DESCRIPTION
## Summary

- Add `## Required env vars` section in `_BRIDGE_AGENT_HELP` listing `GH_TOKEN`, `ADO_BRIDGE_SYNC_SOURCE`, `ADO_BRIDGE_CLIENT`
- Expand `## Examples` (renamed from `## Example`) with 5 production-ready examples: dry-run, real run, explicit run, inject dry-run, inject real
- Fix `--repo` default: `claire-labs/fivepoints-test` → `CLAIRE-Fivepoints/fivepoints`
- Fix `--source-repo` default: `CLAIRE-Fivepoints/fivepoints-test` → `CLAIRE-Fivepoints/fivepoints`

Closes #170

## Verification Log

```
$ uv run python -c "from claire_fivepoints.cli import bridge_app; ..."
# claire fivepoints azure-issue-bridge

## Required env vars

  GH_TOKEN              GitHub token — required for gh issue create / gh issue edit
                        (or GITHUB_TOKEN; gh CLI picks up either)
  ADO_BRIDGE_SYNC_SOURCE  Override --source-repo (e.g. CLAIRE-Fivepoints/fivepoints)
  ADO_BRIDGE_CLIENT       Override --client slug (e.g. fivepoints)

## Options (run)

  --repo TEXT       Target GitHub repo (default: CLAIRE-Fivepoints/fivepoints)
  ...

## Examples

  # dry-run — vérifier les emails détectés sans créer d'issues
  claire fivepoints azure-issue-bridge run --dry-run

  # run réel — créer les issues GitHub depuis les emails ADO
  claire fivepoints azure-issue-bridge run

  # inject réel — pipeline complet (create issue → label → sync → worktree → assign)
  claire fivepoints azure-issue-bridge inject \
    --from azuredevops@microsoft.com \
    --subject "Product Backlog Item 12345 - DEV - Client Management"
```

Tests: 112 passed (7 pre-existing failures on yaml import unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrFXkAuNEDLDRx2aM83po9