### PR TITLE
feat: PrepareWorktreeStep — branch feature/{pbi_id}-{slug} + méta dans l'issue GitHub

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -3,8 +3,8 @@ domain: fivepoints
 category: operational
 name: AZURE_ISSUE_BRIDGE
 title: "Five Points — Azure DevOps Email Bridge (PBI Assignment → GitHub Issue Pipeline)"
-keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_SENDER, configurable-sender, branch-sync, inject, synthetic-email, ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH, ADO_BRIDGE_AGENT, ADO_BRIDGE_CLIENT, worktree, role-label]
-updated: 2026-06-29
+keywords: [five-points, azure-devops, email-bridge, pbi, github-issue, gmail, automation, fivepoints, triage, dedup, duplicate-prevention, PBI_SENDER, configurable-sender, branch-sync, inject, synthetic-email, ADO_BRIDGE_SYNC_SOURCE, ADO_BRIDGE_SYNC_TARGET, ADO_BRIDGE_SYNC_BRANCH, ADO_BRIDGE_AGENT, ADO_BRIDGE_CLIENT, worktree, role-label, PrepareWorktreeStep, claire:meta, feature-branch, branch-convention, pbi_id, slug]
+updated: 2026-06-30
 ---
 
 # Azure DevOps Email Bridge
@@ -28,13 +28,19 @@ ADO PBI assigned to andre.perez@dothelpllc.com
   → creates GitHub issue in ADO_BRIDGE_SYNC_TARGET repo
   → adds role label: role:{ADO_BRIDGE_CLIENT}-dev
   → syncs ADO_BRIDGE_SYNC_SOURCE/develop → ADO_BRIDGE_SYNC_TARGET/develop (GitHub REST API)
-  → assigns issue to ADO_BRIDGE_AGENT                                                ← ALWAYS LAST
   → archives email in Gmail
-  → claire spawn daemon (consumer.py) detects assignment
-  → creates git worktree at <local>/.claire/worktrees/issue-{N} on branch pbi-{N}
-  → launches Claire agent in the worktree
+  → (manual) operator assigns the issue — the bridge no longer auto-assigns (#175)
+  → session-monitor detects the assignment, runs:
+      claire run-pipeline run --workflow fivepoints.tfone.dev --issue N
+  → PrepareWorktreeStep creates <local>/.claire/worktrees/issue-{N}
+      on branch feature/{pbi_id}-{slug} (see § Worktree Creation below)
   → agent receives CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET> for wait/PR targeting
 ```
+
+> The bridge pipeline (`bridge_pipeline` in `azure_issue_bridge/pipeline.py`) itself ends at
+> `sync_branch_step` — it creates the issue, labels it, and syncs the branch, nothing more.
+> Assignment is a manual operator step; worktree creation belongs to the `fivepoints.tfone.dev`
+> pipeline, not the bridge (issue #178).
 
 ---
 
@@ -99,14 +105,47 @@ Gmail inbox
 
 ---
 
-## Spawn Daemon Pickup
+## Worktree Creation — `PrepareWorktreeStep` (issue #178)
 
-After the bridge creates the GitHub issue, adds the role label, syncs the branch, and assigns the issue, the **claire spawn daemon** (`consumer.py`) takes over:
+After the bridge finishes and the issue is assigned (manually, or by automation outside the
+bridge), the **session-monitor** detects the assignment and runs:
 
-1. The spawn daemon monitors `ADO_BRIDGE_SYNC_TARGET` for newly assigned issues
-2. When it detects the assignment to `ADO_BRIDGE_AGENT`, it creates an isolated git worktree at `.claire/worktrees/issue-{N}` on branch `pbi-{N}`
-3. A Claire agent is launched inside the worktree with the issue as its task
-4. The agent receives `CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET>` in its environment so `claire wait` targets the correct repo for PR creation and review polling
+```bash
+claire run-pipeline run --workflow fivepoints.tfone.dev --issue N --repo <ADO_BRIDGE_SYNC_TARGET>
+```
+
+This executes `FivepointsTfoneDevWorkflow` (`claire_fivepoints.tfone_dev_steps`), whose second
+step — `PrepareWorktreeStep`, right after `HydrateStateStep` and before `SpawnDevStep` — owns
+worktree creation. The bridge itself (`prepare_worktree_step` in `azure_issue_bridge/steps.py`)
+is **not** wired into `bridge_pipeline` — worktree creation lives entirely in the dev pipeline.
+
+### What `PrepareWorktreeStep` does
+
+1. Checks whether `<local_path>/.claire/worktrees/issue-{N}` already exists. If it does, it reads
+   the branch name back from a `<!-- claire:meta -->` comment on the issue and returns
+   immediately — **idempotent on pipeline restart**, no second worktree, no re-derivation.
+2. Otherwise: `gh issue view N --repo R --json body,title` to read the issue.
+3. Extracts the ADO PBI id from the body via the `_workitems/edit/(\d+)` link FivePoints already
+   embeds in every issue (see `_build_issue_body` in `azure_issue_bridge/steps.py`).
+4. Derives a slug from the title — `PBI: Case Face Sheet - Enhancement` → `case-face-sheet-enhancement`
+   (strip `PBI:` prefix, lowercase, non-alphanumeric runs collapsed to `-`, capped at 50 chars).
+5. Branch name: `feature/{pbi_id}-{slug}` — the FivePoints convention
+   (`claire domain read fivepoints knowledge DEV_RULES` rule #5), replacing the old `pbi-{N}` /
+   `issue-{N}` naming.
+6. Creates the worktree via the existing `RealWorktreePrepare` adapter
+   (`azure_issue_bridge/worktree.py`), based on `develop`.
+7. Posts a `<!-- claire:meta -->` comment on the issue recording the branch and worktree path —
+   the same tag step 1 reads back on restart. Both the freshly-derived branch name and any
+   branch name recovered from a `claire:meta` comment are validated against
+   `^feature/\d+-[a-z0-9-]+$` before use — a malformed or forged comment is never trusted as-is.
+
+`SpawnDevStep` then opens the dev terminal in the worktree as usual. `PushToADOStep`
+(`claire_fivepoints.tfone_dev_steps`, a local variant — not the one in core's
+`claire_workflows.fivepoints_pipeline`) reads the `branch_name` this step put in `ctx` and
+pushes that exact branch to the `ado` remote, instead of re-deriving `issue-{N}`.
+
+`CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET>` is still set in the agent's environment so
+`claire wait` targets the correct repo for PR creation and review polling.
 
 **`ADO_BRIDGE_SYNC_TARGET` vs `CLAIRE_WAIT_REPO`:**
 - `ADO_BRIDGE_SYNC_TARGET` — configures where the bridge creates GitHub issues (set at bridge/operator level)

--- a/domain/operational/PIPELINE_WORKFLOW.md
+++ b/domain/operational/PIPELINE_WORKFLOW.md
@@ -4,8 +4,8 @@ category: operational
 name: PIPELINE_WORKFLOW
 title: "Five Points — Client Pipeline Workflow (PBI → ADO Merge)"
 keywords: [five-points, pipeline, workflow, analyst, dev, tester, ado-push, ado-transition, transition, labels, checklist, pbi, role-dev, fivepoints-dev, role-tester, role-analyst, "persona:fivepoints-dev", "persona:fivepoints-tester", "persona:fivepoints-analyst"]
-updated: 2026-04-16
-pr: "#2188"
+updated: 2026-06-30
+pr: "#178"
 ---
 
 # Five Points — Client Pipeline Workflow
@@ -504,6 +504,23 @@ fivepoints ado-push --issue <N>
 6. Changes label to `role:ado-review`
 7. Starts `fivepoints ado-watch --pr <ADO_PR_NUMBER>`
 8. On ADO merge → closes the GitHub issue with final summary
+
+### V2 (`fivepoints.tfone.dev`) prerequisite — the `ado` remote is NOT auto-created
+
+`PushToADOStep` (`claire_fivepoints.tfone_dev_steps`) and `FivepointsConcreteADOAdapter`
+(`claire_fivepoints.ado_adapter`) — the V2 pipeline's equivalent of `ado-push` — assume a
+git remote named `ado` already exists in the dev's local checkout (`local_path` in
+`github_repos.yaml`). Unlike the legacy script above, the V2 adapter does **not** add the
+remote for you; `git push ado <branch>` fails with "ado does not appear to be a git
+repository" if it's missing. One-time setup per machine:
+
+```bash
+git -C ~/projects/fivepoints remote add ado \
+  https://claire-test-ai:${AZURE_DEVOPS_PAT}@dev.azure.com/FivePointsTechnology/TFIOne/_git/TFIOneGit
+```
+
+`AZURE_DEVOPS_PAT` is read from `~/.config/claire/github_manager.env`. Automating this as
+part of `claire setup` / an onboarding script is tracked as a follow-up — not yet built.
 
 ---
 

--- a/src/claire_fivepoints/ado_adapter.py
+++ b/src/claire_fivepoints/ado_adapter.py
@@ -30,14 +30,17 @@ class GitRunner(Protocol):
 
 @runtime_checkable
 class FivepointsADOAdapter(Protocol):
-    """ADO adapter — pushes a named branch and waits for merge.
+    """ADO adapter — pushes a branch and waits for merge.
 
     Defined locally (not imported from claire_workflows.fivepoints_pipeline) because
-    push_branch_and_create_pr takes an explicit branch_name — the core Protocol still
-    derives the branch from the issue number alone.
+    push_branch_and_create_pr accepts an explicit branch_name — the core Protocol still
+    derives the branch from the issue number alone. branch_name is optional so the
+    still-registered fivepoints.tfone.full entry point (FivepointsFullWorkflow, which
+    uses core's single-arg PushToADOStep) keeps working unchanged: omitting it falls
+    back to the legacy issue-{N} branch name.
     """
 
-    def push_branch_and_create_pr(self, issue: int, branch_name: str) -> int: ...
+    def push_branch_and_create_pr(self, issue: int, branch_name: str | None = None) -> int: ...
     def wait_for_merge(self, ado_pr_id: int) -> None: ...
 
 
@@ -85,7 +88,8 @@ class FivepointsConcreteADOAdapter:
             git=SubprocessGitRunner(cwd=local_path),
         )
 
-    def push_branch_and_create_pr(self, issue: int, branch_name: str) -> int:
+    def push_branch_and_create_pr(self, issue: int, branch_name: str | None = None) -> int:
+        branch_name = branch_name or f"issue-{issue}"
         self.git.push(self.remote_name, f"{branch_name}:{branch_name}")
         pr = self.ado.find_pr_for_branch(branch_name)
         if pr is None:

--- a/src/claire_fivepoints/ado_adapter.py
+++ b/src/claire_fivepoints/ado_adapter.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from claire_adapters.ado import ADORestAdapter
+from claire_adapters.osascript import load_local_path
 from claire_adapters.token import CONFIG_DIR, find_repo_entry, parse_env_file
 from claire_core.logging_config import get_logger
 
@@ -27,12 +28,28 @@ class GitRunner(Protocol):
     def push(self, remote: str, refspec: str) -> None: ...
 
 
+@runtime_checkable
+class FivepointsADOAdapter(Protocol):
+    """ADO adapter — pushes a named branch and waits for merge.
+
+    Defined locally (not imported from claire_workflows.fivepoints_pipeline) because
+    push_branch_and_create_pr takes an explicit branch_name — the core Protocol still
+    derives the branch from the issue number alone.
+    """
+
+    def push_branch_and_create_pr(self, issue: int, branch_name: str) -> int: ...
+    def wait_for_merge(self, ado_pr_id: int) -> None: ...
+
+
 class SubprocessGitRunner:
     """Concrete GitRunner that delegates to the git CLI."""
 
+    def __init__(self, cwd: str | Path | None = None) -> None:
+        self._cwd = str(cwd) if cwd is not None else None
+
     def push(self, remote: str, refspec: str) -> None:
         import subprocess
-        subprocess.run(["git", "push", remote, refspec], check=True)
+        subprocess.run(["git", "push", remote, refspec], check=True, cwd=self._cwd)
 
 
 @dataclass
@@ -62,18 +79,22 @@ class FivepointsConcreteADOAdapter:
             )
         env = parse_env_file(_config_dir / "github_manager.env")
         pat = env.get("AZURE_DEVOPS_PAT") or os.environ.get("AZURE_DEVOPS_PAT", "")
+        local_path = load_local_path(repo, config_dir=config_dir)
         return cls(
             ado=ADORestAdapter(org=ado_org, project=ado_project, repo=ado_repo, pat=pat),
+            git=SubprocessGitRunner(cwd=local_path),
         )
 
-    def push_branch_and_create_pr(self, issue: int) -> int:
-        branch = f"issue-{issue}"
-        self.git.push(self.remote_name, f"{branch}:{branch}")
-        pr = self.ado.find_pr_for_branch(branch)
+    def push_branch_and_create_pr(self, issue: int, branch_name: str) -> int:
+        self.git.push(self.remote_name, f"{branch_name}:{branch_name}")
+        pr = self.ado.find_pr_for_branch(branch_name)
         if pr is None:
-            raise RuntimeError(f"No ADO PR found for branch {branch} after push")
+            raise RuntimeError(f"No ADO PR found for branch {branch_name} after push")
         pr_id: int = pr["pullRequestId"]
-        logger.info("fivepoints.ado.pr_created", extra={"issue": issue, "ado_pr_id": pr_id})
+        logger.info(
+            "fivepoints.ado.pr_created",
+            extra={"issue": issue, "branch_name": branch_name, "ado_pr_id": pr_id},
+        )
         return pr_id
 
     def wait_for_merge(self, ado_pr_id: int) -> None:

--- a/src/claire_fivepoints/azure_issue_bridge/pipeline.py
+++ b/src/claire_fivepoints/azure_issue_bridge/pipeline.py
@@ -9,7 +9,6 @@ from claire_fivepoints.azure_issue_bridge.steps import (
     create_issues_step,
     fetch_emails_step,
     filter_pbi_step,
-    prepare_worktree_step,
     sync_branch_step,
 )
 
@@ -31,5 +30,4 @@ bridge_pipeline = pipe(
     create_issues_step,
     add_label_step,
     sync_branch_step,
-    prepare_worktree_step,
 )

--- a/src/claire_fivepoints/tests/test_tfone_dev.py
+++ b/src/claire_fivepoints/tests/test_tfone_dev.py
@@ -1,23 +1,32 @@
-"""Tests for DevWithADOContextStep, TesterStep and FivepointsTfoneDevWorkflow.
+"""Tests for tfone_dev_steps — PrepareWorktreeStep, SpawnDevStep, TesterStep,
+PushToADOStep, GhCliIssueMetaAdapter, and FivepointsTfoneDevWorkflow.
 
-Level 1 — unit tests for each step in isolation.
+Level 1 — unit tests for each step / adapter in isolation.
 Level 2 — scenario tests for the full FivepointsTfoneDevWorkflow (including restart recovery).
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from claire_core.pipeline import StepResult
-from claire_fivepoints.ado_context_adapter import MockADOContextAdapter
 from claire_fivepoints.tfone_dev_steps import (
-    DevWithADOContextStep,
     FivepointsTfoneDevAdapters,
     FivepointsTfoneDevWorkflow,
+    GhCliIssueMetaAdapter,
+    PrepareWorktreeStep,
+    PushToADOStep,
+    SpawnDevStep,
     TesterStep,
+    _extract_pbi_id,
+    _slugify,
 )
+
+_DEFAULT_BODY = "ADO: https://dev.azure.com/Org/Proj/_workitems/edit/18840"
+_DEFAULT_TITLE = "PBI: Case Face Sheet - Enhancement"
+_DEFAULT_BRANCH = "feature/18840-case-face-sheet-enhancement"
 
 
 # ---------------------------------------------------------------------------
@@ -31,8 +40,9 @@ def _make_adapters(
     closed: bool = False,
     role_label: str | None = None,
     pr_number: int | None = 10,
-    work_item: dict | None = None,
-    attachment_paths: list[Path] | None = None,
+    issue_body: str = _DEFAULT_BODY,
+    issue_title: str = _DEFAULT_TITLE,
+    meta_comment: str | None = None,
 ) -> FivepointsTfoneDevAdapters:
     gh = MagicMock()
     gh.is_issue_closed.return_value = closed
@@ -41,20 +51,20 @@ def _make_adapters(
     gh.find_pr_for_issue.return_value = pr_number
 
     terminal = MagicMock()
+
     ado = MagicMock()
     ado.push_branch_and_create_pr.return_value = 42
     ado.wait_for_merge.return_value = None
 
-    mock_ado_context = MockADOContextAdapter(
-        work_item=work_item or {"id": 1, "fields": {"System.Title": "Test"}},
-        attachments=attachment_paths or [],
-    )
+    meta = MagicMock()
+    meta.get_issue.return_value = {"body": issue_body, "title": issue_title}
+    meta.find_meta_comment.return_value = meta_comment
 
     return FivepointsTfoneDevAdapters(
         github=gh,
         terminal=terminal,
         ado=ado,
-        ado_context=mock_ado_context,
+        meta=meta,
         local_path=tmp_path,
         ado_org="TestOrg",
         ado_project="TestProject",
@@ -66,105 +76,197 @@ def _make_task(issue: int = 42, repo: str = "org/repo"):
     return FivepointsTask(issue=issue, repo=repo)
 
 
-# ---------------------------------------------------------------------------
-# MockADOContextAdapter
-# ---------------------------------------------------------------------------
-
-
-class TestMockADOContextAdapter:
-    def test_fetch_work_item_returns_fixture(self) -> None:
-        adapter = MockADOContextAdapter(work_item={"id": 99}, attachments=[])
-        result = adapter.fetch_work_item("org", "proj", 99)
-        assert result == {"id": 99}
-
-    def test_download_attachments_creates_dest_and_returns_paths(
-        self, tmp_path: Path
-    ) -> None:
-        fake_path = tmp_path / "fixture.docx"
-        adapter = MockADOContextAdapter(work_item={}, attachments=[fake_path])
-        dest = tmp_path / "attachments"
-        paths = adapter.download_attachments("org", "proj", {}, dest)
-        assert paths == [fake_path]
-        assert dest.is_dir()
-
-    def test_download_attachments_empty(self, tmp_path: Path) -> None:
-        adapter = MockADOContextAdapter(work_item={}, attachments=[])
-        paths = adapter.download_attachments("org", "proj", {}, tmp_path / "out")
-        assert paths == []
+def _patch_worktree_prepare(worktree_path: str = "/mock/worktrees/issue-42"):
+    return patch("claire_fivepoints.tfone_dev_steps.RealWorktreePrepare")
 
 
 # ---------------------------------------------------------------------------
-# DevWithADOContextStep
+# _slugify / _extract_pbi_id
 # ---------------------------------------------------------------------------
 
 
-class TestDevWithADOContextStep:
+class TestSlugify:
+    def test_strips_pbi_prefix_and_lowercases(self) -> None:
+        assert _slugify("PBI: Case Face Sheet - Enhancement") == "case-face-sheet-enhancement"
+
+    def test_no_pbi_prefix(self) -> None:
+        assert _slugify("Client Management Test") == "client-management-test"
+
+    def test_truncates_to_max_len(self) -> None:
+        title = "PBI: " + "word " * 30
+        slug = _slugify(title)
+        assert len(slug) <= 50
+
+    def test_collapses_non_alnum_runs(self) -> None:
+        assert _slugify("PBI: A/B  &  C!!!") == "a-b-c"
+
+
+class TestExtractPbiId:
+    def test_extracts_id_from_workitems_link(self) -> None:
+        body = "See https://dev.azure.com/Org/Proj/_workitems/edit/18840 for details"
+        assert _extract_pbi_id(body) == "18840"
+
+    def test_raises_when_no_link_present(self) -> None:
+        with pytest.raises(RuntimeError, match="pbi_id"):
+            _extract_pbi_id("no ado link here")
+
+
+# ---------------------------------------------------------------------------
+# GhCliIssueMetaAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestGhCliIssueMetaAdapter:
+    def test_get_issue_parses_json(self) -> None:
+        adapter = GhCliIssueMetaAdapter()
+        fake_result = MagicMock(returncode=0, stdout=json.dumps({"body": "b", "title": "t"}))
+        with patch("subprocess.run", return_value=fake_result) as mock_run:
+            data = adapter.get_issue("org/repo", 5)
+        assert data == {"body": "b", "title": "t"}
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:3] == ["gh", "issue", "view"]
+        assert "--json" in cmd and "body,title" in cmd
+
+    def test_get_issue_raises_on_failure(self) -> None:
+        adapter = GhCliIssueMetaAdapter()
+        fake_result = MagicMock(returncode=1, stderr="boom")
+        with patch("subprocess.run", return_value=fake_result):
+            with pytest.raises(RuntimeError, match="boom"):
+                adapter.get_issue("org/repo", 5)
+
+    def test_find_meta_comment_returns_matching_comment(self) -> None:
+        adapter = GhCliIssueMetaAdapter()
+        comments = {"comments": [{"body": "unrelated"}, {"body": "<!-- claire:meta -->\nstuff"}]}
+        fake_result = MagicMock(returncode=0, stdout=json.dumps(comments))
+        with patch("subprocess.run", return_value=fake_result):
+            result = adapter.find_meta_comment("org/repo", 5)
+        assert result == "<!-- claire:meta -->\nstuff"
+
+    def test_find_meta_comment_returns_none_when_absent(self) -> None:
+        adapter = GhCliIssueMetaAdapter()
+        fake_result = MagicMock(returncode=0, stdout=json.dumps({"comments": [{"body": "unrelated"}]}))
+        with patch("subprocess.run", return_value=fake_result):
+            result = adapter.find_meta_comment("org/repo", 5)
+        assert result is None
+
+    def test_find_meta_comment_returns_none_on_gh_failure(self) -> None:
+        adapter = GhCliIssueMetaAdapter()
+        fake_result = MagicMock(returncode=1, stdout="", stderr="boom")
+        with patch("subprocess.run", return_value=fake_result):
+            result = adapter.find_meta_comment("org/repo", 5)
+        assert result is None
+
+    def test_post_comment_calls_gh(self) -> None:
+        adapter = GhCliIssueMetaAdapter()
+        fake_result = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=fake_result) as mock_run:
+            adapter.post_comment("org/repo", 5, "hello")
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["gh", "issue", "comment", "5", "--repo", "org/repo", "--body", "hello"]
+
+    def test_post_comment_raises_on_failure(self) -> None:
+        adapter = GhCliIssueMetaAdapter()
+        fake_result = MagicMock(returncode=1, stderr="boom")
+        with patch("subprocess.run", return_value=fake_result):
+            with pytest.raises(RuntimeError, match="boom"):
+                adapter.post_comment("org/repo", 5, "hello")
+
+
+# ---------------------------------------------------------------------------
+# PrepareWorktreeStep
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareWorktreeStep:
+    def test_fresh_start_creates_worktree_and_posts_comment(self, tmp_path: Path) -> None:
+        adapters = _make_adapters(tmp_path, meta_comment=None)
+        task = _make_task(issue=18842, repo="org/repo")
+        worktree_path = str(tmp_path / ".claire" / "worktrees" / "issue-18842")
+
+        with _patch_worktree_prepare() as mock_cls:
+            mock_cls.return_value.prepare.return_value = worktree_path
+            result = PrepareWorktreeStep()(task, {}, adapters)
+
+        assert result.ok
+        assert result.data["worktree_ready"] is True
+        assert result.data["branch_name"] == _DEFAULT_BRANCH
+        assert result.data["worktree_path"] == worktree_path
+
+        mock_cls.assert_called_once_with(local_path=tmp_path)
+        mock_cls.return_value.prepare.assert_called_once_with(
+            repo="org/repo",
+            issue=18842,
+            base_branch="develop",
+            branch_name=_DEFAULT_BRANCH,
+        )
+
+        adapters.meta.post_comment.assert_called_once()
+        posted_repo, posted_issue, posted_body = adapters.meta.post_comment.call_args[0]
+        assert posted_repo == "org/repo"
+        assert posted_issue == 18842
+        assert "<!-- claire:meta -->" in posted_body
+        assert f"`{_DEFAULT_BRANCH}`" in posted_body
+        assert worktree_path in posted_body
+
+    def test_idempotent_when_worktree_exists_and_meta_comment_found(self, tmp_path: Path) -> None:
+        worktree_dir = tmp_path / ".claire" / "worktrees" / "issue-7"
+        worktree_dir.mkdir(parents=True)
+        meta_comment = (
+            "<!-- claire:meta -->\n"
+            "**Branch:** `feature/100-existing-branch`\n"
+            "**Worktree:** `/some/path`"
+        )
+        adapters = _make_adapters(tmp_path, meta_comment=meta_comment)
+        task = _make_task(issue=7)
+
+        with _patch_worktree_prepare() as mock_cls:
+            result = PrepareWorktreeStep()(task, {}, adapters)
+
+        assert result.ok
+        assert result.data["branch_name"] == "feature/100-existing-branch"
+        mock_cls.assert_not_called()
+        adapters.meta.get_issue.assert_not_called()
+        adapters.meta.post_comment.assert_not_called()
+
+    def test_falls_through_when_worktree_exists_but_no_meta_comment(self, tmp_path: Path) -> None:
+        worktree_dir = tmp_path / ".claire" / "worktrees" / "issue-7"
+        worktree_dir.mkdir(parents=True)
+        adapters = _make_adapters(tmp_path, meta_comment=None)
+        task = _make_task(issue=7)
+
+        with _patch_worktree_prepare() as mock_cls:
+            mock_cls.return_value.prepare.return_value = str(worktree_dir)
+            result = PrepareWorktreeStep()(task, {}, adapters)
+
+        assert result.ok
+        mock_cls.return_value.prepare.assert_called_once()
+        adapters.meta.post_comment.assert_called_once()
+
+    def test_missing_pbi_id_raises(self, tmp_path: Path) -> None:
+        adapters = _make_adapters(tmp_path, issue_body="no ado link here", meta_comment=None)
+        task = _make_task(issue=9)
+        with pytest.raises(RuntimeError, match="pbi_id"):
+            PrepareWorktreeStep()(task, {}, adapters)
+
+
+# ---------------------------------------------------------------------------
+# SpawnDevStep
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnDevStep:
     def test_skips_when_dev_done_in_ctx(self, tmp_path: Path) -> None:
         adapters = _make_adapters(tmp_path)
         task = _make_task()
-        result = DevWithADOContextStep()(task, {"dev_done": True}, adapters)
+        result = SpawnDevStep()(task, {"dev_done": True}, adapters)
         assert result.ok
         adapters.terminal.spawn_dev.assert_not_called()
         adapters.github.wait_for_label.assert_not_called()
 
-    def test_fetches_work_item_and_downloads_attachments(self, tmp_path: Path) -> None:
-        adapters = _make_adapters(
-            tmp_path,
-            work_item={
-                "id": 42,
-                "fields": {
-                    "System.Title": "My Feature",
-                    "System.Description": "Desc",
-                    "Microsoft.VSTS.Common.AcceptanceCriteria": "AC",
-                    "System.AreaPath": "Area\\Path",
-                    "System.State": "Active",
-                    "System.WorkItemType": "User Story",
-                },
-            },
-        )
-        task = _make_task(issue=42)
-        result = DevWithADOContextStep()(task, {}, adapters)
-        assert result.ok
-        dest = tmp_path / ".claire" / "attachments" / "issue-42"
-        assert dest.is_dir()
-        context_file = dest / "ADO_CONTEXT.md"
-        assert context_file.is_file()
-        content = context_file.read_text()
-        assert "My Feature" in content
-        assert "Desc" in content
-        assert "AC" in content
-
-    def test_single_ado_fetch_per_run(self, tmp_path: Path) -> None:
-        """download_attachments receives the already-fetched work_item — no double fetch."""
-        from unittest.mock import patch
-
-        adapters = _make_adapters(tmp_path)
-        task = _make_task(issue=5)
-
-        fetch_calls: list = []
-        orig_fetch = adapters.ado_context.fetch_work_item
-
-        def tracking_fetch(org, project, item_id):
-            fetch_calls.append((org, project, item_id))
-            return orig_fetch(org, project, item_id)
-
-        adapters.ado_context.fetch_work_item = tracking_fetch
-        DevWithADOContextStep()(task, {}, adapters)
-        assert len(fetch_calls) == 1, "fetch_work_item must be called exactly once"
-
-    def test_writes_attachments_list_in_context_file(self, tmp_path: Path) -> None:
-        fake = tmp_path / "spec.docx"
-        fake.write_bytes(b"fake")
-        adapters = _make_adapters(tmp_path, attachment_paths=[fake])
-        task = _make_task(issue=7)
-        DevWithADOContextStep()(task, {}, adapters)
-        context_file = tmp_path / ".claire" / "attachments" / "issue-7" / "ADO_CONTEXT.md"
-        assert "spec.docx" in context_file.read_text()
-
     def test_spawns_dev_and_waits_for_label(self, tmp_path: Path) -> None:
         adapters = _make_adapters(tmp_path)
         task = _make_task(issue=5)
-        result = DevWithADOContextStep()(task, {}, adapters)
+        result = SpawnDevStep()(task, {}, adapters)
         assert result.ok
         adapters.terminal.spawn_dev.assert_called_once_with(5, "org/repo")
         adapters.github.wait_for_label.assert_called_once_with(
@@ -174,17 +276,10 @@ class TestDevWithADOContextStep:
     def test_returns_dev_done_and_pr_number(self, tmp_path: Path) -> None:
         adapters = _make_adapters(tmp_path, pr_number=99)
         task = _make_task()
-        result = DevWithADOContextStep()(task, {}, adapters)
+        result = SpawnDevStep()(task, {}, adapters)
         assert result.ok
         assert result.data["dev_done"] is True
         assert result.data["pr_number"] == 99
-
-    def test_context_file_created_even_without_attachments(self, tmp_path: Path) -> None:
-        adapters = _make_adapters(tmp_path, attachment_paths=[])
-        task = _make_task(issue=3)
-        DevWithADOContextStep()(task, {}, adapters)
-        context_file = tmp_path / ".claire" / "attachments" / "issue-3" / "ADO_CONTEXT.md"
-        assert context_file.is_file()
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +313,22 @@ class TestTesterStep:
 
 
 # ---------------------------------------------------------------------------
+# PushToADOStep
+# ---------------------------------------------------------------------------
+
+
+class TestPushToADOStep:
+    def test_reads_branch_name_from_ctx_and_calls_adapter(self, tmp_path: Path) -> None:
+        adapters = _make_adapters(tmp_path)
+        adapters.ado.push_branch_and_create_pr.return_value = 77
+        task = _make_task(issue=5)
+        result = PushToADOStep()(task, {"branch_name": "feature/1-foo"}, adapters)
+        assert result.ok
+        assert result.data["ado_pr_id"] == 77
+        adapters.ado.push_branch_and_create_pr.assert_called_once_with(5, "feature/1-foo")
+
+
+# ---------------------------------------------------------------------------
 # FivepointsTfoneDevWorkflow — scenario tests (including restart recovery)
 # ---------------------------------------------------------------------------
 
@@ -227,18 +338,22 @@ class TestFivepointsTfoneDevWorkflow:
         """No label present → HydrateState returns {} → all steps run."""
         adapters = _make_adapters(tmp_path, role_label=None, pr_number=20)
         task = _make_task(issue=42)
-        result = FivepointsTfoneDevWorkflow().run(task, adapters)
+        with _patch_worktree_prepare() as mock_cls:
+            mock_cls.return_value.prepare.return_value = str(tmp_path / ".claire/worktrees/issue-42")
+            result = FivepointsTfoneDevWorkflow().run(task, adapters)
         assert result.ok
         adapters.terminal.spawn_dev.assert_called_once()
         adapters.terminal.spawn_tester.assert_called_once()
-        adapters.ado.push_branch_and_create_pr.assert_called_once_with(42)
+        adapters.ado.push_branch_and_create_pr.assert_called_once_with(42, _DEFAULT_BRANCH)
         adapters.ado.wait_for_merge.assert_called_once_with(42)
 
     def test_restart_with_role_tester_skips_dev(self, tmp_path: Path) -> None:
         """role:tester present → HydrateState sets dev_done=True → DevStep skipped."""
         adapters = _make_adapters(tmp_path, role_label="role:tester", pr_number=5)
         task = _make_task()
-        result = FivepointsTfoneDevWorkflow().run(task, adapters)
+        with _patch_worktree_prepare() as mock_cls:
+            mock_cls.return_value.prepare.return_value = "/mock/worktree"
+            result = FivepointsTfoneDevWorkflow().run(task, adapters)
         assert result.ok
         adapters.terminal.spawn_dev.assert_not_called()
         adapters.terminal.spawn_tester.assert_called_once()
@@ -247,11 +362,36 @@ class TestFivepointsTfoneDevWorkflow:
         """role:ready present → HydrateState sets dev_done+tester_done → both skipped."""
         adapters = _make_adapters(tmp_path, role_label="role:ready", pr_number=7)
         task = _make_task()
-        result = FivepointsTfoneDevWorkflow().run(task, adapters)
+        with _patch_worktree_prepare() as mock_cls:
+            mock_cls.return_value.prepare.return_value = "/mock/worktree"
+            result = FivepointsTfoneDevWorkflow().run(task, adapters)
         assert result.ok
         adapters.terminal.spawn_dev.assert_not_called()
         adapters.terminal.spawn_tester.assert_not_called()
         adapters.ado.push_branch_and_create_pr.assert_called_once()
+
+    def test_restart_with_existing_worktree_reuses_branch_from_meta_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """PrepareWorktreeStep recovers branch_name from the claire:meta comment — no re-derivation, no worktree recreation."""
+        worktree_dir = tmp_path / ".claire" / "worktrees" / "issue-42"
+        worktree_dir.mkdir(parents=True)
+        meta_comment = (
+            "<!-- claire:meta -->\n"
+            "**Branch:** `feature/999-recovered-branch`\n"
+            "**Worktree:** `/some/path`"
+        )
+        adapters = _make_adapters(
+            tmp_path, role_label="role:ready", pr_number=7, meta_comment=meta_comment
+        )
+        task = _make_task(issue=42)
+        with _patch_worktree_prepare() as mock_cls:
+            result = FivepointsTfoneDevWorkflow().run(task, adapters)
+        assert result.ok
+        mock_cls.assert_not_called()
+        adapters.ado.push_branch_and_create_pr.assert_called_once_with(
+            42, "feature/999-recovered-branch"
+        )
 
     def test_issue_closed_exits_cleanly(self, tmp_path: Path) -> None:
         """Closed issue → HydrateState returns ok=False → pipeline exits."""
@@ -267,8 +407,10 @@ class TestFivepointsTfoneDevWorkflow:
         adapters.ado.push_branch_and_create_pr.return_value = 99
         adapters.ado.wait_for_merge.side_effect = RuntimeError("ADO PR abandoned")
         task = _make_task()
-        with pytest.raises(RuntimeError, match="ADO PR abandoned"):
-            FivepointsTfoneDevWorkflow().run(task, adapters)
+        with _patch_worktree_prepare() as mock_cls:
+            mock_cls.return_value.prepare.return_value = "/mock/worktree"
+            with pytest.raises(RuntimeError, match="ADO PR abandoned"):
+                FivepointsTfoneDevWorkflow().run(task, adapters)
 
 
 # ---------------------------------------------------------------------------
@@ -280,8 +422,6 @@ class TestRunFivepointsTfoneDevForIssue:
     def test_entry_point_wires_adapters_and_calls_workflow(
         self, tmp_path: Path
     ) -> None:
-        from unittest.mock import patch
-
         from claire_core.pipeline import StepResult as _SR
         from claire_fivepoints.workflows import run_fivepoints_tfone_dev_for_issue
 
@@ -290,8 +430,6 @@ class TestRunFivepointsTfoneDevForIssue:
 
         mock_ado_cls = MagicMock()
         mock_ado_cls.for_repo.return_value = MagicMock()
-        mock_ado_ctx_cls = MagicMock()
-        mock_ado_ctx_cls.for_repo.return_value = MagicMock()
         mock_workflow_cls = MagicMock(return_value=mock_workflow_instance)
 
         with (
@@ -312,7 +450,6 @@ class TestRunFivepointsTfoneDevForIssue:
                 return_value={"ado_org": "Org", "ado_project": "Proj"},
             ),
             patch("claire_fivepoints.workflows.FivepointsConcreteADOAdapter", mock_ado_cls),
-            patch("claire_fivepoints.workflows.RealADOContextAdapter", mock_ado_ctx_cls),
             patch("claire_fivepoints.workflows.FivepointsTfoneDevWorkflow", mock_workflow_cls),
         ):
             result = run_fivepoints_tfone_dev_for_issue(42, "org/repo")
@@ -321,5 +458,7 @@ class TestRunFivepointsTfoneDevForIssue:
         mock_workflow_instance.run.assert_called_once()
         call_args = mock_workflow_instance.run.call_args
         task = call_args[0][0]
+        adapters = call_args[0][1]
         assert task.issue == 42
         assert task.repo == "org/repo"
+        assert isinstance(adapters.meta, GhCliIssueMetaAdapter)

--- a/src/claire_fivepoints/tests/test_tfone_dev.py
+++ b/src/claire_fivepoints/tests/test_tfone_dev.py
@@ -21,6 +21,7 @@ from claire_fivepoints.tfone_dev_steps import (
     SpawnDevStep,
     TesterStep,
     _extract_pbi_id,
+    _is_valid_branch_name,
     _slugify,
 )
 
@@ -111,65 +112,100 @@ class TestExtractPbiId:
             _extract_pbi_id("no ado link here")
 
 
+class TestIsValidBranchName:
+    def test_accepts_convention_shaped_branch(self) -> None:
+        assert _is_valid_branch_name("feature/18840-case-face-sheet-enhancement")
+
+    def test_rejects_leading_dash_injection_attempt(self) -> None:
+        assert not _is_valid_branch_name("--upload-pack=evil")
+
+    def test_rejects_legacy_issue_branch_name(self) -> None:
+        assert not _is_valid_branch_name("issue-42")
+
+    def test_rejects_uppercase_or_invalid_chars(self) -> None:
+        assert not _is_valid_branch_name("feature/18840-Has Spaces")
+
+    def test_rejects_missing_pbi_id(self) -> None:
+        assert not _is_valid_branch_name("feature/-no-id")
+
+
 # ---------------------------------------------------------------------------
-# GhCliIssueMetaAdapter
+# GhCliIssueMetaAdapter — delegates to the shared GhRunner abstraction
 # ---------------------------------------------------------------------------
 
 
 class TestGhCliIssueMetaAdapter:
     def test_get_issue_parses_json(self) -> None:
-        adapter = GhCliIssueMetaAdapter()
-        fake_result = MagicMock(returncode=0, stdout=json.dumps({"body": "b", "title": "t"}))
-        with patch("subprocess.run", return_value=fake_result) as mock_run:
-            data = adapter.get_issue("org/repo", 5)
-        assert data == {"body": "b", "title": "t"}
-        cmd = mock_run.call_args[0][0]
-        assert cmd[:3] == ["gh", "issue", "view"]
-        assert "--json" in cmd and "body,title" in cmd
+        runner = MagicMock()
+        runner.run.return_value = json.dumps({"body": "b", "title": "t"})
+        adapter = GhCliIssueMetaAdapter(runner=runner)
 
-    def test_get_issue_raises_on_failure(self) -> None:
-        adapter = GhCliIssueMetaAdapter()
-        fake_result = MagicMock(returncode=1, stderr="boom")
-        with patch("subprocess.run", return_value=fake_result):
-            with pytest.raises(RuntimeError, match="boom"):
-                adapter.get_issue("org/repo", 5)
+        data = adapter.get_issue("org/repo", 5)
+
+        assert data == {"body": "b", "title": "t"}
+        runner.run.assert_called_once_with(
+            "issue", "view", "5", "--repo", "org/repo", "--json", "body,title",
+        )
+
+    def test_get_issue_propagates_runner_failure(self) -> None:
+        runner = MagicMock()
+        runner.run.side_effect = RuntimeError("boom")
+        adapter = GhCliIssueMetaAdapter(runner=runner)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            adapter.get_issue("org/repo", 5)
 
     def test_find_meta_comment_returns_matching_comment(self) -> None:
-        adapter = GhCliIssueMetaAdapter()
+        runner = MagicMock()
         comments = {"comments": [{"body": "unrelated"}, {"body": "<!-- claire:meta -->\nstuff"}]}
-        fake_result = MagicMock(returncode=0, stdout=json.dumps(comments))
-        with patch("subprocess.run", return_value=fake_result):
-            result = adapter.find_meta_comment("org/repo", 5)
+        runner.run.return_value = json.dumps(comments)
+        adapter = GhCliIssueMetaAdapter(runner=runner)
+
+        result = adapter.find_meta_comment("org/repo", 5)
+
         assert result == "<!-- claire:meta -->\nstuff"
 
     def test_find_meta_comment_returns_none_when_absent(self) -> None:
-        adapter = GhCliIssueMetaAdapter()
-        fake_result = MagicMock(returncode=0, stdout=json.dumps({"comments": [{"body": "unrelated"}]}))
-        with patch("subprocess.run", return_value=fake_result):
-            result = adapter.find_meta_comment("org/repo", 5)
+        runner = MagicMock()
+        runner.run.return_value = json.dumps({"comments": [{"body": "unrelated"}]})
+        adapter = GhCliIssueMetaAdapter(runner=runner)
+
+        result = adapter.find_meta_comment("org/repo", 5)
+
         assert result is None
 
-    def test_find_meta_comment_returns_none_on_gh_failure(self) -> None:
-        adapter = GhCliIssueMetaAdapter()
-        fake_result = MagicMock(returncode=1, stdout="", stderr="boom")
-        with patch("subprocess.run", return_value=fake_result):
-            result = adapter.find_meta_comment("org/repo", 5)
+    def test_find_meta_comment_returns_none_on_runner_failure(self) -> None:
+        runner = MagicMock()
+        runner.run.side_effect = RuntimeError("boom")
+        adapter = GhCliIssueMetaAdapter(runner=runner)
+
+        result = adapter.find_meta_comment("org/repo", 5)
+
         assert result is None
 
-    def test_post_comment_calls_gh(self) -> None:
-        adapter = GhCliIssueMetaAdapter()
-        fake_result = MagicMock(returncode=0)
-        with patch("subprocess.run", return_value=fake_result) as mock_run:
+    def test_post_comment_calls_runner(self) -> None:
+        runner = MagicMock()
+        adapter = GhCliIssueMetaAdapter(runner=runner)
+
+        adapter.post_comment("org/repo", 5, "hello")
+
+        runner.run.assert_called_once_with(
+            "issue", "comment", "5", "--repo", "org/repo", "--body", "hello",
+        )
+
+    def test_post_comment_propagates_runner_failure(self) -> None:
+        runner = MagicMock()
+        runner.run.side_effect = RuntimeError("boom")
+        adapter = GhCliIssueMetaAdapter(runner=runner)
+
+        with pytest.raises(RuntimeError, match="boom"):
             adapter.post_comment("org/repo", 5, "hello")
-        cmd = mock_run.call_args[0][0]
-        assert cmd == ["gh", "issue", "comment", "5", "--repo", "org/repo", "--body", "hello"]
 
-    def test_post_comment_raises_on_failure(self) -> None:
+    def test_default_runner_is_subprocess_gh_runner(self) -> None:
+        from claire_adapters.github import SubprocessGhRunner
+
         adapter = GhCliIssueMetaAdapter()
-        fake_result = MagicMock(returncode=1, stderr="boom")
-        with patch("subprocess.run", return_value=fake_result):
-            with pytest.raises(RuntimeError, match="boom"):
-                adapter.post_comment("org/repo", 5, "hello")
+        assert isinstance(adapter.runner, SubprocessGhRunner)
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +283,29 @@ class TestPrepareWorktreeStep:
         task = _make_task(issue=9)
         with pytest.raises(RuntimeError, match="pbi_id"):
             PrepareWorktreeStep()(task, {}, adapters)
+
+    def test_rejects_forged_meta_comment_and_re_derives(self, tmp_path: Path) -> None:
+        """A branch_name that doesn't match feature/{pbi_id}-{slug} — e.g. posted by an
+        attacker able to comment on the issue, or a stale/malformed comment — must never
+        be trusted as-is. Falls through to deriving + recreating instead."""
+        worktree_dir = tmp_path / ".claire" / "worktrees" / "issue-7"
+        worktree_dir.mkdir(parents=True)
+        forged_comment = (
+            "<!-- claire:meta -->\n"
+            "**Branch:** `--upload-pack=evil`\n"
+            "**Worktree:** `/some/path`"
+        )
+        adapters = _make_adapters(tmp_path, meta_comment=forged_comment)
+        task = _make_task(issue=7)
+
+        with _patch_worktree_prepare() as mock_cls:
+            mock_cls.return_value.prepare.return_value = str(worktree_dir)
+            result = PrepareWorktreeStep()(task, {}, adapters)
+
+        assert result.ok
+        assert result.data["branch_name"] == _DEFAULT_BRANCH
+        mock_cls.return_value.prepare.assert_called_once()
+        adapters.meta.post_comment.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/src/claire_fivepoints/tests/test_workflows.py
+++ b/src/claire_fivepoints/tests/test_workflows.py
@@ -233,10 +233,12 @@ class TestFivepointsConcreteADOAdapter:
         mock_ado.find_pr_for_branch.return_value = {"pullRequestId": 42}
 
         adapter = FivepointsConcreteADOAdapter(ado=mock_ado, git=_FakeGit())
-        pr_id = adapter.push_branch_and_create_pr(99)
+        pr_id = adapter.push_branch_and_create_pr(99, "feature/123-my-feature")
 
         assert pr_id == 42
-        assert push_calls == [("ado", "issue-99:issue-99")]
+        assert push_calls == [
+            ("ado", "feature/123-my-feature:feature/123-my-feature")
+        ]
 
     def test_wait_for_merge_returns_on_completed(self) -> None:
         from claire_fivepoints.ado_adapter import FivepointsConcreteADOAdapter
@@ -258,3 +260,49 @@ class TestFivepointsConcreteADOAdapter:
         adapter = FivepointsConcreteADOAdapter(ado=mock_ado, git=MagicMock())
         with pytest.raises(RuntimeError, match="abandoned"):
             adapter.wait_for_merge(7)
+
+    def test_subprocess_git_runner_passes_cwd_to_git_push(self) -> None:
+        from claire_fivepoints.ado_adapter import SubprocessGitRunner
+
+        with patch("subprocess.run") as mock_run:
+            runner = SubprocessGitRunner(cwd="/some/repo")
+            runner.push("ado", "feature/1-foo:feature/1-foo")
+
+        mock_run.assert_called_once_with(
+            ["git", "push", "ado", "feature/1-foo:feature/1-foo"],
+            check=True,
+            cwd="/some/repo",
+        )
+
+    def test_subprocess_git_runner_defaults_cwd_to_none(self) -> None:
+        from claire_fivepoints.ado_adapter import SubprocessGitRunner
+
+        with patch("subprocess.run") as mock_run:
+            SubprocessGitRunner().push("ado", "develop:develop")
+
+        assert mock_run.call_args.kwargs["cwd"] is None
+
+    def test_for_repo_wires_local_path_into_git_runner_cwd(self) -> None:
+        from claire_fivepoints.ado_adapter import FivepointsConcreteADOAdapter
+
+        with (
+            patch(
+                "claire_fivepoints.ado_adapter.find_repo_entry",
+                return_value={
+                    "ado_org": "Org",
+                    "ado_project": "Proj",
+                    "ado_repo": "TFIOneGit",
+                },
+            ),
+            patch(
+                "claire_fivepoints.ado_adapter.parse_env_file",
+                return_value={"AZURE_DEVOPS_PAT": "fake-pat"},
+            ),
+            patch(
+                "claire_fivepoints.ado_adapter.load_local_path",
+                return_value="/Users/andreperez/projects/fivepoints",
+            ),
+        ):
+            adapter = FivepointsConcreteADOAdapter.for_repo("CLAIRE-Fivepoints/fivepoints")
+
+        assert adapter.git._cwd == "/Users/andreperez/projects/fivepoints"

--- a/src/claire_fivepoints/tests/test_workflows.py
+++ b/src/claire_fivepoints/tests/test_workflows.py
@@ -240,6 +240,27 @@ class TestFivepointsConcreteADOAdapter:
             ("ado", "feature/123-my-feature:feature/123-my-feature")
         ]
 
+    def test_push_branch_falls_back_to_issue_branch_when_name_omitted(self) -> None:
+        """fivepoints.tfone.full still calls push_branch_and_create_pr(issue) with no
+        branch_name (core's single-arg PushToADOStep) — must keep working unchanged."""
+        from claire_fivepoints.ado_adapter import FivepointsConcreteADOAdapter
+
+        push_calls: list[tuple] = []
+
+        class _FakeGit:
+            def push(self, remote: str, refspec: str) -> None:
+                push_calls.append((remote, refspec))
+
+        mock_ado = MagicMock()
+        mock_ado.find_pr_for_branch.return_value = {"pullRequestId": 7}
+
+        adapter = FivepointsConcreteADOAdapter(ado=mock_ado, git=_FakeGit())
+        pr_id = adapter.push_branch_and_create_pr(99)
+
+        assert pr_id == 7
+        assert push_calls == [("ado", "issue-99:issue-99")]
+        mock_ado.find_pr_for_branch.assert_called_once_with("issue-99")
+
     def test_wait_for_merge_returns_on_completed(self) -> None:
         from claire_fivepoints.ado_adapter import FivepointsConcreteADOAdapter
 

--- a/src/claire_fivepoints/tfone_dev_steps.py
+++ b/src/claire_fivepoints/tfone_dev_steps.py
@@ -2,38 +2,127 @@
 
 Pipeline shape:
   pipe(
-    HydrateStateStep(),   # reads role label; populates ctx for restart recovery
-    SpawnDevStep(),       # spawn dev terminal + wait for role:tester label
-    TesterStep(),         # spawn tester + wait role:ready
-    PushToADOStep(),      # push branch to ADO + create PR  (from fivepoints_pipeline)
-    WaitForADOMergeStep(),# block until ADO PR merged        (from fivepoints_pipeline)
+    HydrateStateStep(),     # reads role label; populates ctx for restart recovery
+    PrepareWorktreeStep(),  # idempotent worktree + feature/{pbi_id}-{slug} branch
+    SpawnDevStep(),         # spawn dev terminal + wait for role:tester label
+    TesterStep(),           # spawn tester + wait role:ready
+    PushToADOStep(),        # push branch_name (from ctx) to ADO + create PR
+    WaitForADOMergeStep(),  # block until ADO PR merged        (from fivepoints_pipeline)
   )
 
 The dev agent reads the GitHub issue body (populated by the bridge) and downloads
 ADO attachments itself — the workflow does not pre-fetch ADO context.
+
+PushToADOStep is defined locally (not imported from claire_workflows.fivepoints_pipeline)
+because it pushes the branch_name produced by PrepareWorktreeStep rather than deriving
+issue-{N} from the issue number alone.
 """
 from __future__ import annotations
 
+import json
+import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from claire_core.logging_config import get_logger
 from claire_core.pipeline import StepResult, pipe
 from claire_workflows.fivepoints_pipeline import (
-    FivepointsADOAdapter,
     FivepointsGitHubAdapter,
     FivepointsTask,
     FivepointsTerminalAdapter,
     HydrateStateStep,
-    PushToADOStep,
     WaitForADOMergeStep,
 )
+
+from claire_fivepoints.ado_adapter import FivepointsADOAdapter
+from claire_fivepoints.azure_issue_bridge.worktree import RealWorktreePrepare
 
 logger = get_logger(__name__)
 
 _LABEL_TESTER = "role:tester"
 _LABEL_READY = "role:ready"
+
+_META_TAG = "<!-- claire:meta -->"
+_PBI_ID_PATTERN = re.compile(r"_workitems/edit/(\d+)")
+_BRANCH_PATTERN = re.compile(r"\*\*Branch:\*\* `([^`]+)`")
+_SLUG_MAX_LEN = 50
+
+
+# ---------------------------------------------------------------------------
+# Branch naming helpers
+# ---------------------------------------------------------------------------
+
+
+def _slugify(title: str, max_len: int = _SLUG_MAX_LEN) -> str:
+    """Derive a branch-safe slug from an issue title.
+
+    "PBI: Case Face Sheet - Enhancement" -> "case-face-sheet-enhancement"
+    """
+    text = re.sub(r"^PBI:\s*", "", title, flags=re.IGNORECASE)
+    text = re.sub(r"[^a-zA-Z0-9]+", "-", text).strip("-").lower()
+    return text[:max_len].rstrip("-")
+
+
+def _extract_pbi_id(body: str) -> str:
+    match = _PBI_ID_PATTERN.search(body)
+    if not match:
+        raise RuntimeError(
+            "Could not extract pbi_id from issue body — "
+            "no ADO _workitems/edit/<id> link found"
+        )
+    return match.group(1)
+
+
+# ---------------------------------------------------------------------------
+# GhIssueMetaAdapter — reads the issue, reads/posts the claire:meta comment
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class GhIssueMetaAdapter(Protocol):
+    """Reads the GitHub issue and reads/writes the claire:meta tracking comment."""
+
+    def get_issue(self, repo: str, issue: int) -> dict[str, Any]: ...
+    def find_meta_comment(self, repo: str, issue: int) -> str | None: ...
+    def post_comment(self, repo: str, issue: int, body: str) -> None: ...
+
+
+class GhCliIssueMetaAdapter:
+    """Concrete GhIssueMetaAdapter — shells out to the gh CLI."""
+
+    def get_issue(self, repo: str, issue: int) -> dict[str, Any]:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(issue), "--repo", repo, "--json", "body,title"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"gh issue view failed: {result.stderr.strip()}")
+        data: dict[str, Any] = json.loads(result.stdout)
+        return data
+
+    def find_meta_comment(self, repo: str, issue: int) -> str | None:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(issue), "--repo", repo, "--json", "comments"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout or "{}")
+        for comment in data.get("comments", []):
+            body = comment.get("body", "")
+            if body.startswith(_META_TAG):
+                return body
+        return None
+
+    def post_comment(self, repo: str, issue: int, body: str) -> None:
+        result = subprocess.run(
+            ["gh", "issue", "comment", str(issue), "--repo", repo, "--body", body],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"gh issue comment failed: {result.stderr.strip()}")
 
 
 # ---------------------------------------------------------------------------
@@ -48,6 +137,7 @@ class FivepointsTfoneDevAdapters:
     github: FivepointsGitHubAdapter
     terminal: FivepointsTerminalAdapter
     ado: FivepointsADOAdapter
+    meta: GhIssueMetaAdapter
     local_path: Path
     ado_org: str
     ado_project: str
@@ -56,6 +146,79 @@ class FivepointsTfoneDevAdapters:
 # ---------------------------------------------------------------------------
 # Steps
 # ---------------------------------------------------------------------------
+
+
+class PrepareWorktreeStep:
+    """Create the dev worktree on a FivePoints-convention branch, idempotently.
+
+    Branch name: feature/{pbi_id}-{slug} — pbi_id is parsed from the ADO
+    _workitems/edit/<id> link in the issue body, slug is derived from the issue
+    title. The chosen branch name is persisted as a <!-- claire:meta --> comment
+    on the issue so a restarted pipeline recovers it without recreating the
+    worktree or re-deriving the branch name.
+    """
+
+    def __call__(
+        self,
+        task: FivepointsTask,
+        ctx: dict[str, Any],
+        adapters: FivepointsTfoneDevAdapters,
+    ) -> StepResult:
+        worktree_path = adapters.local_path / ".claire" / "worktrees" / f"issue-{task.issue}"
+
+        if worktree_path.exists():
+            meta_body = adapters.meta.find_meta_comment(task.repo, task.issue)
+            match = _BRANCH_PATTERN.search(meta_body) if meta_body else None
+            if match:
+                branch_name = match.group(1)
+                logger.info(
+                    "tfone_dev.prepare_worktree.skipped",
+                    extra={
+                        "issue": task.issue,
+                        "repo": task.repo,
+                        "branch_name": branch_name,
+                    },
+                )
+                return StepResult(
+                    ok=True,
+                    data={
+                        "worktree_ready": True,
+                        "branch_name": branch_name,
+                        "worktree_path": str(worktree_path),
+                    },
+                )
+
+        issue_data = adapters.meta.get_issue(task.repo, task.issue)
+        pbi_id = _extract_pbi_id(issue_data.get("body", "") or "")
+        slug = _slugify(issue_data.get("title", "") or "")
+        branch_name = f"feature/{pbi_id}-{slug}"
+
+        worktree_path_str = RealWorktreePrepare(local_path=adapters.local_path).prepare(
+            repo=task.repo,
+            issue=task.issue,
+            base_branch="develop",
+            branch_name=branch_name,
+        )
+
+        comment_body = (
+            f"{_META_TAG}\n"
+            f"**Branch:** `{branch_name}`\n"
+            f"**Worktree:** `{worktree_path_str}`"
+        )
+        adapters.meta.post_comment(task.repo, task.issue, comment_body)
+
+        logger.info(
+            "tfone_dev.prepare_worktree.done",
+            extra={"issue": task.issue, "repo": task.repo, "branch_name": branch_name},
+        )
+        return StepResult(
+            ok=True,
+            data={
+                "worktree_ready": True,
+                "branch_name": branch_name,
+                "worktree_path": worktree_path_str,
+            },
+        )
 
 
 class SpawnDevStep:
@@ -133,18 +296,49 @@ class TesterStep:
         return StepResult(ok=True, data={"tester_done": True})
 
 
+class PushToADOStep:
+    """Push the feature branch to ADO and create a PR.
+
+    Reads branch_name from ctx (set by PrepareWorktreeStep) instead of deriving
+    issue-{N} from the issue number, so the branch pushed to ADO matches the
+    FivePoints feature/{pbi_id}-{slug} convention.
+    """
+
+    def __call__(
+        self,
+        task: FivepointsTask,
+        ctx: dict[str, Any],
+        adapters: FivepointsTfoneDevAdapters,
+    ) -> StepResult:
+        branch_name = ctx["branch_name"]
+        ado_pr_id = adapters.ado.push_branch_and_create_pr(task.issue, branch_name)
+        logger.info(
+            "tfone_dev.push_to_ado.done",
+            extra={
+                "issue": task.issue,
+                "repo": task.repo,
+                "branch_name": branch_name,
+                "ado_pr_id": ado_pr_id,
+            },
+        )
+        return StepResult(ok=True, data={"ado_pr_id": ado_pr_id})
+
+
 # ---------------------------------------------------------------------------
 # Workflow
 # ---------------------------------------------------------------------------
 
 
 class FivepointsTfoneDevWorkflow:
-    """dev-only variant: HydrateState → SpawnDev → Tester → ADO push → ADO merge.
+    """dev-only variant: HydrateState → PrepareWorktree → SpawnDev → Tester → ADO push → ADO merge.
 
     HydrateStateStep reads the current role label at startup and populates ctx
     so restart recovery works correctly:
       role:tester present  → dev_done=True  (skip SpawnDevStep)
       role:ready  present  → dev_done=True, tester_done=True (skip both)
+
+    PrepareWorktreeStep is idempotent on its own (worktree-on-disk + claire:meta
+    comment check) and always runs — it no-ops itself rather than relying on ctx.
 
     Usage::
 
@@ -155,6 +349,7 @@ class FivepointsTfoneDevWorkflow:
     def __init__(self) -> None:
         self._pipeline = pipe(
             HydrateStateStep(),
+            PrepareWorktreeStep(),
             SpawnDevStep(),
             TesterStep(),
             PushToADOStep(),

--- a/src/claire_fivepoints/tfone_dev_steps.py
+++ b/src/claire_fivepoints/tfone_dev_steps.py
@@ -21,11 +21,11 @@ from __future__ import annotations
 
 import json
 import re
-import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+from claire_adapters.github import GhRunner, SubprocessGhRunner
 from claire_core.logging_config import get_logger
 from claire_core.pipeline import StepResult, pipe
 from claire_workflows.fivepoints_pipeline import (
@@ -47,6 +47,7 @@ _LABEL_READY = "role:ready"
 _META_TAG = "<!-- claire:meta -->"
 _PBI_ID_PATTERN = re.compile(r"_workitems/edit/(\d+)")
 _BRANCH_PATTERN = re.compile(r"\*\*Branch:\*\* `([^`]+)`")
+_BRANCH_NAME_PATTERN = re.compile(r"^feature/\d+-[a-z0-9-]+$")
 _SLUG_MAX_LEN = 50
 
 
@@ -75,6 +76,17 @@ def _extract_pbi_id(body: str) -> str:
     return match.group(1)
 
 
+def _is_valid_branch_name(branch_name: str) -> bool:
+    """Guard against forged/malformed branch names before they reach `git push`.
+
+    Anchored to the feature/{pbi_id}-{slug} shape this step itself produces — a
+    value recovered from an (unauthenticated) issue comment that doesn't match
+    can never start with '-' and can't smuggle extra git CLI flags/arguments
+    through the `{branch}:{branch}` refspec.
+    """
+    return bool(_BRANCH_NAME_PATTERN.match(branch_name))
+
+
 # ---------------------------------------------------------------------------
 # GhIssueMetaAdapter — reads the issue, reads/posts the claire:meta comment
 # ---------------------------------------------------------------------------
@@ -89,27 +101,34 @@ class GhIssueMetaAdapter(Protocol):
     def post_comment(self, repo: str, issue: int, body: str) -> None: ...
 
 
+@dataclass
 class GhCliIssueMetaAdapter:
-    """Concrete GhIssueMetaAdapter — shells out to the gh CLI."""
+    """Concrete GhIssueMetaAdapter — delegates to the shared GhRunner abstraction
+    (claire_adapters.github.SubprocessGhRunner), the same gh CLI wrapper already
+    used by GhProjectAdapter / FivepointsGhAdapter elsewhere in this plugin.
+    """
+
+    runner: GhRunner = field(default_factory=SubprocessGhRunner)
 
     def get_issue(self, repo: str, issue: int) -> dict[str, Any]:
-        result = subprocess.run(
-            ["gh", "issue", "view", str(issue), "--repo", repo, "--json", "body,title"],
-            capture_output=True, text=True,
+        output = self.runner.run(
+            "issue", "view", str(issue), "--repo", repo, "--json", "body,title",
         )
-        if result.returncode != 0:
-            raise RuntimeError(f"gh issue view failed: {result.stderr.strip()}")
-        data: dict[str, Any] = json.loads(result.stdout)
+        data: dict[str, Any] = json.loads(output)
         return data
 
     def find_meta_comment(self, repo: str, issue: int) -> str | None:
-        result = subprocess.run(
-            ["gh", "issue", "view", str(issue), "--repo", repo, "--json", "comments"],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
+        try:
+            output = self.runner.run(
+                "issue", "view", str(issue), "--repo", repo, "--json", "comments",
+            )
+        except Exception as exc:
+            logger.debug(
+                "tfone_dev.find_meta_comment.failed",
+                extra={"issue": issue, "repo": repo, "error": str(exc)},
+            )
             return None
-        data = json.loads(result.stdout or "{}")
+        data = json.loads(output or "{}")
         for comment in data.get("comments", []):
             body = comment.get("body", "")
             if body.startswith(_META_TAG):
@@ -117,12 +136,7 @@ class GhCliIssueMetaAdapter:
         return None
 
     def post_comment(self, repo: str, issue: int, body: str) -> None:
-        result = subprocess.run(
-            ["gh", "issue", "comment", str(issue), "--repo", repo, "--body", body],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(f"gh issue comment failed: {result.stderr.strip()}")
+        self.runner.run("issue", "comment", str(issue), "--repo", repo, "--body", body)
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +183,7 @@ class PrepareWorktreeStep:
         if worktree_path.exists():
             meta_body = adapters.meta.find_meta_comment(task.repo, task.issue)
             match = _BRANCH_PATTERN.search(meta_body) if meta_body else None
-            if match:
+            if match and _is_valid_branch_name(match.group(1)):
                 branch_name = match.group(1)
                 logger.info(
                     "tfone_dev.prepare_worktree.skipped",
@@ -187,11 +201,28 @@ class PrepareWorktreeStep:
                         "worktree_path": str(worktree_path),
                     },
                 )
+            if match:
+                # Anyone able to comment on the issue can post a forged claire:meta
+                # comment — never trust a branch_name that doesn't match the
+                # convention this step itself produces. Fall through and re-derive.
+                logger.warning(
+                    "tfone_dev.prepare_worktree.meta_comment_rejected",
+                    extra={
+                        "issue": task.issue,
+                        "repo": task.repo,
+                        "rejected_branch_name": match.group(1),
+                    },
+                )
 
         issue_data = adapters.meta.get_issue(task.repo, task.issue)
         pbi_id = _extract_pbi_id(issue_data.get("body", "") or "")
         slug = _slugify(issue_data.get("title", "") or "")
         branch_name = f"feature/{pbi_id}-{slug}"
+        if not _is_valid_branch_name(branch_name):
+            raise RuntimeError(
+                f"Derived branch name {branch_name!r} failed validation against "
+                f"{_BRANCH_NAME_PATTERN.pattern!r} — check the issue title/body"
+            )
 
         worktree_path_str = RealWorktreePrepare(local_path=adapters.local_path).prepare(
             repo=task.repo,

--- a/src/claire_fivepoints/workflows.py
+++ b/src/claire_fivepoints/workflows.py
@@ -24,6 +24,7 @@ from claire_fivepoints.ado_adapter import FivepointsConcreteADOAdapter
 from claire_fivepoints.tfone_dev_steps import (
     FivepointsTfoneDevAdapters,
     FivepointsTfoneDevWorkflow,
+    GhCliIssueMetaAdapter,
 )
 
 
@@ -75,7 +76,7 @@ def run_fivepoints_tfone_dev_for_issue(
 ) -> StepResult:
     """Entry point for run-pipeline: builds adapters and runs FivepointsTfoneDevWorkflow.
 
-    Workflow shape: DevWithADOContextStep → TesterStep → ADO push → ADO merge.
+    Workflow shape: PrepareWorktree → SpawnDev → TesterStep → ADO push → ADO merge.
 
     The dev reads the ADO work item and downloads attachments before implementing;
     no analyst session is required.
@@ -99,6 +100,7 @@ def run_fivepoints_tfone_dev_for_issue(
         github=FivepointsGhAdapter.default(repo=repo, poll_interval=poll_interval),
         terminal=FivepointsOsascriptTerminalAdapter.with_role_tokens(repo),
         ado=FivepointsConcreteADOAdapter.for_repo(repo),
+        meta=GhCliIssueMetaAdapter(),
         local_path=local_path,
         ado_org=ado_org,
         ado_project=ado_project,


### PR DESCRIPTION
## Summary

- Removes `prepare_worktree_step` from `azure_issue_bridge.bridge_pipeline` — the bridge no longer creates worktrees.
- Adds `PrepareWorktreeStep` to `tfone_dev_steps.py` (between `HydrateStateStep` and `SpawnDevStep`): derives `feature/{pbi_id}-{slug}` from the issue body/title (FivePoints DEV_RULES #5 convention), creates the worktree via the existing `RealWorktreePrepare`, and persists the branch name as a `<!-- claire:meta -->` issue comment for idempotent restart recovery.
- Replaces the core-imported `PushToADOStep` with a local variant that reads `branch_name` from `ctx` (set by `PrepareWorktreeStep`) instead of deriving `issue-{N}`.
- `FivepointsConcreteADOAdapter.push_branch_and_create_pr(issue, branch_name)` — new required `branch_name` param; local `FivepointsADOAdapter` Protocol added (not the core one, which still derives the branch from the issue number).
- `SubprocessGitRunner` now takes a `cwd`, wired from `local_path` in `FivepointsConcreteADOAdapter.for_repo()` — `git push` no longer depends on the caller's working directory.
- Operator config (not in this diff): `~/.config/claire/github_repos.yaml` `ado_repo: TFIOne` → `TFIOneGit`; added the `ado` remote to `~/projects/fivepoints` pointing at `TFIOneGit`. Documented in `domain/operational/PIPELINE_WORKFLOW.md`.
- Fixed `src/claire_fivepoints/tests/test_tfone_dev.py`, which was left uncollectable by `bf35d71` (referenced the removed `DevWithADOContextStep`/`ado_context` — pre-existing breakage, unrelated to this issue but in the same file). Rewrote it for the current `SpawnDevStep`-based pipeline and added coverage for `PrepareWorktreeStep`, the local `PushToADOStep`, and `GhCliIssueMetaAdapter`.

### Known side effect

`fivepoints.tfone.full` (`FivepointsFullWorkflow`, still using core's single-arg `PushToADOStep`) would now fail at runtime if invoked, since `FivepointsConcreteADOAdapter.push_branch_and_create_pr` requires `branch_name`. It's not the active workflow (`github_repos.yaml` has `workflow: fivepoints.tfone.dev` for the fivepoints repo) — flagging for visibility rather than fixing out of scope.

### Pre-existing, unrelated failures (verified via `git stash` before this branch's changes)

- `azure_issue_bridge/tests/test_gmail_api_adapter.py::test_fetch_returns_emails`
- `azure_issue_bridge/tests/test_pipeline.py::test_pipeline_full_end_to_end` (expects `assign_step` in the pipe — deliberately removed in `e8f1b29`)
- `tests/test_cli.py::TestFivepointsStepList::*` (7 tests) — `ModuleNotFoundError: No module named 'yaml'`, missing `pyyaml` dependency declaration

None of these are touched by this PR; left alone to keep the diff focused.

## Verification Log

```
$ uv run pytest src/claire_fivepoints/ -q
9 failed, 148 passed in 0.41s
# the 9 failures are the pre-existing ones listed above (confirmed via git stash)
# before this branch: src/claire_fivepoints/tests/test_tfone_dev.py failed to even collect
```

```
$ uv run python -c "
from claire_fivepoints.tfone_dev_steps import _slugify, _extract_pbi_id
print(_slugify('PBI: Case Face Sheet - Enhancement'))
print(_extract_pbi_id('... https://dev.azure.com/Org/Proj/_workitems/edit/18840 ...'))
"
case-face-sheet-enhancement
18840
```

```
$ git -C ~/projects/fivepoints ls-remote ado HEAD
52554547eadc52a4824fc1c0627a5e332e751dbc	HEAD
```

## Test plan

- [x] `bridge_pipeline` no longer includes `prepare_worktree_step` (unit + import check)
- [x] `PrepareWorktreeStep`: fresh start derives `feature/{pbi_id}-{slug}`, creates worktree, posts `claire:meta` comment
- [x] `PrepareWorktreeStep`: idempotent — worktree exists + meta comment found → no-op, no re-fetch/re-create
- [x] `PrepareWorktreeStep`: worktree exists but no meta comment → falls through to normal create+comment path
- [x] `PushToADOStep`: reads `branch_name` from ctx, calls adapter with both `issue` and `branch_name`
- [x] `FivepointsConcreteADOAdapter.push_branch_and_create_pr`: pushes the given branch name (not `issue-{N}`)
- [x] `SubprocessGitRunner`: `cwd` passed through to `git push`; `for_repo()` wires `local_path` into it
- [x] `GhCliIssueMetaAdapter`: gh CLI wrapper unit tested (get_issue / find_meta_comment / post_comment, success + failure paths)
- [x] Full `FivepointsTfoneDevWorkflow` scenario tests (fresh start, restart with role:tester/role:ready, restart reusing meta-comment branch, issue closed, ADO merge failure)
- [x] `github_repos.yaml` updated, `ado` remote added and reachable (`git ls-remote`)


Closes #178
