### PR TITLE
fix: run_fivepoints_tfone_dev_for_issue — ajouter support dry_run

### DIFF
--- a/src/claire_fivepoints/adapters.py
+++ b/src/claire_fivepoints/adapters.py
@@ -107,8 +107,8 @@ class FivepointsOsascriptTerminalAdapter:
         self._open_role_terminal(issue, repo, "analyst", self.analyst_token)
         logger.info("fivepoints.spawn_analyst.terminal", extra={"issue": issue, "repo": repo})
 
-    def spawn_dev(self, issue: int, repo: str) -> None:
-        self._open_role_terminal(issue, repo, "dev", self.dev_token)
+    def spawn_dev(self, issue: int, repo: str, *, dry_run: bool = False) -> None:
+        self._open_role_terminal(issue, repo, "dev", self.dev_token, dry_run=dry_run)
         logger.info("fivepoints.spawn_dev.terminal", extra={"issue": issue, "repo": repo})
 
     def spawn_tester(self, issue: int, repo: str) -> None:
@@ -116,7 +116,7 @@ class FivepointsOsascriptTerminalAdapter:
         logger.info("fivepoints.spawn_tester.terminal", extra={"issue": issue, "repo": repo})
 
     def _open_role_terminal(
-        self, issue: int, repo: str, role: str, token: str | None
+        self, issue: int, repo: str, role: str, token: str | None, *, dry_run: bool = False
     ) -> None:
         local_path = load_local_path(repo, config_dir=self.config_dir)
         entry = find_repo_entry(repo, config_dir=self.config_dir) or {}
@@ -124,11 +124,13 @@ class FivepointsOsascriptTerminalAdapter:
         prefix = build_token_export_prefix(token) if token else ""
         cd_prefix = f"cd {shlex.quote(str(local_path))} && "
         persona_flag = f"--persona {shlex.quote(persona)} " if persona else ""
+        dry_run_flag = "--dry-run " if dry_run else ""
         cmd = (
             f"{prefix}{cd_prefix}claire start "
             f"--issue {issue} "
             f"--repo {shlex.quote(repo)} "
             f"{persona_flag}"
+            f"{dry_run_flag}"
         )
         escaped = cmd.replace('"', '\\"')
         script = f'tell application "Terminal" to do script "{escaped}"'

--- a/src/claire_fivepoints/tests/test_tfone_dev.py
+++ b/src/claire_fivepoints/tests/test_tfone_dev.py
@@ -44,6 +44,7 @@ def _make_adapters(
     issue_body: str = _DEFAULT_BODY,
     issue_title: str = _DEFAULT_TITLE,
     meta_comment: str | None = None,
+    dry_run: bool = False,
 ) -> FivepointsTfoneDevAdapters:
     gh = MagicMock()
     gh.is_issue_closed.return_value = closed
@@ -69,6 +70,7 @@ def _make_adapters(
         local_path=tmp_path,
         ado_org="TestOrg",
         ado_project="TestProject",
+        dry_run=dry_run,
     )
 
 
@@ -327,10 +329,17 @@ class TestSpawnDevStep:
         task = _make_task(issue=5)
         result = SpawnDevStep()(task, {}, adapters)
         assert result.ok
-        adapters.terminal.spawn_dev.assert_called_once_with(5, "org/repo")
+        adapters.terminal.spawn_dev.assert_called_once_with(5, "org/repo", dry_run=False)
         adapters.github.wait_for_label.assert_called_once_with(
             "org/repo", 5, "role:tester"
         )
+
+    def test_forwards_dry_run_to_terminal(self, tmp_path: Path) -> None:
+        adapters = _make_adapters(tmp_path, dry_run=True)
+        task = _make_task(issue=5)
+        result = SpawnDevStep()(task, {}, adapters)
+        assert result.ok
+        adapters.terminal.spawn_dev.assert_called_once_with(5, "org/repo", dry_run=True)
 
     def test_returns_dev_done_and_pr_number(self, tmp_path: Path) -> None:
         adapters = _make_adapters(tmp_path, pr_number=99)
@@ -521,3 +530,44 @@ class TestRunFivepointsTfoneDevForIssue:
         assert task.issue == 42
         assert task.repo == "org/repo"
         assert isinstance(adapters.meta, GhCliIssueMetaAdapter)
+        assert adapters.dry_run is False
+
+    def test_entry_point_accepts_and_forwards_dry_run(self, tmp_path: Path) -> None:
+        """claire run-pipeline run --dry-run calls the entry point with dry_run=True
+        (packages/cli/src/claire_cli/commands/run_pipeline.py: _accepts_kwarg check) —
+        this must not raise TypeError, and must reach FivepointsTfoneDevAdapters.dry_run."""
+        from claire_core.pipeline import StepResult as _SR
+        from claire_fivepoints.workflows import run_fivepoints_tfone_dev_for_issue
+
+        mock_workflow_instance = MagicMock()
+        mock_workflow_instance.run.return_value = _SR(ok=True, data={})
+
+        mock_ado_cls = MagicMock()
+        mock_ado_cls.for_repo.return_value = MagicMock()
+        mock_workflow_cls = MagicMock(return_value=mock_workflow_instance)
+
+        with (
+            patch(
+                "claire_fivepoints.workflows.FivepointsGhAdapter.default",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "claire_fivepoints.workflows.FivepointsOsascriptTerminalAdapter.with_role_tokens",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "claire_fivepoints.workflows.load_local_path",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "claire_fivepoints.workflows.find_repo_entry",
+                return_value={"ado_org": "Org", "ado_project": "Proj"},
+            ),
+            patch("claire_fivepoints.workflows.FivepointsConcreteADOAdapter", mock_ado_cls),
+            patch("claire_fivepoints.workflows.FivepointsTfoneDevWorkflow", mock_workflow_cls),
+        ):
+            result = run_fivepoints_tfone_dev_for_issue(42, "org/repo", dry_run=True)
+
+        assert result.ok
+        adapters = mock_workflow_instance.run.call_args[0][1]
+        assert adapters.dry_run is True

--- a/src/claire_fivepoints/tests/test_workflows.py
+++ b/src/claire_fivepoints/tests/test_workflows.py
@@ -100,6 +100,50 @@ class TestFivepointsGhAdapter:
 
 
 # ---------------------------------------------------------------------------
+# FivepointsOsascriptTerminalAdapter.spawn_dev — dry_run flag
+# ---------------------------------------------------------------------------
+
+
+class TestFivepointsOsascriptTerminalAdapterSpawnDev:
+    def _make_adapter(self) -> FivepointsOsascriptTerminalAdapter:
+        return FivepointsOsascriptTerminalAdapter(runner=MagicMock())
+
+    def test_spawn_dev_appends_dry_run_flag_when_true(self) -> None:
+        adapter = self._make_adapter()
+        with (
+            patch(
+                "claire_fivepoints.adapters.load_local_path",
+                return_value="/repo",
+            ),
+            patch(
+                "claire_fivepoints.adapters.find_repo_entry",
+                return_value={},
+            ),
+        ):
+            adapter.spawn_dev(42, "org/repo", dry_run=True)
+
+        script = adapter.runner.run.call_args[0][0]
+        assert "--dry-run" in script
+
+    def test_spawn_dev_omits_dry_run_flag_by_default(self) -> None:
+        adapter = self._make_adapter()
+        with (
+            patch(
+                "claire_fivepoints.adapters.load_local_path",
+                return_value="/repo",
+            ),
+            patch(
+                "claire_fivepoints.adapters.find_repo_entry",
+                return_value={},
+            ),
+        ):
+            adapter.spawn_dev(42, "org/repo")
+
+        script = adapter.runner.run.call_args[0][0]
+        assert "--dry-run" not in script
+
+
+# ---------------------------------------------------------------------------
 # run_fivepoints_tfone_github_for_issue
 # ---------------------------------------------------------------------------
 

--- a/src/claire_fivepoints/tfone_dev_steps.py
+++ b/src/claire_fivepoints/tfone_dev_steps.py
@@ -155,6 +155,7 @@ class FivepointsTfoneDevAdapters:
     local_path: Path
     ado_org: str
     ado_project: str
+    dry_run: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -276,7 +277,7 @@ class SpawnDevStep:
             )
             return StepResult(ok=True, data={})
 
-        adapters.terminal.spawn_dev(task.issue, task.repo)
+        adapters.terminal.spawn_dev(task.issue, task.repo, dry_run=adapters.dry_run)
         logger.info(
             "tfone_dev.spawn_dev.done",
             extra={"issue": task.issue, "repo": task.repo},

--- a/src/claire_fivepoints/workflows.py
+++ b/src/claire_fivepoints/workflows.py
@@ -73,6 +73,7 @@ def run_fivepoints_tfone_dev_for_issue(
     repo: str,
     *,
     poll_interval: float = 30.0,
+    dry_run: bool = False,
 ) -> StepResult:
     """Entry point for run-pipeline: builds adapters and runs FivepointsTfoneDevWorkflow.
 
@@ -80,6 +81,9 @@ def run_fivepoints_tfone_dev_for_issue(
 
     The dev reads the ADO work item and downloads attachments before implementing;
     no analyst session is required.
+
+    `dry_run` is forwarded to `terminal.spawn_dev()`, which passes `--dry-run` to
+    `claire start` — no dry-run short-circuit logic lives in this workflow itself.
 
     Requires ADO configuration in github_repos.yaml:
       ado_org, ado_project, ado_repo
@@ -104,5 +108,6 @@ def run_fivepoints_tfone_dev_for_issue(
         local_path=local_path,
         ado_org=ado_org,
         ado_project=ado_project,
+        dry_run=dry_run,
     )
     return FivepointsTfoneDevWorkflow().run(task, adapters)


### PR DESCRIPTION
## Problème

`claire run-pipeline run --workflow fivepoints.tfone.dev --dry-run` levait un `TypeError: run_fivepoints_tfone_dev_for_issue() got an unexpected keyword argument 'dry_run'`.

Root cause confirmée : `packages/cli/src/claire_cli/commands/run_pipeline.py` appelle l'entry point avec `dry_run=True` dès que `_accepts_kwarg(workflow_entry, "dry_run")` est vrai — l'entry point fivepoints ne déclarait pas ce paramètre.

## Fix

Suivant la clarification de l'auteur de l'issue (aucune logique dry_run dans le workflow lui-même — `claire start` s'en charge) :

1. `src/claire_fivepoints/workflows.py` — `run_fivepoints_tfone_dev_for_issue` accepte `dry_run: bool = False`, transmis à `FivepointsTfoneDevAdapters`.
2. `src/claire_fivepoints/tfone_dev_steps.py` — `FivepointsTfoneDevAdapters` gagne un champ `dry_run: bool = False` ; `SpawnDevStep` le transmet à `adapters.terminal.spawn_dev(..., dry_run=...)`.
3. `src/claire_fivepoints/adapters.py` — `FivepointsOsascriptTerminalAdapter.spawn_dev` / `_open_role_terminal` acceptent `dry_run` et ajoutent `--dry-run` à la commande `claire start` lorsqu'il est vrai.

## Verification Log

```
$ uv run pytest src/claire_fivepoints/tests/test_tfone_dev.py src/claire_fivepoints/tests/test_workflows.py -q
............................................................             [100%]
60 passed in 0.09s

$ uv run pytest src/ -q
9 failed, 160 passed in 1.91s
```

Les 9 échecs restants sont préexistants sur `main` (dépendance `yaml` manquante dans l'environnement local, sans rapport avec ce changement — vérifié en stashant le diff et en relançant les mêmes tests).

```
$ uv run python -c "
import inspect
from claire_fivepoints.workflows import run_fivepoints_tfone_dev_for_issue
sig = inspect.signature(run_fivepoints_tfone_dev_for_issue)
assert 'dry_run' in sig.parameters
print('OK: dry_run accepted')
"
OK: dry_run accepted
```

Closes #182