### PR TITLE
refactor: PrepareWorktreeStep — retirer création de branche, déléguer à l'agent dev

### DIFF
--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -33,7 +33,9 @@ ADO PBI assigned to andre.perez@dothelpllc.com
   → session-monitor detects the assignment, runs:
       claire run-pipeline run --workflow fivepoints.tfone.dev --issue N
   → PrepareWorktreeStep creates <local>/.claire/worktrees/issue-{N}
-      on branch feature/{pbi_id}-{slug} (see § Worktree Creation below)
+      on develop, synced from ado/dev (see § Worktree Creation below)
+  → the dev agent creates feature/{pbi_id}-{slug} itself and posts it
+      in a <!-- claire:meta --> comment (see fivepoints-dev persona)
   → agent receives CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET> for wait/PR targeting
 ```
 
@@ -119,30 +121,30 @@ step — `PrepareWorktreeStep`, right after `HydrateStateStep` and before `Spawn
 worktree creation. The bridge itself (`prepare_worktree_step` in `azure_issue_bridge/steps.py`)
 is **not** wired into `bridge_pipeline` — worktree creation lives entirely in the dev pipeline.
 
-### What `PrepareWorktreeStep` does
+### What `PrepareWorktreeStep` does (issue #184)
 
-1. Checks whether `<local_path>/.claire/worktrees/issue-{N}` already exists. If it does, it reads
-   the branch name back from a `<!-- claire:meta -->` comment on the issue and returns
-   immediately — **idempotent on pipeline restart**, no second worktree, no re-derivation.
-2. Otherwise: `gh issue view N --repo R --json body,title` to read the issue.
-3. Extracts the ADO PBI id from the body via the `_workitems/edit/(\d+)` link FivePoints already
-   embeds in every issue (see `_build_issue_body` in `azure_issue_bridge/steps.py`).
-4. Derives a slug from the title — `PBI: Case Face Sheet - Enhancement` → `case-face-sheet-enhancement`
-   (strip `PBI:` prefix, lowercase, non-alphanumeric runs collapsed to `-`, capped at 50 chars).
-5. Branch name: `feature/{pbi_id}-{slug}` — the FivePoints convention
-   (`claire domain read fivepoints knowledge DEV_RULES` rule #5), replacing the old `pbi-{N}` /
-   `issue-{N}` naming.
-6. Creates the worktree via the existing `RealWorktreePrepare` adapter
-   (`azure_issue_bridge/worktree.py`), based on `develop`.
-7. Posts a `<!-- claire:meta -->` comment on the issue recording the branch and worktree path —
-   the same tag step 1 reads back on restart. Both the freshly-derived branch name and any
-   branch name recovered from a `claire:meta` comment are validated against
-   `^feature/\d+-[a-z0-9-]+$` before use — a malformed or forged comment is never trusted as-is.
+`PrepareWorktreeStep` only prepares the worktree — it does not derive or create a named
+branch. Branch naming is the dev agent's responsibility (see the `fivepoints-dev` persona
+checklist).
 
-`SpawnDevStep` then opens the dev terminal in the worktree as usual. `PushToADOStep`
+1. Checks whether `<local_path>/.claire/worktrees/issue-{N}` already exists. If it does,
+   returns immediately — **idempotent on pipeline restart**, no second worktree.
+2. Otherwise, via `RealWorktreePrepare` (`azure_issue_bridge/worktree.py`):
+   a. `git fetch ado dev` — pulls the latest `TFIOneGit/dev` from the ADO remote. The
+      GitHub mirror (`origin/develop`) can lag behind ADO, so this step syncs directly
+      from ADO rather than trusting the mirror.
+   b. `git branch -f develop ado/dev` — force-updates the local `develop` branch to match.
+   c. `git worktree add --detach <path> develop` — checks out `develop` in the new
+      worktree in a **detached HEAD** state. No branch is created or named here.
+
+The dev agent (`fivepoints-dev` persona), after reading the issue and the FDS, creates
+`feature/{pbi_id}-{slug}` itself — the FivePoints convention
+(`claire domain read fivepoints knowledge DEV_RULES` rule #5) — and posts it in a
+`<!-- claire:meta -->` comment on the issue. `PushToADOStep`
 (`claire_fivepoints.tfone_dev_steps`, a local variant — not the one in core's
-`claire_workflows.fivepoints_pipeline`) reads the `branch_name` this step put in `ctx` and
-pushes that exact branch to the `ado` remote, instead of re-deriving `issue-{N}`.
+`claire_workflows.fivepoints_pipeline`) reads `branch_name` back from that comment
+(validated against `^feature/\d+-[a-z0-9-]+$` — a malformed or forged comment is never
+trusted as-is) and pushes that exact branch to the `ado` remote.
 
 `CLAIRE_WAIT_REPO=<ADO_BRIDGE_SYNC_TARGET>` is still set in the agent's environment so
 `claire wait` targets the correct repo for PR creation and review polling.

--- a/domain/operational/AZURE_ISSUE_BRIDGE.md
+++ b/domain/operational/AZURE_ISSUE_BRIDGE.md
@@ -132,7 +132,10 @@ checklist).
 2. Otherwise, via `RealWorktreePrepare` (`azure_issue_bridge/worktree.py`):
    a. `git fetch ado dev` — pulls the latest `TFIOneGit/dev` from the ADO remote. The
       GitHub mirror (`origin/develop`) can lag behind ADO, so this step syncs directly
-      from ADO rather than trusting the mirror.
+      from ADO rather than trusting the mirror. **Prerequisite:** the `ado` git remote
+      is not auto-created — see `claire domain read fivepoints operational
+      PIPELINE_WORKFLOW` § "V2 (fivepoints.tfone.dev) prerequisite — the ado remote
+      is NOT auto-created" for the one-time per-machine setup command.
    b. `git branch -f develop ado/dev` — force-updates the local `develop` branch to match.
    c. `git worktree add --detach <path> develop` — checks out `develop` in the new
       worktree in a **detached HEAD** state. No branch is created or named here.

--- a/domain/persona/fivepoints-dev.md
+++ b/domain/persona/fivepoints-dev.md
@@ -59,6 +59,15 @@ Issue body present in CLAUDE.md — session started with `claire start --issue N
   GET https://dev.azure.com/{org}/{project}/_apis/wit/workitems/{id}?$expand=relations&api-version=7.1
   ```
   Filter `relations[].rel == "AttachedFile"` and download each to `.fds-cache/<pbi>/` in the worktree. Read `FDS_<NAME>.md` from there.
+- [ ] **Create the feature branch** — `PrepareWorktreeStep` only prepares the worktree on `develop`; it no longer names a branch. After reading the issue and the FDS, derive a short slug from the PBI title/FDS and create the branch yourself:
+  ```bash
+  git checkout -b feature/<pbi_id>-<slug>
+  ```
+  Then post the branch name in a `<!-- claire:meta -->` comment on the issue — `PushToADOStep` reads it from there to know what to push:
+  ```bash
+  gh issue comment <N> --repo CLAIRE-Fivepoints/fivepoints --body "<!-- claire:meta -->
+  **Branch:** \`feature/<pbi_id>-<slug>\`"
+  ```
 - [ ] Search relevant context — `claire context` on 2–3 keywords from the issue
 
 ### Implementation Workflow

--- a/src/claire_fivepoints/azure_issue_bridge/worktree.py
+++ b/src/claire_fivepoints/azure_issue_bridge/worktree.py
@@ -1,9 +1,12 @@
 """azure_issue_bridge.worktree — WorktreePrepare adapter: Protocol + real/mock implementations.
 
-Responsible for creating a git worktree for a GitHub issue on a named branch
-before the issue is assigned to the agent.  The worktree is created at the
-standard path (<local_path>/.claire/worktrees/issue-<N>) so that claire start
---issue N --repo R reuses it without re-creating (idempotent hand-off).
+Responsible for creating a git worktree for a GitHub issue before the issue is
+assigned to the agent.  The worktree is created at the standard path
+(<local_path>/.claire/worktrees/issue-<N>) so that claire start --issue N
+--repo R reuses it without re-creating (idempotent hand-off). Naming a branch
+for the worktree is optional (branch_name) — when omitted, the worktree checks
+out base_branch in a detached HEAD state and branch naming is left to the
+caller (e.g. the dev agent, see PrepareWorktreeStep).
 """
 
 from __future__ import annotations
@@ -64,6 +67,14 @@ class RealWorktreePrepare:
         base_branch: str,
         branch_name: str | None = None,
     ) -> str:
+        if base_branch != "develop":
+            raise ValueError(
+                f"RealWorktreePrepare only supports base_branch='develop' "
+                f"(got {base_branch!r}) — the sync fetch is hardcoded to the "
+                "ado remote's dev branch (TFIOneGit/dev) and force-updates "
+                "base_branch to match it."
+            )
+
         local_path = Path(self._local_path or self._resolve_local_path(repo))
         worktree_path = local_path / ".claire" / "worktrees" / f"issue-{issue}"
 

--- a/src/claire_fivepoints/azure_issue_bridge/worktree.py
+++ b/src/claire_fivepoints/azure_issue_bridge/worktree.py
@@ -24,15 +24,19 @@ class WorktreePrepareAdapter(Protocol):
         repo: str,
         issue: int,
         base_branch: str,
-        branch_name: str,
+        branch_name: str | None = None,
     ) -> str:
-        """Create a worktree on base_branch with a new branch branch_name.
+        """Create a worktree on base_branch, optionally on a new named branch.
 
         Args:
             repo:        GitHub repo slug, e.g. "CLAIRE-Fivepoints/fivepoints".
             issue:       GitHub issue number.
-            base_branch: Branch to base the new branch on, e.g. "develop".
-            branch_name: Name of the new branch, e.g. "pbi-42".
+            base_branch: Branch to base the worktree on, e.g. "develop".
+            branch_name: Name of a new branch to create for the worktree, e.g.
+                         "pbi-42". When omitted, the worktree checks out
+                         base_branch in a detached HEAD state — no branch is
+                         created or named. Branch naming is the dev agent's
+                         responsibility (see PrepareWorktreeStep).
 
         Returns:
             Absolute filesystem path to the created (or already-existing) worktree.
@@ -58,7 +62,7 @@ class RealWorktreePrepare:
         repo: str,
         issue: int,
         base_branch: str,
-        branch_name: str,
+        branch_name: str | None = None,
     ) -> str:
         local_path = Path(self._local_path or self._resolve_local_path(repo))
         worktree_path = local_path / ".claire" / "worktrees" / f"issue-{issue}"
@@ -67,35 +71,59 @@ class RealWorktreePrepare:
             logger.info("Worktree already exists at %s — reusing", worktree_path)
             return str(worktree_path)
 
-        logger.info("Fetching %s from origin to get latest %s", repo, base_branch)
-        self._run(
-            ["git", "-C", str(local_path), "fetch", "origin", base_branch],
-            repo=repo,
-        )
-
         logger.info(
-            "Creating worktree %s on branch %s (from origin/%s)",
-            worktree_path,
-            branch_name,
-            base_branch,
+            "Fetching %s from ado remote to sync %s with TFIOneGit/dev", repo, base_branch
         )
+        self._run(["git", "-C", str(local_path), "fetch", "ado", "dev"], repo=repo)
         self._run(
-            [
-                "git",
-                "-C",
-                str(local_path),
-                "worktree",
-                "add",
-                "--track",
-                "-b",
-                branch_name,
-                str(worktree_path),
-                f"origin/{base_branch}",
-            ],
+            ["git", "-C", str(local_path), "branch", "-f", base_branch, "ado/dev"],
             repo=repo,
         )
 
-        logger.info("Worktree created at %s (branch: %s)", worktree_path, branch_name)
+        if branch_name:
+            logger.info(
+                "Creating worktree %s on branch %s (from %s)",
+                worktree_path,
+                branch_name,
+                base_branch,
+            )
+            self._run(
+                [
+                    "git",
+                    "-C",
+                    str(local_path),
+                    "worktree",
+                    "add",
+                    "--track",
+                    "-b",
+                    branch_name,
+                    str(worktree_path),
+                    base_branch,
+                ],
+                repo=repo,
+            )
+            logger.info("Worktree created at %s (branch: %s)", worktree_path, branch_name)
+        else:
+            logger.info(
+                "Creating worktree %s on %s (detached — no named branch)",
+                worktree_path,
+                base_branch,
+            )
+            self._run(
+                [
+                    "git",
+                    "-C",
+                    str(local_path),
+                    "worktree",
+                    "add",
+                    "--detach",
+                    str(worktree_path),
+                    base_branch,
+                ],
+                repo=repo,
+            )
+            logger.info("Worktree created at %s (detached from %s)", worktree_path, base_branch)
+
         return str(worktree_path)
 
     @staticmethod
@@ -158,7 +186,7 @@ class MockWorktreePrepare:
         repo: str,
         issue: int,
         base_branch: str,
-        branch_name: str,
+        branch_name: str | None = None,
     ) -> str:
         entry = {
             "repo": repo,
@@ -168,4 +196,4 @@ class MockWorktreePrepare:
         }
         self.prepared.append(entry)
         logger.debug("MockWorktreePrepare.prepare called: %s", entry)
-        return f"/mock/worktrees/{branch_name}"
+        return f"/mock/worktrees/{branch_name or f'issue-{issue}'}"

--- a/src/claire_fivepoints/tests/test_tfone_dev.py
+++ b/src/claire_fivepoints/tests/test_tfone_dev.py
@@ -20,14 +20,17 @@ from claire_fivepoints.tfone_dev_steps import (
     PushToADOStep,
     SpawnDevStep,
     TesterStep,
-    _extract_pbi_id,
     _is_valid_branch_name,
-    _slugify,
 )
 
 _DEFAULT_BODY = "ADO: https://dev.azure.com/Org/Proj/_workitems/edit/18840"
 _DEFAULT_TITLE = "PBI: Case Face Sheet - Enhancement"
 _DEFAULT_BRANCH = "feature/18840-case-face-sheet-enhancement"
+_DEFAULT_META_COMMENT = (
+    "<!-- claire:meta -->\n"
+    f"**Branch:** `{_DEFAULT_BRANCH}`\n"
+    "**Worktree:** `/mock/worktree`"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -43,7 +46,7 @@ def _make_adapters(
     pr_number: int | None = 10,
     issue_body: str = _DEFAULT_BODY,
     issue_title: str = _DEFAULT_TITLE,
-    meta_comment: str | None = None,
+    meta_comment: str | None = _DEFAULT_META_COMMENT,
     dry_run: bool = False,
 ) -> FivepointsTfoneDevAdapters:
     gh = MagicMock()
@@ -81,37 +84,6 @@ def _make_task(issue: int = 42, repo: str = "org/repo"):
 
 def _patch_worktree_prepare(worktree_path: str = "/mock/worktrees/issue-42"):
     return patch("claire_fivepoints.tfone_dev_steps.RealWorktreePrepare")
-
-
-# ---------------------------------------------------------------------------
-# _slugify / _extract_pbi_id
-# ---------------------------------------------------------------------------
-
-
-class TestSlugify:
-    def test_strips_pbi_prefix_and_lowercases(self) -> None:
-        assert _slugify("PBI: Case Face Sheet - Enhancement") == "case-face-sheet-enhancement"
-
-    def test_no_pbi_prefix(self) -> None:
-        assert _slugify("Client Management Test") == "client-management-test"
-
-    def test_truncates_to_max_len(self) -> None:
-        title = "PBI: " + "word " * 30
-        slug = _slugify(title)
-        assert len(slug) <= 50
-
-    def test_collapses_non_alnum_runs(self) -> None:
-        assert _slugify("PBI: A/B  &  C!!!") == "a-b-c"
-
-
-class TestExtractPbiId:
-    def test_extracts_id_from_workitems_link(self) -> None:
-        body = "See https://dev.azure.com/Org/Proj/_workitems/edit/18840 for details"
-        assert _extract_pbi_id(body) == "18840"
-
-    def test_raises_when_no_link_present(self) -> None:
-        with pytest.raises(RuntimeError, match="pbi_id"):
-            _extract_pbi_id("no ado link here")
 
 
 class TestIsValidBranchName:
@@ -216,8 +188,8 @@ class TestGhCliIssueMetaAdapter:
 
 
 class TestPrepareWorktreeStep:
-    def test_fresh_start_creates_worktree_and_posts_comment(self, tmp_path: Path) -> None:
-        adapters = _make_adapters(tmp_path, meta_comment=None)
+    def test_fresh_start_creates_worktree(self, tmp_path: Path) -> None:
+        adapters = _make_adapters(tmp_path)
         task = _make_task(issue=18842, repo="org/repo")
         worktree_path = str(tmp_path / ".claire" / "worktrees" / "issue-18842")
 
@@ -227,87 +199,35 @@ class TestPrepareWorktreeStep:
 
         assert result.ok
         assert result.data["worktree_ready"] is True
-        assert result.data["branch_name"] == _DEFAULT_BRANCH
         assert result.data["worktree_path"] == worktree_path
+        assert "branch_name" not in result.data
 
         mock_cls.assert_called_once_with(local_path=tmp_path)
         mock_cls.return_value.prepare.assert_called_once_with(
             repo="org/repo",
             issue=18842,
             base_branch="develop",
-            branch_name=_DEFAULT_BRANCH,
         )
 
-        adapters.meta.post_comment.assert_called_once()
-        posted_repo, posted_issue, posted_body = adapters.meta.post_comment.call_args[0]
-        assert posted_repo == "org/repo"
-        assert posted_issue == 18842
-        assert "<!-- claire:meta -->" in posted_body
-        assert f"`{_DEFAULT_BRANCH}`" in posted_body
-        assert worktree_path in posted_body
-
-    def test_idempotent_when_worktree_exists_and_meta_comment_found(self, tmp_path: Path) -> None:
-        worktree_dir = tmp_path / ".claire" / "worktrees" / "issue-7"
-        worktree_dir.mkdir(parents=True)
-        meta_comment = (
-            "<!-- claire:meta -->\n"
-            "**Branch:** `feature/100-existing-branch`\n"
-            "**Worktree:** `/some/path`"
-        )
-        adapters = _make_adapters(tmp_path, meta_comment=meta_comment)
-        task = _make_task(issue=7)
-
-        with _patch_worktree_prepare() as mock_cls:
-            result = PrepareWorktreeStep()(task, {}, adapters)
-
-        assert result.ok
-        assert result.data["branch_name"] == "feature/100-existing-branch"
-        mock_cls.assert_not_called()
         adapters.meta.get_issue.assert_not_called()
+        adapters.meta.find_meta_comment.assert_not_called()
         adapters.meta.post_comment.assert_not_called()
 
-    def test_falls_through_when_worktree_exists_but_no_meta_comment(self, tmp_path: Path) -> None:
+    def test_idempotent_when_worktree_exists(self, tmp_path: Path) -> None:
         worktree_dir = tmp_path / ".claire" / "worktrees" / "issue-7"
         worktree_dir.mkdir(parents=True)
-        adapters = _make_adapters(tmp_path, meta_comment=None)
+        adapters = _make_adapters(tmp_path)
         task = _make_task(issue=7)
 
         with _patch_worktree_prepare() as mock_cls:
-            mock_cls.return_value.prepare.return_value = str(worktree_dir)
             result = PrepareWorktreeStep()(task, {}, adapters)
 
         assert result.ok
-        mock_cls.return_value.prepare.assert_called_once()
-        adapters.meta.post_comment.assert_called_once()
-
-    def test_missing_pbi_id_raises(self, tmp_path: Path) -> None:
-        adapters = _make_adapters(tmp_path, issue_body="no ado link here", meta_comment=None)
-        task = _make_task(issue=9)
-        with pytest.raises(RuntimeError, match="pbi_id"):
-            PrepareWorktreeStep()(task, {}, adapters)
-
-    def test_rejects_forged_meta_comment_and_re_derives(self, tmp_path: Path) -> None:
-        """A branch_name that doesn't match feature/{pbi_id}-{slug} — e.g. posted by an
-        attacker able to comment on the issue, or a stale/malformed comment — must never
-        be trusted as-is. Falls through to deriving + recreating instead."""
-        worktree_dir = tmp_path / ".claire" / "worktrees" / "issue-7"
-        worktree_dir.mkdir(parents=True)
-        forged_comment = (
-            "<!-- claire:meta -->\n"
-            "**Branch:** `--upload-pack=evil`\n"
-            "**Worktree:** `/some/path`"
-        )
-        adapters = _make_adapters(tmp_path, meta_comment=forged_comment)
-        task = _make_task(issue=7)
-
-        with _patch_worktree_prepare() as mock_cls:
-            mock_cls.return_value.prepare.return_value = str(worktree_dir)
-            result = PrepareWorktreeStep()(task, {}, adapters)
-
-        assert result.ok
-        assert result.data["branch_name"] == _DEFAULT_BRANCH
-        mock_cls.return_value.prepare.assert_called_once()
-        adapters.meta.post_comment.assert_called_once()
+        assert result.data["worktree_path"] == str(worktree_dir)
+        mock_cls.assert_not_called()
+        adapters.meta.get_issue.assert_not_called()
+        adapters.meta.find_meta_comment.assert_not_called()
+        adapters.meta.post_comment.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -386,14 +306,34 @@ class TestTesterStep:
 
 
 class TestPushToADOStep:
-    def test_reads_branch_name_from_ctx_and_calls_adapter(self, tmp_path: Path) -> None:
-        adapters = _make_adapters(tmp_path)
+    def test_reads_branch_name_from_meta_comment_and_calls_adapter(self, tmp_path: Path) -> None:
+        meta_comment = "<!-- claire:meta -->\n**Branch:** `feature/1-foo`\n**Worktree:** `/some/path`"
+        adapters = _make_adapters(tmp_path, meta_comment=meta_comment)
         adapters.ado.push_branch_and_create_pr.return_value = 77
         task = _make_task(issue=5)
-        result = PushToADOStep()(task, {"branch_name": "feature/1-foo"}, adapters)
+        result = PushToADOStep()(task, {}, adapters)
         assert result.ok
         assert result.data["ado_pr_id"] == 77
+        assert result.data["branch_name"] == "feature/1-foo"
         adapters.ado.push_branch_and_create_pr.assert_called_once_with(5, "feature/1-foo")
+
+    def test_raises_when_meta_comment_missing(self, tmp_path: Path) -> None:
+        adapters = _make_adapters(tmp_path, meta_comment=None)
+        task = _make_task(issue=5)
+        with pytest.raises(RuntimeError, match="claire:meta"):
+            PushToADOStep()(task, {}, adapters)
+        adapters.ado.push_branch_and_create_pr.assert_not_called()
+
+    def test_raises_when_meta_comment_branch_name_is_forged(self, tmp_path: Path) -> None:
+        """A branch_name that doesn't match feature/{pbi_id}-{slug} — e.g. posted by an
+        attacker able to comment on the issue, or a stale/malformed comment — must never
+        be trusted and must never reach `git push`."""
+        forged_comment = "<!-- claire:meta -->\n**Branch:** `--upload-pack=evil`\n"
+        adapters = _make_adapters(tmp_path, meta_comment=forged_comment)
+        task = _make_task(issue=5)
+        with pytest.raises(RuntimeError, match="claire:meta"):
+            PushToADOStep()(task, {}, adapters)
+        adapters.ado.push_branch_and_create_pr.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -438,10 +378,11 @@ class TestFivepointsTfoneDevWorkflow:
         adapters.terminal.spawn_tester.assert_not_called()
         adapters.ado.push_branch_and_create_pr.assert_called_once()
 
-    def test_restart_with_existing_worktree_reuses_branch_from_meta_comment(
+    def test_restart_with_existing_worktree_pushes_branch_from_meta_comment(
         self, tmp_path: Path
     ) -> None:
-        """PrepareWorktreeStep recovers branch_name from the claire:meta comment — no re-derivation, no worktree recreation."""
+        """PrepareWorktreeStep no-ops when the worktree already exists (no recreation);
+        PushToADOStep reads the branch_name straight from the claire:meta comment."""
         worktree_dir = tmp_path / ".claire" / "worktrees" / "issue-42"
         worktree_dir.mkdir(parents=True)
         meta_comment = (

--- a/src/claire_fivepoints/tests/test_worktree.py
+++ b/src/claire_fivepoints/tests/test_worktree.py
@@ -1,0 +1,110 @@
+"""Unit tests for RealWorktreePrepare — mocks subprocess.run directly (no mocking
+of RealWorktreePrepare itself), so the actual git command sequence is exercised:
+ado-remote sync (git fetch ado dev + git branch -f) and the detached-HEAD vs
+named-branch worktree add paths.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claire_fivepoints.azure_issue_bridge.worktree import RealWorktreePrepare
+
+
+class TestRealWorktreePrepareSync:
+    def test_returns_existing_worktree_without_git_call(self, tmp_path) -> None:
+        worktree_path = tmp_path / ".claire" / "worktrees" / "issue-5"
+        worktree_path.mkdir(parents=True)
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+
+        with patch("subprocess.run") as mock_run:
+            result = prepare.prepare(repo="org/repo", issue=5, base_branch="develop")
+
+        mock_run.assert_not_called()
+        assert result == str(worktree_path)
+
+    def test_fetches_ado_dev_and_force_updates_develop(self, tmp_path) -> None:
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+
+        with patch(
+            "subprocess.run", return_value=MagicMock(returncode=0, stderr="")
+        ) as mock_run:
+            prepare.prepare(repo="org/repo", issue=7, base_branch="develop")
+
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        assert ["git", "-C", str(tmp_path), "fetch", "ado", "dev"] in commands
+        assert [
+            "git", "-C", str(tmp_path), "branch", "-f", "develop", "ado/dev",
+        ] in commands
+
+    def test_rejects_base_branch_other_than_develop(self, tmp_path) -> None:
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+
+        with patch("subprocess.run") as mock_run:
+            with pytest.raises(ValueError, match="develop"):
+                prepare.prepare(repo="org/repo", issue=1, base_branch="main")
+
+        mock_run.assert_not_called()
+
+    def test_raises_when_git_fetch_fails(self, tmp_path) -> None:
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="fatal: error")
+            with pytest.raises(RuntimeError, match="git command failed"):
+                prepare.prepare(repo="org/repo", issue=1, base_branch="develop")
+
+
+class TestRealWorktreePrepareDetachedHead:
+    """No branch_name — the new default path for PrepareWorktreeStep (issue #184)."""
+
+    def test_worktree_add_uses_detach_no_named_branch(self, tmp_path) -> None:
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+        expected_path = tmp_path / ".claire" / "worktrees" / "issue-9"
+
+        with patch(
+            "subprocess.run", return_value=MagicMock(returncode=0, stderr="")
+        ) as mock_run:
+            result = prepare.prepare(repo="org/repo", issue=9, base_branch="develop")
+
+        assert result == str(expected_path)
+        worktree_cmd = mock_run.call_args_list[-1].args[0]
+        assert worktree_cmd == [
+            "git", "-C", str(tmp_path), "worktree", "add", "--detach",
+            str(expected_path), "develop",
+        ]
+
+    def test_raises_when_git_worktree_add_fails(self, tmp_path) -> None:
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+
+        def run_side_effect(cmd, **kwargs):
+            if "fetch" in cmd or "branch" in cmd:
+                return MagicMock(returncode=0, stderr="", stdout="")
+            return MagicMock(returncode=128, stderr="fatal: worktree add failed")
+
+        with patch("subprocess.run", side_effect=run_side_effect):
+            with pytest.raises(RuntimeError, match="git command failed"):
+                prepare.prepare(repo="org/repo", issue=10, base_branch="develop")
+
+
+class TestRealWorktreePrepareNamedBranch:
+    """branch_name provided — legacy path kept for the (unwired) bridge step."""
+
+    def test_worktree_add_creates_named_branch_from_develop(self, tmp_path) -> None:
+        prepare = RealWorktreePrepare(local_path=str(tmp_path))
+        expected_path = tmp_path / ".claire" / "worktrees" / "issue-11"
+
+        with patch(
+            "subprocess.run", return_value=MagicMock(returncode=0, stderr="")
+        ) as mock_run:
+            result = prepare.prepare(
+                repo="org/repo", issue=11, base_branch="develop", branch_name="pbi-11",
+            )
+
+        assert result == str(expected_path)
+        worktree_cmd = mock_run.call_args_list[-1].args[0]
+        assert worktree_cmd == [
+            "git", "-C", str(tmp_path), "worktree", "add", "--track", "-b",
+            "pbi-11", str(expected_path), "develop",
+        ]

--- a/src/claire_fivepoints/tfone_dev_steps.py
+++ b/src/claire_fivepoints/tfone_dev_steps.py
@@ -3,19 +3,21 @@
 Pipeline shape:
   pipe(
     HydrateStateStep(),     # reads role label; populates ctx for restart recovery
-    PrepareWorktreeStep(),  # idempotent worktree + feature/{pbi_id}-{slug} branch
+    PrepareWorktreeStep(),  # idempotent worktree on develop — no named branch
     SpawnDevStep(),         # spawn dev terminal + wait for role:tester label
     TesterStep(),           # spawn tester + wait role:ready
-    PushToADOStep(),        # push branch_name (from ctx) to ADO + create PR
+    PushToADOStep(),        # push branch_name (from claire:meta comment) to ADO + create PR
     WaitForADOMergeStep(),  # block until ADO PR merged        (from fivepoints_pipeline)
   )
 
 The dev agent reads the GitHub issue body (populated by the bridge) and downloads
-ADO attachments itself — the workflow does not pre-fetch ADO context.
+ADO attachments itself — the workflow does not pre-fetch ADO context. It also
+creates the feature/{pbi_id}-{slug} branch itself (after reading the issue and
+the FDS) and posts the branch name in a <!-- claire:meta --> comment.
 
 PushToADOStep is defined locally (not imported from claire_workflows.fivepoints_pipeline)
-because it pushes the branch_name produced by PrepareWorktreeStep rather than deriving
-issue-{N} from the issue number alone.
+because it pushes the branch_name recovered from the claire:meta comment rather than
+deriving issue-{N} from the issue number alone.
 """
 from __future__ import annotations
 
@@ -45,10 +47,8 @@ _LABEL_TESTER = "role:tester"
 _LABEL_READY = "role:ready"
 
 _META_TAG = "<!-- claire:meta -->"
-_PBI_ID_PATTERN = re.compile(r"_workitems/edit/(\d+)")
 _BRANCH_PATTERN = re.compile(r"\*\*Branch:\*\* `([^`]+)`")
 _BRANCH_NAME_PATTERN = re.compile(r"^feature/\d+-[a-z0-9-]+$")
-_SLUG_MAX_LEN = 50
 
 
 # ---------------------------------------------------------------------------
@@ -56,30 +56,10 @@ _SLUG_MAX_LEN = 50
 # ---------------------------------------------------------------------------
 
 
-def _slugify(title: str, max_len: int = _SLUG_MAX_LEN) -> str:
-    """Derive a branch-safe slug from an issue title.
-
-    "PBI: Case Face Sheet - Enhancement" -> "case-face-sheet-enhancement"
-    """
-    text = re.sub(r"^PBI:\s*", "", title, flags=re.IGNORECASE)
-    text = re.sub(r"[^a-zA-Z0-9]+", "-", text).strip("-").lower()
-    return text[:max_len].rstrip("-")
-
-
-def _extract_pbi_id(body: str) -> str:
-    match = _PBI_ID_PATTERN.search(body)
-    if not match:
-        raise RuntimeError(
-            "Could not extract pbi_id from issue body — "
-            "no ADO _workitems/edit/<id> link found"
-        )
-    return match.group(1)
-
-
 def _is_valid_branch_name(branch_name: str) -> bool:
     """Guard against forged/malformed branch names before they reach `git push`.
 
-    Anchored to the feature/{pbi_id}-{slug} shape this step itself produces — a
+    Anchored to the feature/{pbi_id}-{slug} shape the dev agent produces — a
     value recovered from an (unauthenticated) issue comment that doesn't match
     can never start with '-' and can't smuggle extra git CLI flags/arguments
     through the `{branch}:{branch}` refspec.
@@ -164,13 +144,17 @@ class FivepointsTfoneDevAdapters:
 
 
 class PrepareWorktreeStep:
-    """Create the dev worktree on a FivePoints-convention branch, idempotently.
+    """Create the dev worktree on develop, idempotently.
 
-    Branch name: feature/{pbi_id}-{slug} — pbi_id is parsed from the ADO
-    _workitems/edit/<id> link in the issue body, slug is derived from the issue
-    title. The chosen branch name is persisted as a <!-- claire:meta --> comment
-    on the issue so a restarted pipeline recovers it without recreating the
-    worktree or re-deriving the branch name.
+    Only prepares the worktree — it does not derive or create a named branch.
+    The underlying adapter (RealWorktreePrepare) first syncs the local develop
+    branch from the ado remote's dev branch (TFIOneGit/dev), then checks out
+    develop in the new worktree in a detached HEAD state (no branch is created
+    or named here).
+
+    Branch naming is the dev agent's responsibility: after reading the issue
+    and the FDS, it creates feature/{pbi_id}-{slug} itself and posts the name
+    in a <!-- claire:meta --> comment (see PushToADOStep, which reads it back).
     """
 
     def __call__(
@@ -182,74 +166,28 @@ class PrepareWorktreeStep:
         worktree_path = adapters.local_path / ".claire" / "worktrees" / f"issue-{task.issue}"
 
         if worktree_path.exists():
-            meta_body = adapters.meta.find_meta_comment(task.repo, task.issue)
-            match = _BRANCH_PATTERN.search(meta_body) if meta_body else None
-            if match and _is_valid_branch_name(match.group(1)):
-                branch_name = match.group(1)
-                logger.info(
-                    "tfone_dev.prepare_worktree.skipped",
-                    extra={
-                        "issue": task.issue,
-                        "repo": task.repo,
-                        "branch_name": branch_name,
-                    },
-                )
-                return StepResult(
-                    ok=True,
-                    data={
-                        "worktree_ready": True,
-                        "branch_name": branch_name,
-                        "worktree_path": str(worktree_path),
-                    },
-                )
-            if match:
-                # Anyone able to comment on the issue can post a forged claire:meta
-                # comment — never trust a branch_name that doesn't match the
-                # convention this step itself produces. Fall through and re-derive.
-                logger.warning(
-                    "tfone_dev.prepare_worktree.meta_comment_rejected",
-                    extra={
-                        "issue": task.issue,
-                        "repo": task.repo,
-                        "rejected_branch_name": match.group(1),
-                    },
-                )
-
-        issue_data = adapters.meta.get_issue(task.repo, task.issue)
-        pbi_id = _extract_pbi_id(issue_data.get("body", "") or "")
-        slug = _slugify(issue_data.get("title", "") or "")
-        branch_name = f"feature/{pbi_id}-{slug}"
-        if not _is_valid_branch_name(branch_name):
-            raise RuntimeError(
-                f"Derived branch name {branch_name!r} failed validation against "
-                f"{_BRANCH_NAME_PATTERN.pattern!r} — check the issue title/body"
+            logger.info(
+                "tfone_dev.prepare_worktree.skipped",
+                extra={"issue": task.issue, "repo": task.repo},
+            )
+            return StepResult(
+                ok=True,
+                data={"worktree_ready": True, "worktree_path": str(worktree_path)},
             )
 
         worktree_path_str = RealWorktreePrepare(local_path=adapters.local_path).prepare(
             repo=task.repo,
             issue=task.issue,
             base_branch="develop",
-            branch_name=branch_name,
         )
-
-        comment_body = (
-            f"{_META_TAG}\n"
-            f"**Branch:** `{branch_name}`\n"
-            f"**Worktree:** `{worktree_path_str}`"
-        )
-        adapters.meta.post_comment(task.repo, task.issue, comment_body)
 
         logger.info(
             "tfone_dev.prepare_worktree.done",
-            extra={"issue": task.issue, "repo": task.repo, "branch_name": branch_name},
+            extra={"issue": task.issue, "repo": task.repo},
         )
         return StepResult(
             ok=True,
-            data={
-                "worktree_ready": True,
-                "branch_name": branch_name,
-                "worktree_path": worktree_path_str,
-            },
+            data={"worktree_ready": True, "worktree_path": worktree_path_str},
         )
 
 
@@ -331,9 +269,10 @@ class TesterStep:
 class PushToADOStep:
     """Push the feature branch to ADO and create a PR.
 
-    Reads branch_name from ctx (set by PrepareWorktreeStep) instead of deriving
-    issue-{N} from the issue number, so the branch pushed to ADO matches the
-    FivePoints feature/{pbi_id}-{slug} convention.
+    Reads branch_name from the <!-- claire:meta --> comment on the issue —
+    posted by the dev agent after it creates the feature/{pbi_id}-{slug}
+    branch — instead of ctx, since PrepareWorktreeStep no longer derives or
+    names the branch.
     """
 
     def __call__(
@@ -342,7 +281,16 @@ class PushToADOStep:
         ctx: dict[str, Any],
         adapters: FivepointsTfoneDevAdapters,
     ) -> StepResult:
-        branch_name = ctx["branch_name"]
+        meta_body = adapters.meta.find_meta_comment(task.repo, task.issue)
+        match = _BRANCH_PATTERN.search(meta_body) if meta_body else None
+        if not match or not _is_valid_branch_name(match.group(1)):
+            raise RuntimeError(
+                f"No valid branch_name found in a {_META_TAG} comment on issue "
+                f"{task.issue} — the dev agent must post it after creating the "
+                "feature branch"
+            )
+        branch_name = match.group(1)
+
         ado_pr_id = adapters.ado.push_branch_and_create_pr(task.issue, branch_name)
         logger.info(
             "tfone_dev.push_to_ado.done",
@@ -353,7 +301,7 @@ class PushToADOStep:
                 "ado_pr_id": ado_pr_id,
             },
         )
-        return StepResult(ok=True, data={"ado_pr_id": ado_pr_id})
+        return StepResult(ok=True, data={"ado_pr_id": ado_pr_id, "branch_name": branch_name})
 
 
 # ---------------------------------------------------------------------------
@@ -369,8 +317,8 @@ class FivepointsTfoneDevWorkflow:
       role:tester present  → dev_done=True  (skip SpawnDevStep)
       role:ready  present  → dev_done=True, tester_done=True (skip both)
 
-    PrepareWorktreeStep is idempotent on its own (worktree-on-disk + claire:meta
-    comment check) and always runs — it no-ops itself rather than relying on ctx.
+    PrepareWorktreeStep is idempotent on its own (worktree-on-disk check) and
+    always runs — it no-ops itself rather than relying on ctx.
 
     Usage::
 


### PR DESCRIPTION
Closes #184

## Résumé

- `PrepareWorktreeStep` (`src/claire_fivepoints/tfone_dev_steps.py`) ne dérive plus le pbi_id/slug et ne crée plus de branche nommée. Il vérifie juste l'existence du worktree, idempotent.
- `RealWorktreePrepare.prepare()` (`src/claire_fivepoints/azure_issue_bridge/worktree.py`) fetch désormais `ado dev`, force-update `develop` local vers `ado/dev`, puis crée le worktree en HEAD détaché sur `develop` (`branch_name` devient optionnel — conservé pour le call site legacy, non câblé, du bridge).
- `PushToADOStep` lit `branch_name` depuis le commentaire `<!-- claire:meta -->` de l'issue (posté par l'agent dev) au lieu du `ctx` du pipeline — même garde anti-forgery (`_is_valid_branch_name`) qu'avant.
- Persona `fivepoints-dev` : nouvelle étape explicite "créer la branche `feature/{pbi_id}-{slug}` après lecture FDS, poster dans `<!-- claire:meta -->`".
- `domain/operational/AZURE_ISSUE_BRIDGE.md` mis à jour pour refléter la nouvelle architecture.

## Verification Log

```
$ uv run pytest src/claire_fivepoints/tests/test_tfone_dev.py -q
33 passed in 0.10s

$ uv run pytest -q
365 passed, 10 failed in 0.38s
```

Les 10 échecs sont pré-existants et sans rapport (module `yaml` manquant dans l'environnement de test) — confirmé identiques avant/après ce changement via `git stash`.

## Acceptance Criteria
- [x] `PrepareWorktreeStep` ne crée plus de branche nommée — worktree sur `develop` uniquement
- [x] `PrepareWorktreeStep` fetch depuis `ado/dev` avant création pour garantir la synchro
- [x] Dev persona checklist (`fivepoints-dev`) : étape explicite ajoutée
- [x] `PushToADOStep` lit le nom de branche depuis le commentaire `<!-- claire:meta -->`